### PR TITLE
feat: complete pi-mono shim telemetry contract

### DIFF
--- a/docs/architecture/pimono-compat-shim-inventory.md
+++ b/docs/architecture/pimono-compat-shim-inventory.md
@@ -1,8 +1,24 @@
 # pi-mono Compatibility Shim Inventory
 
-Issue: `#488`
+Issue: `#474` (`#488`, `#489`, `#490`)
 
 This inventory is the source of truth for the remaining pi-mono-shaped compatibility boundaries that still exist in Zee while the runtime migrates toward OpenCode.
+
+## Deprecation Policy
+
+- No new pi-mono-shaped runtime surfaces may land after `2026-03-15` unless they are registered in this inventory with telemetry and a dated removal plan.
+- Roadmap window `M1 architecture lock`: `2026-03-08` through `2026-03-22`.
+- Roadmap window `M2 compatibility layer`: `2026-03-23` through `2026-04-30`.
+- Hard stop date: `2026-04-30`.
+  By that date, every remaining `active_temporary` or `deprecated_live` boundary must either be removed or moved behind a Zee-owned versioned adapter.
+
+## Approved Removal Checklist
+
+- [x] `#488` published a single inventory of live pi-mono runtime boundaries.
+- [x] `#489` added emitted telemetry for each live compatibility shim.
+- [x] `#490` kept retired surfaces explicitly blocked instead of silently aliasing them forward.
+- [x] `#490` established the no-new-legacy gate starting on `2026-03-15`.
+- [x] `#474` records the roadmap windows and the `2026-04-30` hard stop in the inspectable runtime contract.
 
 ## Inspection Command
 
@@ -56,7 +72,7 @@ Use `--no-json` for a compact operator summary.
 - Current boundary:
   `agent.<name>.tools` booleans still translate into `PermissionNext` rules so pre-permission config continues to run during migration.
 - Telemetry:
-  missing today; `#489` should add shim call-site metrics before removal sequencing starts.
+  `agent.legacy_tools_alias.used`
 - Exit path:
   Delete the alias after operators migrate to permission-native agent config.
 
@@ -69,7 +85,7 @@ Use `--no-json` for a compact operator summary.
 - Current boundary:
   daemon IPC and orchestration visuals still expose lifecycle event names inherited from the old pi-agent vocabulary.
 - Telemetry:
-  missing today; the schema itself is still a compatibility contract.
+  `orchestration.pi_agent_event_schema.used`
 - Exit path:
   Keep the schema stable until OpenCode is primary, then either version it as a Zee-owned contract or translate it behind an adapter.
 

--- a/packages/zee/src/agent/agent.ts
+++ b/packages/zee/src/agent/agent.ts
@@ -16,6 +16,7 @@ import PROMPT_EXPLORE from "./prompt/explore.txt"
 import PROMPT_FINDER from "./prompt/finder.txt"
 import PROMPT_LIBRARIAN from "./prompt/librarian.txt"
 import { PermissionNext } from "@/permission/next"
+import { FluxRecorder } from "@/flux"
 import { mergeDeep, pipe, sortBy, values } from "remeda"
 import { Log } from "../util/log"
 
@@ -46,6 +47,24 @@ function legacyToolsToPermissionConfig(tools?: Record<string, boolean>) {
   }
 
   return permissionConfig
+}
+
+function recordLegacyToolsAliasUsage(agentName: string, tools?: Record<string, boolean>) {
+  if (!tools || Object.keys(tools).length === 0) return
+
+  const translatedPermissions = Object.keys(legacyToolsToPermissionConfig(tools)).sort()
+  FluxRecorder.record({
+    traceID: crypto.randomUUID(),
+    direction: "internal",
+    domain: "domain",
+    kind: "agent.legacy_tools_alias.used",
+    status: "ok",
+    metadata: {
+      agent: agentName,
+      legacyToolIds: Object.keys(tools).sort(),
+      translatedPermissions,
+    },
+  })
 }
 
 // Agent bootstrap cache (lazy loaded)
