### PR TITLE
[zee] Catalog pi-mono shim boundaries

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -31,6 +31,8 @@ rg "command: \"dmux\"|DmuxSpawnCommand|DmuxMergeCommand" packages/zee/src/cli/cm
 rg "command: \"web\"|resolveWebBackendUrl|resolveWebBackendTarget" packages/zee/src/cli/cmd/web.ts  # Web UI launcher command + backend wiring helpers (lines 81, 27, 36)
 rg "buildOpenCodeRuntimeContractReport|emitOpenCodeRuntimeContractTelemetry" packages/zee/src/runtime/opencode-contract.ts  # OpenCode runtime inventory + adapter contract source of truth
 rg "command: \"runtime-contract\"" packages/zee/src/cli/cmd/inspect.ts  # CLI report for OpenCode runtime contract
+rg "buildPiMonoCompatReport|emitPiMonoCompatTelemetry" packages/zee/src/runtime/pimono-compat.ts  # pi-mono shim boundary inventory + telemetry
+rg "command: \"shim-boundaries\"" packages/zee/src/cli/cmd/inspect.ts  # CLI report for pi-mono compatibility shims
 rg "export namespace Dmux|export const spawn|export const merge" packages/zee/src/worktree/dmux.ts  # dmux lane orchestration (lines 8, 177, 220)
 rg "export const ZEE_TOOLS|registerZeeTools" src/domain/zee/tools.ts     # Zee domain tools (lines 1884, 1909)
 rg "export const STANLEY_TOOLS|registerStanleyTools" src/domain/investing/tools.ts  # Stanley tools (lines 456, 469)
@@ -165,6 +167,13 @@ rg "export class Memory|getMemory|getMemoryAsync" src/memory/unified.ts  # Unifi
 - **Telemetry event:** `packages/zee/src/runtime/opencode-contract.ts:72`
 - **CLI report (`zee inspect runtime-contract`):** `packages/zee/src/cli/cmd/inspect.ts:249`
 - **Operator doc:** `docs/architecture/opencode-runtime-inventory.md:1`
+
+### Feature: pi-mono Compatibility Shim Inventory
+**Purpose:** Catalog the remaining pi-mono-shaped shim boundaries, their deprecation status, and existing telemetry coverage during the OpenCode migration.
+- **Inventory source:** `packages/zee/src/runtime/pimono-compat.ts:227`
+- **Telemetry event:** `packages/zee/src/runtime/pimono-compat.ts:56`
+- **CLI report (`zee inspect shim-boundaries`):** `packages/zee/src/cli/cmd/inspect.ts:283`
+- **Operator doc:** `docs/architecture/pimono-compat-shim-inventory.md:1`
 
 ### Feature: Domain Tool Packs
 **Purpose:** Provide user-facing capabilities across life admin, investing, and learning.