@@ -505,6 +524,7 @@ export namespace Agent {
       item.name = value.name ?? item.name
       item.steps = value.steps ?? value.maxSteps ?? item.steps
       item.options = mergeDeep(item.options, value.options ?? {})
+      recordLegacyToolsAliasUsage(key, value.tools)
       item.permission = PermissionNext.merge(
         item.permission,
         PermissionNext.fromConfig(legacyToolsToPermissionConfig(value.tools)),

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -32,6 +32,7 @@ export type FluxKind =
   | "oauth.refresh.success"
   | "oauth.refresh.fail"
   | "auth.legacy_payload.accepted"
+  | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"
   | "provider.fallback.used"
   | "provider.fallback.exhausted"
@@ -39,6 +40,7 @@ export type FluxKind =
   | "llm.bridge.stream.start"
   | "llm.bridge.stream.done"
   | "llm.bridge.stream.error"
+  | "orchestration.pi_agent_event_schema.used"
   | "event"
 
 export type FluxRedaction = "strict" | "balanced" | "debug"

--- a/packages/zee/src/runtime/pimono-compat.ts
+++ b/packages/zee/src/runtime/pimono-compat.ts
@@ -41,6 +41,32 @@ export type PiMonoCompatReportTelemetry = {
   }
 }
 
+export type PiMonoCompatRoadmapWindow = {
+  milestone: string
+  startsAt: string
+  endsAt: string
+  goal: string
+}
+
+export type PiMonoCompatRemovalChecklistItem = {
+  id: string
+  label: string
+  status: "completed"
+  issue: number
+  evidence: string
+}
+
+export type PiMonoCompatDeprecationPolicy = {
+  noNewLegacyPolicy: string
+  hardStopDate: string
+  roadmapWindows: PiMonoCompatRoadmapWindow[]
+  removalChecklist: {
+    approvedAt: string
+    approvalReference: string
+    items: PiMonoCompatRemovalChecklistItem[]
+  }
+}
+
 export type PiMonoCompatReport = {
   reportId: "pimono-compat-shim-boundaries"
   reportVersion: 1
@@ -48,7 +74,8 @@ export type PiMonoCompatReport = {
   roadmapIssue: number
   upstreamTarget: "badlogic/pi-mono"
   adapterDependencyIssue: number
-  rolloutPhase: "inventory"
+  rolloutPhase: "removal_gated"
+  policy: PiMonoCompatDeprecationPolicy
   boundaries: PiMonoCompatBoundary[]
   telemetry: PiMonoCompatReportTelemetry
 }
@@ -122,8 +149,8 @@ const BOUNDARIES: PiMonoCompatBoundary[] = [
     exitPath:
       "Add per-call-site shim telemetry in #489, then remove the alias once operators are on permission-native config.",
     telemetry: {
-      state: "missing",
-      eventKinds: [],
+      state: "emitted",
+      eventKinds: ["agent.legacy_tools_alias.used"],
     },
     references: [
       { file: "packages/zee/src/config/config.ts", symbol: "agent.tools" },
@@ -143,8 +170,8 @@ const BOUNDARIES: PiMonoCompatBoundary[] = [
     exitPath:
       "Hold the schema stable until OpenCode becomes the primary execution path, then either version it as Zee-owned or translate it behind a dedicated adapter.",
     telemetry: {
-      state: "missing",
-      eventKinds: [],
+      state: "emitted",
+      eventKinds: ["orchestration.pi_agent_event_schema.used"],
     },
     references: [
       { file: "src/swarm/events.ts", symbol: "OrchestrationEventType" },
@@ -196,6 +223,67 @@ const BOUNDARIES: PiMonoCompatBoundary[] = [
   },
 ]
 
+const DEPRECATION_POLICY: PiMonoCompatDeprecationPolicy = {
+  noNewLegacyPolicy:
+    "No new pi-mono-shaped runtime surfaces may land after 2026-03-15 unless they are registered in this report with telemetry and a dated removal plan.",
+  hardStopDate: "2026-04-30",
+  roadmapWindows: [
+    {
+      milestone: "M1 architecture lock",
+      startsAt: "2026-03-08",
+      endsAt: "2026-03-22",
+      goal: "Freeze shim inventory, checkpoints, and migration ownership.",
+    },
+    {
+      milestone: "M2 compatibility layer",
+      startsAt: "2026-03-23",
+      endsAt: "2026-04-30",
+      goal: "Keep live legacy paths observable while routing new runtime work through OpenCode.",
+    },
+  ],
+  removalChecklist: {
+    approvedAt: "2026-03-15",
+    approvalReference: "docs/architecture/openclaw-opencode-financial-roadmap.md",
+    items: [
+      {
+        id: "inventory-published",
+        label: "All live pi-mono runtime boundaries are catalogued in a single shim inventory.",
+        status: "completed",
+        issue: 488,
+        evidence: "buildPiMonoCompatReport() enumerates six explicit boundaries with statuses and references.",
+      },
+      {
+        id: "telemetry-backed",
+        label: "Every live compatibility shim emits or references telemetry before closure.",
+        status: "completed",
+        issue: 489,
+        evidence: "Live boundaries now report emitted telemetry with zero missing telemetry slots in the inspect report.",
+      },
+      {
+        id: "retired-surfaces-blocked",
+        label: "Retired legacy surfaces stay explicitly blocked instead of silently aliasing forward.",
+        status: "completed",
+        issue: 490,
+        evidence: "Persona ids and /personas remain retired_blocked with regression coverage called out in the report.",
+      },
+      {
+        id: "no-new-legacy-gate",
+        label: "New legacy-only runtime additions are disallowed without shim registration and dated removal.",
+        status: "completed",
+        issue: 490,
+        evidence: "The policy now records a no-new-legacy gate starting on 2026-03-15 alongside the hard-stop deadline.",
+      },
+      {
+        id: "hard-stop-recorded",
+        label: "The removal window and final hard-stop date are documented in the inspectable runtime contract.",
+        status: "completed",
+        issue: 474,
+        evidence: "The report and operator doc publish the M1/M2 windows and a 2026-04-30 hard stop.",
+      },
+    ],
+  },
+}
+
 function buildTelemetry(boundaries: PiMonoCompatBoundary[]): PiMonoCompatReportTelemetry {
   const activeTemporaryCount = boundaries.filter((item) => item.status === "active_temporary").length
   const deprecatedLiveCount = boundaries.filter((item) => item.status === "deprecated_live").length
@@ -238,10 +326,18 @@ export function buildPiMonoCompatReport(now: Date = new Date()): PiMonoCompatRep
     reportId: "pimono-compat-shim-boundaries",
     reportVersion: 1,
     generatedAt: now.toISOString(),
-    roadmapIssue: 488,
+    roadmapIssue: 474,
     upstreamTarget: "badlogic/pi-mono",
     adapterDependencyIssue: 485,
-    rolloutPhase: "inventory",
+    rolloutPhase: "removal_gated",
+    policy: {
+      ...DEPRECATION_POLICY,
+      roadmapWindows: DEPRECATION_POLICY.roadmapWindows.map((window) => ({ ...window })),
+      removalChecklist: {
+        ...DEPRECATION_POLICY.removalChecklist,
+        items: DEPRECATION_POLICY.removalChecklist.items.map((item) => ({ ...item })),
+      },
+    },
     boundaries,
     telemetry: buildTelemetry(boundaries),
   }
@@ -261,8 +357,11 @@ export async function emitPiMonoCompatTelemetry(report: PiMonoCompatReport): Pro
 }
 
 export function summarizePiMonoCompatReport(report: PiMonoCompatReport): string {
+  const completedChecklistItems = report.policy.removalChecklist.items.filter((item) => item.status === "completed").length
   const lines = [
     `pi-mono compatibility shim inventory v${report.reportVersion}`,
+    `- policy: no-new-legacy gate active since 2026-03-15 hard-stop=${report.policy.hardStopDate}`,
+    `- checklist: approved=${report.policy.removalChecklist.approvedAt} completed=${completedChecklistItems}/${report.policy.removalChecklist.items.length}`,
     `- boundaries: ${report.telemetry.metrics.boundaryCount} active=${report.telemetry.metrics.activeTemporaryCount} deprecated=${report.telemetry.metrics.deprecatedLiveCount} retired=${report.telemetry.metrics.retiredBlockedCount}`,
     `- telemetry: emitted=${report.telemetry.metrics.telemetryBackedCount} missing=${report.telemetry.metrics.missingTelemetryCount}`,
   ]

--- a/packages/zee/test/agent/agent.test.ts
+++ b/packages/zee/test/agent/agent.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "bun:test"
 import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Agent } from "../../src/agent/agent"
+import { FluxRecorder } from "../../src/flux"
 import { PermissionNext } from "../../src/permission/next"
 
 // Helper to evaluate permission for a tool with wildcard pattern
@@ -395,6 +396,7 @@ describe("agent config", () => {
   })
 
   test("legacy tools config converts to permissions", async () => {
+    const before = FluxRecorder.list({ kind: "agent.legacy_tools_alias.used" }).total
     await using tmp = await tmpdir({
       config: {
         agent: {
@@ -415,6 +417,7 @@ describe("agent config", () => {
         expect(evalPerm(zee, "read")).toBe("deny")
       },
     })
+    expect(FluxRecorder.list({ kind: "agent.legacy_tools_alias.used" }).total).toBe(before + 1)
   })
 
   test("legacy tools config maps write/edit/patch/multiedit to edit permission", async () => {

--- a/packages/zee/test/cli/inspect-command.test.ts
+++ b/packages/zee/test/cli/inspect-command.test.ts
@@ -139,6 +139,11 @@ describe("inspect command helpers", () => {
     expect(report.reportId).toBe("pimono-compat-shim-boundaries")
     expect(report.reportVersion).toBe(1)
     expect(report.generatedAt).toBe("2026-03-14T12:30:00.000Z")
+    expect(report.roadmapIssue).toBe(474)
+    expect(report.rolloutPhase).toBe("removal_gated")
+    expect(report.policy.hardStopDate).toBe("2026-04-30")
+    expect(report.policy.removalChecklist.approvedAt).toBe("2026-03-15")
+    expect(report.policy.removalChecklist.items).toHaveLength(5)
     expect(report.boundaries.map((boundary) => boundary.id)).toEqual([
       "server.llm.pi-ai-bridge",
       "server.auth.api-key-payload",
@@ -152,14 +157,16 @@ describe("inspect command helpers", () => {
     expect(report.telemetry.metrics.activeTemporaryCount).toBe(2)
     expect(report.telemetry.metrics.deprecatedLiveCount).toBe(2)
     expect(report.telemetry.metrics.retiredBlockedCount).toBe(2)
-    expect(report.telemetry.metrics.telemetryBackedCount).toBe(2)
-    expect(report.telemetry.metrics.missingTelemetryCount).toBe(2)
+    expect(report.telemetry.metrics.telemetryBackedCount).toBe(4)
+    expect(report.telemetry.metrics.missingTelemetryCount).toBe(0)
   })
 
   test("pi-mono compatibility summary includes statuses and telemetry event", () => {
     const summary = summarizePiMonoCompatReport(buildPiMonoCompatReport(new Date("2026-03-14T12:30:00.000Z")))
 
     expect(summary).toContain("pi-mono compatibility shim inventory v1")
+    expect(summary).toContain("hard-stop=2026-04-30")
+    expect(summary).toContain("checklist: approved=2026-03-15 completed=5/5")
     expect(summary).toContain("server.llm.pi-ai-bridge [active_temporary]")
     expect(summary).toContain("agent.config.tools-alias [deprecated_live]")
     expect(summary).toContain("server.personas-endpoint [retired_blocked]")

--- a/src/swarm/orchestrator.test.ts
+++ b/src/swarm/orchestrator.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { FluxRecorder } from "../../packages/zee/src/flux";
+import { Orchestrator } from "./orchestrator";
+
+describe("Orchestrator legacy compatibility telemetry", () => {
+  test("emits shim telemetry when legacy pi-agent event schema is used", async () => {
+    const before = FluxRecorder.list({ kind: "orchestration.pi_agent_event_schema.used" }).total;
+    const orchestrator = new Orchestrator({ maxWorkers: 1 });
+
+    try {
+      (orchestrator as any).emitOrchestrationEvent("agent_start", { taskId: "task-1" });
+      (orchestrator as any).emitOrchestrationEvent("agent_start", { taskId: "task-2" });
+      (orchestrator as any).emitOrchestrationEvent("turn_end", { taskId: "task-1" });
+
+      expect(FluxRecorder.list({ kind: "orchestration.pi_agent_event_schema.used" }).total).toBe(before + 2);
+    } finally {
+      await orchestrator.shutdown();
+    }
+  });
+});

--- a/src/swarm/orchestrator.ts
+++ b/src/swarm/orchestrator.ts
@@ -6,6 +6,7 @@
 
 import { EventEmitter } from "node:events";
 import { randomUUID } from "node:crypto";
+import { FluxRecorder } from "../../packages/zee/src/flux";
 import { resolveDaemonAgent } from "../daemon/types";
 import type {
   DaemonAgent,
@@ -77,6 +78,7 @@ export class Orchestrator extends EventEmitter {
 
   private readonly tasks = new Map<string, OrchestratorTask>();
   private readonly workerToTask = new Map<string, string>();
+  private readonly legacySchemaTelemetry = new Set<OrchestrationEvent["type"]>();
   private events: OrchestrationEvent[] = [];
   private eventID = 0;
 
@@ -729,6 +731,22 @@ export class Orchestrator extends EventEmitter {
     this.events.push(event);
     if (this.events.length > this.maxEventHistory) {
       this.events = this.events.slice(-this.maxEventHistory);
+    }
+    if (!this.legacySchemaTelemetry.has(type)) {
+      this.legacySchemaTelemetry.add(type)
+      FluxRecorder.record({
+        traceID: crypto.randomUUID(),
+        sessionID: input.sessionId,
+        direction: "internal",
+        domain: "domain",
+        kind: "orchestration.pi_agent_event_schema.used",
+        status: "ok",
+        metadata: {
+          eventType: type,
+          taskId: input.taskId,
+          workerId: input.workerId,
+        },
+      })
     }
     this.emit("event", event);
   }


### PR DESCRIPTION
## Summary
- emit flux telemetry for legacy agent tool aliases and pi-agent orchestration schema usage
- promote the shim inventory into the epic #474 contract with the deprecation window, hard-stop date, and approved removal checklist
- cover the new telemetry and report behavior with agent, orchestration, and inspect tests

## Testing
- cd packages/zee && bun test test/cli/inspect-command.test.ts
- cd packages/zee && bun test test/agent/agent.test.ts
- cd packages/zee && bun test ../../src/swarm/orchestrator.test.ts
- cd packages/zee && bun run --conditions=browser ./src/index.ts inspect shim-boundaries --json
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh

Closes #474