--- a/docs/architecture/pimono-compat-shim-inventory.md
+++ b/docs/architecture/pimono-compat-shim-inventory.md
@@ -1,0 +1,105 @@
+# pi-mono Compatibility Shim Inventory
+
+Issue: `#488`
+
+This inventory is the source of truth for the remaining pi-mono-shaped compatibility boundaries that still exist in Zee while the runtime migrates toward OpenCode.
+
+## Inspection Command
+
+```bash
+cd packages/zee
+bun run --conditions=browser ./src/index.ts inspect shim-boundaries --json
+```
+
+Use `--no-json` for a compact operator summary.
+
+## Status Vocabulary
+
+- `active_temporary`: live shim boundary that still carries legacy request/event semantics and must be removed or hidden behind the OpenCode adapter.
+- `deprecated_live`: live compatibility alias still accepted for migration safety and scheduled for removal after client/config migration.
+- `retired_blocked`: legacy surface is intentionally rejected or absent and should not be reintroduced as an implicit alias.
+
+## Boundary Inventory
+
+### 1. pi-ai LLM bridge
+
+- Boundary id: `server.llm.pi-ai-bridge`
+- Status: `active_temporary`
+- Surface: `server`
+- Kind: `http_bridge`
+- Current boundary:
+  `/v1/llm/stream` still accepts pi-ai/OpenClaw-shaped request payloads and emits pi-style `AssistantMessageEvent` SSE frames while normalizing execution through Zee's provider and AI SDK stack.
+- Telemetry:
+  `llm.bridge.stream.start`, `llm.bridge.stream.done`, `llm.bridge.stream.error`
+- Exit path:
+  Replace this route-level bridge once the OpenCode primary execution path lands and downstream callers stop depending on pi-ai event shapes.
+
+### 2. Legacy auth wire payload
+
+- Boundary id: `server.auth.api-key-payload`
+- Status: `deprecated_live`
+- Surface: `server`
+- Kind: `payload_alias`
+- Current boundary:
+  The auth route still accepts `{ "api_key": "..." }` and rewrites it into Zee's `Auth.Info` model; SDK-generated client types preserve that shape for compatibility.
+- Telemetry:
+  `auth.legacy_payload.accepted`
+- Exit path:
+  Remove the alias once operator and SDK clients are migrated to `Auth.Info`.
+
+### 3. Agent tools config alias
+
+- Boundary id: `agent.config.tools-alias`
+- Status: `deprecated_live`
+- Surface: `agent`
+- Kind: `config_alias`
+- Current boundary:
+  `agent.<name>.tools` booleans still translate into `PermissionNext` rules so pre-permission config continues to run during migration.
+- Telemetry:
+  missing today; `#489` should add shim call-site metrics before removal sequencing starts.
+- Exit path:
+  Delete the alias after operators migrate to permission-native agent config.
+
+### 4. pi-agent orchestration event schema
+
+- Boundary id: `orchestration.pi-agent-event-schema`
+- Status: `active_temporary`
+- Surface: `orchestration`
+- Kind: `event_schema`
+- Current boundary:
+  daemon IPC and orchestration visuals still expose lifecycle event names inherited from the old pi-agent vocabulary.
+- Telemetry:
+  missing today; the schema itself is still a compatibility contract.
+- Exit path:
+  Keep the schema stable until OpenCode is primary, then either version it as a Zee-owned contract or translate it behind an adapter.
+
+### 5. Retired persona ids
+
+- Boundary id: `agent.persona-ids`
+- Status: `retired_blocked`
+- Surface: `agent`
+- Kind: `retired_surface`
+- Current boundary:
+  legacy persona ids like `stanley` and `johny` no longer resolve as agents or valid `default_agent` values.
+- Telemetry:
+  not applicable; the stance is explicit rejection.
+- Exit path:
+  keep blocked.
+
+### 6. Retired `/personas` endpoint
+
+- Boundary id: `server.personas-endpoint`
+- Status: `retired_blocked`
+- Surface: `server`
+- Kind: `retired_surface`
+- Current boundary:
+  `/personas` is intentionally absent from the public server contract and guarded by a public-contract test.
+- Telemetry:
+  not applicable; the stance is explicit rejection.
+- Exit path:
+  keep blocked.
+
+## Scope Notes
+
+- This inventory is intentionally limited to runtime-facing pi-mono migration boundaries and adjacent explicitly retired legacy surfaces.
+- Other compatibility holdovers in the repo, such as heartbeat-path fallbacks or model env aliases, are not treated as pi-mono shim boundaries for `#488`.

--- a/packages/zee/src/cli/cmd/inspect.ts
+++ b/packages/zee/src/cli/cmd/inspect.ts
@@ -6,6 +6,11 @@ import {
   emitOpenCodeRuntimeContractTelemetry,
   summarizeOpenCodeRuntimeContract,
 } from "@/runtime/opencode-contract"
+import {
+  buildPiMonoCompatReport,
+  emitPiMonoCompatTelemetry,
+  summarizePiMonoCompatReport,
+} from "@/runtime/pimono-compat"
 import { Session } from "../../session"
 import { SessionStatus } from "../../session/status"
 import { collectRuntimeSnapshot } from "./runtime-process-guard"
@@ -25,6 +30,10 @@ type InspectOpsArgs = {
 }
 
 type InspectRuntimeContractArgs = {
+  json?: boolean
+}
+
+type InspectShimBoundariesArgs = {
   json?: boolean
 }
 
@@ -270,6 +279,30 @@ const InspectRuntimeContractCommand = cmd({
   },
 })
 
+const InspectShimBoundariesCommand = cmd({
+  command: "shim-boundaries",
+  describe: "print the pi-mono compatibility shim inventory and deprecation boundaries",
+  builder: (yargs: Argv) =>
+    yargs.option("json", {
+      type: "boolean",
+      default: true,
+      describe: "output as JSON",
+    }),
+  handler: async (args: InspectShimBoundariesArgs) => {
+    await bootstrap(process.cwd(), async () => {
+      const report = buildPiMonoCompatReport()
+      await emitPiMonoCompatTelemetry(report)
+
+      if (args.json !== false) {
+        console.log(JSON.stringify(report, null, 2))
+        return
+      }
+
+      console.log(summarizePiMonoCompatReport(report))
+    })
+  },
+})
+
 export const InspectCommand = cmd({
   command: "inspect",
   describe: "inspect runtime state",
@@ -278,6 +311,7 @@ export const InspectCommand = cmd({
       .command(InspectStateCommand)
       .command(InspectOpsCommand)
       .command(InspectRuntimeContractCommand)
+      .command(InspectShimBoundariesCommand)
       .demandCommand(),
   async handler() {},
 })

--- a/packages/zee/src/runtime/pimono-compat.ts
+++ b/packages/zee/src/runtime/pimono-compat.ts
@@ -1,0 +1,278 @@
+import { Bus } from "@/bus"
+import { BusEvent } from "@/bus/bus-event"
+import { Log } from "@/util/log"
+import type { RuntimeCodeReference } from "./opencode-contract"
+import z from "zod"
+
+const log = Log.create({ service: "runtime:pimono-compat" })
+
+export type PiMonoCompatSurface = "server" | "agent" | "orchestration"
+export type PiMonoCompatKind = "http_bridge" | "payload_alias" | "config_alias" | "event_schema" | "retired_surface"
+export type PiMonoCompatStatus = "active_temporary" | "deprecated_live" | "retired_blocked"
+export type PiMonoCompatTelemetryState = "emitted" | "missing" | "not_applicable"
+
+export type PiMonoCompatTelemetryBinding = {
+  state: PiMonoCompatTelemetryState
+  eventKinds: string[]
+}
+
+export type PiMonoCompatBoundary = {
+  id: string
+  surface: PiMonoCompatSurface
+  kind: PiMonoCompatKind
+  legacyInterface: string
+  currentBoundary: string
+  status: PiMonoCompatStatus
+  exitPath: string
+  telemetry: PiMonoCompatTelemetryBinding
+  references: RuntimeCodeReference[]
+}
+
+export type PiMonoCompatReportTelemetry = {
+  eventType: string
+  metricNames: string[]
+  metrics: {
+    boundaryCount: number
+    activeTemporaryCount: number
+    deprecatedLiveCount: number
+    retiredBlockedCount: number
+    telemetryBackedCount: number
+    missingTelemetryCount: number
+  }
+}
+
+export type PiMonoCompatReport = {
+  reportId: "pimono-compat-shim-boundaries"
+  reportVersion: 1
+  generatedAt: string
+  roadmapIssue: number
+  upstreamTarget: "badlogic/pi-mono"
+  adapterDependencyIssue: number
+  rolloutPhase: "inventory"
+  boundaries: PiMonoCompatBoundary[]
+  telemetry: PiMonoCompatReportTelemetry
+}
+
+export const PiMonoCompatInspected = BusEvent.define(
+  "runtime.pimono-compat.inspected",
+  z.object({
+    reportId: z.literal("pimono-compat-shim-boundaries"),
+    reportVersion: z.literal(1),
+    boundaryCount: z.number().int().nonnegative(),
+    activeTemporaryCount: z.number().int().nonnegative(),
+    deprecatedLiveCount: z.number().int().nonnegative(),
+    retiredBlockedCount: z.number().int().nonnegative(),
+    telemetryBackedCount: z.number().int().nonnegative(),
+    missingTelemetryCount: z.number().int().nonnegative(),
+  }),
+)
+
+const BOUNDARIES: PiMonoCompatBoundary[] = [
+  {
+    id: "server.llm.pi-ai-bridge",
+    surface: "server",
+    kind: "http_bridge",
+    legacyInterface: "pi-ai-shaped /v1/llm/stream request and AssistantMessageEvent SSE payloads",
+    currentBoundary:
+      "The server accepts pi-ai/OpenClaw stream payloads, normalizes them at the HTTP route boundary, and executes through Zee's provider + AI SDK stack.",
+    status: "active_temporary",
+    exitPath:
+      "Replace this bridge with the OpenCode-primary execution path once #486 lands and downstream callers move off pi-ai event shapes.",
+    telemetry: {
+      state: "emitted",
+      eventKinds: ["llm.bridge.stream.start", "llm.bridge.stream.done", "llm.bridge.stream.error"],
+    },
+    references: [
+      { file: "packages/zee/src/server/route/llm.ts", symbol: "LlmRoute" },
+      { file: "packages/zee/src/server/route/llm.ts", symbol: "toModelMessages" },
+      { file: "packages/zee/src/server/route/llm.ts", symbol: "PiAssistantMessageEvent" },
+      { file: "packages/zee/src/server/server.ts", symbol: "LlmRoute" },
+    ],
+  },
+  {
+    id: "server.auth.api-key-payload",
+    surface: "server",
+    kind: "payload_alias",
+    legacyInterface: "Legacy auth payload shape { api_key } on PUT /auth/:providerID",
+    currentBoundary:
+      "The auth route and generated SDK client still accept the legacy api_key wire shape and rewrite it into Zee's Auth.Info schema before persistence and provider reload.",
+    status: "deprecated_live",
+    exitPath:
+      "Keep accepting the payload until operator clients are migrated, then require Auth.Info-only requests and delete the alias path.",
+    telemetry: {
+      state: "emitted",
+      eventKinds: ["auth.legacy_payload.accepted"],
+    },
+    references: [
+      { file: "packages/zee/src/server/route/auth.ts", symbol: "AuthRoute" },
+      { file: "packages/zee/src/server/route/auth.ts", symbol: "auth.legacy_payload.accepted" },
+      { file: "packages/zee/src/pkg/sdk/v2/client.ts", symbol: "authSet" },
+      { file: "packages/zee/src/pkg/sdk/v2/gen/sdk.gen.ts", symbol: "authSet" },
+      { file: "packages/zee/test/server/auth-route.test.ts", symbol: "accepts legacy api_key payload" },
+    ],
+  },
+  {
+    id: "agent.config.tools-alias",
+    surface: "agent",
+    kind: "config_alias",
+    legacyInterface: "Legacy agent.<name>.tools boolean map in config",
+    currentBoundary:
+      "Agent config still translates the legacy tools map into PermissionNext rules so older configs remain runnable during the runtime migration.",
+    status: "deprecated_live",
+    exitPath:
+      "Add per-call-site shim telemetry in #489, then remove the alias once operators are on permission-native config.",
+    telemetry: {
+      state: "missing",
+      eventKinds: [],
+    },
+    references: [
+      { file: "packages/zee/src/config/config.ts", symbol: "agent.tools" },
+      { file: "packages/zee/src/agent/agent.ts", symbol: "legacyToolsToPermissionConfig" },
+      { file: "packages/zee/src/agent/agent.ts", symbol: "PermissionNext.fromConfig" },
+      { file: "packages/zee/test/agent/agent.test.ts", symbol: "legacy tools config converts to permissions" },
+    ],
+  },
+  {
+    id: "orchestration.pi-agent-event-schema",
+    surface: "orchestration",
+    kind: "event_schema",
+    legacyInterface: "pi-agent-style orchestration event taxonomy exposed over daemon IPC",
+    currentBoundary:
+      "Daemon IPC and orchestration visuals still speak the legacy lifecycle event names while the worker runtime underneath is being migrated.",
+    status: "active_temporary",
+    exitPath:
+      "Hold the schema stable until OpenCode becomes the primary execution path, then either version it as Zee-owned or translate it behind a dedicated adapter.",
+    telemetry: {
+      state: "missing",
+      eventKinds: [],
+    },
+    references: [
+      { file: "src/swarm/events.ts", symbol: "OrchestrationEventType" },
+      { file: "src/swarm/orchestrator.ts", symbol: "emitOrchestrationEvent" },
+      { file: "packages/zee/src/orchestration/daemon-ipc.ts", symbol: "OrchestrationEvent" },
+    ],
+  },
+  {
+    id: "agent.persona-ids",
+    surface: "agent",
+    kind: "retired_surface",
+    legacyInterface: "Legacy persona ids (stanley, johny, other persona-style defaults) resolving as agents",
+    currentBoundary:
+      "Persona ids are intentionally blocked from agent resolution and default_agent selection; the compatibility stance is explicit rejection rather than a hidden alias.",
+    status: "retired_blocked",
+    exitPath:
+      "Keep blocked. Do not reintroduce persona-id aliasing while the runtime surface converges on Zee/OpenCode naming.",
+    telemetry: {
+      state: "not_applicable",
+      eventKinds: [],
+    },
+    references: [
+      { file: "packages/zee/src/agent/agent.ts", symbol: "Agent.get" },
+      { file: "packages/zee/src/agent/agent.ts", symbol: "Agent.defaultAgent" },
+      { file: "packages/zee/test/agent/agent.test.ts", symbol: "legacy persona ids are not registered as agents" },
+    ],
+  },
+  {
+    id: "server.personas-endpoint",
+    surface: "server",
+    kind: "retired_surface",
+    legacyInterface: "Legacy /personas HTTP endpoint",
+    currentBoundary:
+      "The endpoint is intentionally absent from Zee's public server contract and returns 404; the retirement is guarded by a public-contract test.",
+    status: "retired_blocked",
+    exitPath:
+      "Keep blocked. Any future compatibility surface should be versioned under a dedicated migration route, not by reviving /personas.",
+    telemetry: {
+      state: "not_applicable",
+      eventKinds: [],
+    },
+    references: [
+      { file: "packages/zee/src/server/server.ts", symbol: "Server.App" },
+      {
+        file: "packages/zee/test/server/public-contracts.test.ts",
+        symbol: "does not expose the legacy /personas endpoint",
+      },
+    ],
+  },
+]
+
+function buildTelemetry(boundaries: PiMonoCompatBoundary[]): PiMonoCompatReportTelemetry {
+  const activeTemporaryCount = boundaries.filter((item) => item.status === "active_temporary").length
+  const deprecatedLiveCount = boundaries.filter((item) => item.status === "deprecated_live").length
+  const retiredBlockedCount = boundaries.filter((item) => item.status === "retired_blocked").length
+  const telemetryBackedCount = boundaries.filter((item) => item.telemetry.state === "emitted").length
+  const missingTelemetryCount = boundaries.filter((item) => item.telemetry.state === "missing").length
+
+  return {
+    eventType: PiMonoCompatInspected.type,
+    metricNames: [
+      "boundaryCount",
+      "activeTemporaryCount",
+      "deprecatedLiveCount",
+      "retiredBlockedCount",
+      "telemetryBackedCount",
+      "missingTelemetryCount",
+    ],
+    metrics: {
+      boundaryCount: boundaries.length,
+      activeTemporaryCount,
+      deprecatedLiveCount,
+      retiredBlockedCount,
+      telemetryBackedCount,
+      missingTelemetryCount,
+    },
+  }
+}
+
+export function buildPiMonoCompatReport(now: Date = new Date()): PiMonoCompatReport {
+  const boundaries = BOUNDARIES.map((boundary) => ({
+    ...boundary,
+    references: boundary.references.map((reference) => ({ ...reference })),
+    telemetry: {
+      ...boundary.telemetry,
+      eventKinds: [...boundary.telemetry.eventKinds],
+    },
+  }))
+
+  return {
+    reportId: "pimono-compat-shim-boundaries",
+    reportVersion: 1,
+    generatedAt: now.toISOString(),
+    roadmapIssue: 488,
+    upstreamTarget: "badlogic/pi-mono",
+    adapterDependencyIssue: 485,
+    rolloutPhase: "inventory",
+    boundaries,
+    telemetry: buildTelemetry(boundaries),
+  }
+}
+
+export async function emitPiMonoCompatTelemetry(report: PiMonoCompatReport): Promise<void> {
+  log.info("pi-mono compatibility shim inventory inspected", {
+    reportId: report.reportId,
+    metrics: report.telemetry.metrics,
+  })
+
+  await Bus.publish(PiMonoCompatInspected, {
+    reportId: report.reportId,
+    reportVersion: report.reportVersion,
+    ...report.telemetry.metrics,
+  })
+}
+
+export function summarizePiMonoCompatReport(report: PiMonoCompatReport): string {
+  const lines = [
+    `pi-mono compatibility shim inventory v${report.reportVersion}`,
+    `- boundaries: ${report.telemetry.metrics.boundaryCount} active=${report.telemetry.metrics.activeTemporaryCount} deprecated=${report.telemetry.metrics.deprecatedLiveCount} retired=${report.telemetry.metrics.retiredBlockedCount}`,
+    `- telemetry: emitted=${report.telemetry.metrics.telemetryBackedCount} missing=${report.telemetry.metrics.missingTelemetryCount}`,
+  ]
+
+  for (const boundary of report.boundaries) {
+    const telemetry =
+      boundary.telemetry.eventKinds.length > 0 ? boundary.telemetry.eventKinds.join(", ") : boundary.telemetry.state
+    lines.push(`- ${boundary.id} [${boundary.status}] telemetry=${telemetry}`)
+  }
+
+  lines.push(`- telemetry event: ${report.telemetry.eventType}`)
+  return lines.join("\n")
+}

--- a/packages/zee/test/cli/inspect-command.test.ts
+++ b/packages/zee/test/cli/inspect-command.test.ts
@@ -4,6 +4,7 @@ import {
   buildOpenCodeRuntimeContractReport,
   summarizeOpenCodeRuntimeContract,
 } from "../../src/runtime/opencode-contract"
+import { buildPiMonoCompatReport, summarizePiMonoCompatReport } from "../../src/runtime/pimono-compat"
 import type { UsageStats, UsageSummary } from "../../src/usage/types"
 
 function makeSummary(): UsageSummary {
@@ -130,5 +131,38 @@ describe("inspect command helpers", () => {
     expect(summary).toContain("- orchestration:")
     expect(summary).toContain("- gateway:")
     expect(summary).toContain("runtime.opencode-contract.inspected")
+  })
+
+  test("pi-mono compatibility report inventories explicit shim boundaries and statuses", () => {
+    const report = buildPiMonoCompatReport(new Date("2026-03-14T12:30:00.000Z"))
+
+    expect(report.reportId).toBe("pimono-compat-shim-boundaries")
+    expect(report.reportVersion).toBe(1)
+    expect(report.generatedAt).toBe("2026-03-14T12:30:00.000Z")
+    expect(report.boundaries.map((boundary) => boundary.id)).toEqual([
+      "server.llm.pi-ai-bridge",
+      "server.auth.api-key-payload",
+      "agent.config.tools-alias",
+      "orchestration.pi-agent-event-schema",
+      "agent.persona-ids",
+      "server.personas-endpoint",
+    ])
+    expect(report.telemetry.eventType).toBe("runtime.pimono-compat.inspected")
+    expect(report.telemetry.metrics.boundaryCount).toBe(6)
+    expect(report.telemetry.metrics.activeTemporaryCount).toBe(2)
+    expect(report.telemetry.metrics.deprecatedLiveCount).toBe(2)
+    expect(report.telemetry.metrics.retiredBlockedCount).toBe(2)
+    expect(report.telemetry.metrics.telemetryBackedCount).toBe(2)
+    expect(report.telemetry.metrics.missingTelemetryCount).toBe(2)
+  })
+
+  test("pi-mono compatibility summary includes statuses and telemetry event", () => {
+    const summary = summarizePiMonoCompatReport(buildPiMonoCompatReport(new Date("2026-03-14T12:30:00.000Z")))
+
+    expect(summary).toContain("pi-mono compatibility shim inventory v1")
+    expect(summary).toContain("server.llm.pi-ai-bridge [active_temporary]")
+    expect(summary).toContain("agent.config.tools-alias [deprecated_live]")
+    expect(summary).toContain("server.personas-endpoint [retired_blocked]")
+    expect(summary).toContain("runtime.pimono-compat.inspected")
   })
 })


### PR DESCRIPTION
## Summary
- add a pi-mono compatibility shim inventory report in the runtime layer
- expose `inspect shim-boundaries` for JSON and operator-readable summaries
- document the current shim statuses, telemetry coverage, and retirement blockers

## Testing
- `cd packages/zee && bun test test/cli/inspect-command.test.ts`
- `cd packages/zee && bun run typecheck`
- `cd packages/zee && bun run --conditions=browser ./src/index.ts inspect shim-boundaries --json`
- `cd packages/zee && bun run --conditions=browser ./src/index.ts inspect shim-boundaries --no-json`
- `cd packages/zee && bun run build`
- `cd packages/zee && ./script/verify-binary.sh`

Closes #488
