### PR TITLE
feat: codify control-plane scope matrix

### DIFF
--- a/docs/architecture/control-plane-scope-matrix.md
+++ b/docs/architecture/control-plane-scope-matrix.md
@@ -1,0 +1,66 @@
+# Control-Plane Scope Matrix
+
+Issue: `#491`
+
+This document is the operator-facing summary of Zee's HTTP control-plane scope policy.
+The exact route-to-scope source of truth lives in
+`packages/zee/src/server/control-plane-scope.ts` and is verified against the generated
+OpenAPI surface plus hidden routes in `packages/zee/src/server/auth.test.ts`.
+
+## Approved Implementation Plan
+
+Approved in-repo on `2026-03-15`.
+
+- Replace prefix and verb heuristics with an explicit route matrix for mounted operator endpoints.
+- Fail closed to `operator.admin` when a control-plane family route is not present in the matrix.
+- Emit Flux telemetry on every authenticated control-plane request:
+  - `auth.scope.checked`
+  - `auth.scope.fallback`
+- Keep the matrix aligned to the generated OpenAPI spec and the non-OpenAPI usage/cron/heartbeat routes.
+
+## Public Exception
+
+- `OPTIONS *`
+  CORS preflight bypasses auth middleware. No other public bypass is permitted.
+
+## Scope Summary
+
+| Scope | Route families | Intent |
+| --- | --- | --- |
+| `operator.observe` | event streams, process registry reads, usage telemetry, Flux inspection, session event SSE | Diagnostics, traces, and runtime observability without mutation rights |
+| `operator.approvals` | permission queue, question queue, in-session approval replies | Human approval workflows |
+| `operator.pairing` | paired node inventory, pair/reconnect/revoke, node tool authorization | Device and node lifecycle management |
+| `operator.admin` | provider auth mutation, MCP mutation/tool calls, PTY, TUI RPC, process mutations, privileged gateway moderation, session shell, usage purge | High-risk execution and security-sensitive administration |
+| `operator.read` | tool/config/project/provider/session/file/model/registry reads, health/status, Telegram metadata, memory reads, MCP status | Read-only operator inspection |
+| `operator.write` | config/project/theme updates, session mutations, worktree creation, cron/heartbeat triggers, messaging sends, memory writes, STT, legacy LLM bridge | Standard operator mutations that are not full admin |
+
+## Exact Policy Notes
+
+- Provider credential mutation is explicitly `operator.admin`:
+  - `PUT /auth/{providerID}`
+  - `DELETE /auth/{providerID}`
+- Approval queues are explicitly `operator.approvals`:
+  - `GET /permission`
+  - `POST /permission/{requestID}/reply`
+  - `GET /question`
+  - `POST /question/{requestID}/reply`
+  - `POST /question/{requestID}/reject`
+  - `POST /session/{sessionID}/permissions/{permissionID}`
+- Pairing inventory and lifecycle are explicitly `operator.pairing`:
+  - `GET /gateway/node`
+  - `POST /gateway/node/pair`
+  - `POST /gateway/node/reconnect`
+  - `POST /gateway/node/revoke`
+  - `POST /gateway/node/tool/authorize`
+- Privileged remote execution stays `operator.admin`:
+  - `GET|POST|PUT|DELETE /pty...`
+  - `POST /mcp...`
+  - `POST /tui...`
+  - `POST /session/{sessionID}/shell`
+- Unmapped control-plane family routes fail closed to `operator.admin` and emit `auth.scope.fallback`.
+
+## Verification
+
+- Unit coverage checks explicit scope resolution and fail-closed fallback behavior.
+- OpenAPI parity coverage asserts that documented routes never use fallback resolution.
+- Hidden route coverage keeps `usage`, `cron`, and `heartbeat` endpoints out of the parity gap bucket.

--- a/docs/architecture/control-ui-primary.md
+++ b/docs/architecture/control-ui-primary.md
@@ -2,6 +2,8 @@
 
 This document defines the first-class operator path for Zee web control and webchat workflows (issue `#268`).
 
+Explicit HTTP operator scope assignments live in `docs/architecture/control-plane-scope-matrix.md`.
+
 ## Stable Entrypoints
 
 Primary commands:
@@ -23,7 +25,7 @@ Compatibility:
 - session visibility: `GET /session`
 - approvals queue: `GET /question`
 - pairing/gateway reachability: `GET /gateway/status`
-- system health: `GET /health/status`
+- system health: `GET /global/health/status`
 - channel state: `GET /gateway/channels/status`
 
 These workflows are covered by API-surface tests to keep the web operator path stable.

--- a/docs/architecture/gateway-control-plane.md
+++ b/docs/architecture/gateway-control-plane.md
@@ -3,6 +3,7 @@
 Zee includes an optional **Gateway**: a WebSocket (WS) control plane designed for channel integrations (WhatsApp, etc) and remote clients.
 
 Primary web operator guidance: `docs/architecture/control-ui-primary.md`.
+Explicit HTTP operator scope assignments: `docs/architecture/control-plane-scope-matrix.md`.
 
 At a high level:
 

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -32,6 +32,8 @@ export type FluxKind =
   | "oauth.refresh.success"
   | "oauth.refresh.fail"
   | "auth.legacy_payload.accepted"
+  | "auth.scope.checked"
+  | "auth.scope.fallback"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"
   | "provider.fallback.used"

--- a/packages/zee/src/server/auth.test.ts
+++ b/packages/zee/src/server/auth.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { AuthScope, hasScope, resolveRequiredScope, resolveControlUiPolicy, isTrustedControlOrigin } from "./auth"
+import { AuthScope, hasScope, resolveRequiredScope, resolveRequiredScopeInfo, resolveControlUiPolicy, isTrustedControlOrigin } from "./auth"
+import { CONTROL_PLANE_PUBLIC_EXCEPTIONS, CONTROL_PLANE_SCOPE_MATRIX } from "./control-plane-scope"
+import { Server } from "./server"
+
+function materializeOpenapiPath(path: string): string {
+  return path.replace(/\{[^/]+\}/g, "sample")
+}
 
 describe("resolveRequiredScope", () => {
   test("maps gateway node pairing routes to pairing scope", () => {
@@ -16,9 +22,76 @@ describe("resolveRequiredScope", () => {
     expect(resolveRequiredScope("POST", "/tui")).toBe(AuthScope.ADMIN)
   })
 
-  test("defaults GET to read and POST to write", () => {
-    expect(resolveRequiredScope("GET", "/some-unknown-route")).toBe(AuthScope.READ)
-    expect(resolveRequiredScope("POST", "/some-unknown-route")).toBe(AuthScope.WRITE)
+  test("maps explicit control-plane routes beyond the legacy prefix heuristics", () => {
+    expect(resolveRequiredScope("PUT", "/auth/openai")).toBe(AuthScope.ADMIN)
+    expect(resolveRequiredScope("GET", "/global/event")).toBe(AuthScope.OBSERVE)
+    expect(resolveRequiredScope("GET", "/process/events")).toBe(AuthScope.OBSERVE)
+    expect(resolveRequiredScope("GET", "/usage/stats")).toBe(AuthScope.OBSERVE)
+    expect(resolveRequiredScope("GET", "/gateway/node")).toBe(AuthScope.PAIRING)
+    expect(resolveRequiredScope("GET", "/permission")).toBe(AuthScope.APPROVALS)
+    expect(resolveRequiredScope("POST", "/memory/search")).toBe(AuthScope.READ)
+  })
+
+  test("fails closed for unmapped routes", () => {
+    expect(resolveRequiredScopeInfo("GET", "/some-unknown-route")).toEqual({
+      required: AuthScope.ADMIN,
+      fallback: true,
+      controlPlane: false,
+    })
+    expect(resolveRequiredScopeInfo("POST", "/some-unknown-route")).toEqual({
+      required: AuthScope.ADMIN,
+      fallback: true,
+      controlPlane: false,
+    })
+  })
+
+  test("covers every OpenAPI route with an explicit scope binding", async () => {
+    const spec = await Server.openapi()
+    const uncovered: string[] = []
+
+    for (const [path, methods] of Object.entries(spec.paths)) {
+      for (const method of Object.keys(methods)) {
+        const concretePath = materializeOpenapiPath(path)
+        const resolution = resolveRequiredScopeInfo(method, concretePath)
+        if (!resolution.fallback) continue
+        uncovered.push(`${method.toUpperCase()} ${path}`)
+      }
+    }
+
+    expect(uncovered).toEqual([])
+  })
+
+  test("covers non-OpenAPI control-plane routes with explicit bindings", () => {
+    const hiddenRoutes = [
+      ["GET", "/usage/events"],
+      ["GET", "/usage/summary"],
+      ["GET", "/usage/summary/provider/openai"],
+      ["GET", "/usage/summary/model/gpt-4o"],
+      ["GET", "/usage/summary/session/session-1"],
+      ["GET", "/usage/stats"],
+      ["GET", "/usage/cost"],
+      ["DELETE", "/usage/events"],
+      ["GET", "/cron/status"],
+      ["GET", "/cron/jobs"],
+      ["POST", "/cron/jobs"],
+      ["PATCH", "/cron/jobs/job-1"],
+      ["DELETE", "/cron/jobs/job-1"],
+      ["POST", "/cron/jobs/job-1/run"],
+      ["POST", "/cron/wake"],
+      ["POST", "/heartbeat/run"],
+      ["POST", "/heartbeat/wake"],
+    ] as const
+
+    for (const [method, path] of hiddenRoutes) {
+      expect(resolveRequiredScopeInfo(method, path).fallback).toBe(false)
+    }
+  })
+})
+
+describe("control-plane scope matrix", () => {
+  test("documents a non-empty explicit matrix and the only public bypass", () => {
+    expect(CONTROL_PLANE_SCOPE_MATRIX.length).toBeGreaterThan(100)
+    expect(CONTROL_PLANE_PUBLIC_EXCEPTIONS).toEqual(["OPTIONS * (CORS preflight bypasses auth middleware)"])
   })
 })
 

--- a/packages/zee/src/server/auth.ts
+++ b/packages/zee/src/server/auth.ts
@@ -2,108 +2,10 @@ import { Flag } from "@/flag/flag"
 import { extractBasicCredentials, extractBearerToken, timingSafeEqual } from "@/security"
 import { Config } from "../config/config"
 import { Instance } from "../project/instance"
+import { AuthScope, resolveRequiredScope, resolveRequiredScopeInfo, type AuthScopeValue } from "./control-plane-scope"
 
 const DEFAULT_USERNAME = "zee"
 const DEFAULT_CONTROL_UI_AUTH_MODE = "token"
-
-// ---------------------------------------------------------------------------
-// Scoped Permissions
-// ---------------------------------------------------------------------------
-
-/**
- * Permission scopes matching OpenClaw's operator permission model.
- * These control access to different API surface areas.
- */
-export const AuthScope = {
-  /** Full administrative access */
-  ADMIN: "operator.admin",
-  /** Read-only access (list sessions, view models, read config) */
-  READ: "operator.read",
-  /** Observability access (flux events, traces, diagnostics) */
-  OBSERVE: "operator.observe",
-  /** Write access (create sessions, send messages, modify config) */
-  WRITE: "operator.write",
-  /** Approve execution requests and permissions */
-  APPROVALS: "operator.approvals",
-  /** Device pairing and gateway pairing */
-  PAIRING: "operator.pairing",
-} as const
-
-export type AuthScopeValue = (typeof AuthScope)[keyof typeof AuthScope]
-
-/**
- * Maps route prefixes to required scopes.
- * Admin scope grants access to everything.
- * Routes not listed here default to READ.
- */
-const ROUTE_SCOPE_MAP: Record<string, AuthScopeValue> = {
-  // Write operations
-  "POST /session": AuthScope.WRITE,
-  "DELETE /session": AuthScope.WRITE,
-  // Node-client lifecycle (pair/reconnect/revoke + tool authorization)
-  "POST /gateway/node/pair": AuthScope.PAIRING,
-  "POST /gateway/node/reconnect": AuthScope.PAIRING,
-  "POST /gateway/node/revoke": AuthScope.PAIRING,
-  "POST /gateway/node/tool/authorize": AuthScope.PAIRING,
-  "GET /gateway/node": AuthScope.READ,
-  "POST /gateway/telegram/metadata": AuthScope.READ,
-  "POST /gateway/telegram/send": AuthScope.WRITE,
-  "POST /gateway/telegram/moderation": AuthScope.ADMIN,
-  "POST /gateway": AuthScope.WRITE,
-  "POST /memory/store": AuthScope.WRITE,
-  "POST /memory/batch": AuthScope.WRITE,
-  "DELETE /memory": AuthScope.WRITE,
-  "POST /memory/delete-where": AuthScope.WRITE,
-  "POST /memory/reset": AuthScope.WRITE,
-  "PATCH /config": AuthScope.WRITE,
-  "POST /cron": AuthScope.WRITE,
-  "DELETE /cron": AuthScope.WRITE,
-  // High-risk: process execution surface
-  "POST /pty": AuthScope.ADMIN,
-  "DELETE /pty": AuthScope.ADMIN,
-  // High-risk: MCP can execute arbitrary tool logic via external servers
-  "POST /mcp": AuthScope.ADMIN,
-  "DELETE /mcp": AuthScope.ADMIN,
-  // High-risk: UI control plane
-  "POST /tui": AuthScope.ADMIN,
-
-  // Approval operations
-  "POST /session/*/permissions": AuthScope.APPROVALS,
-  "POST /permission": AuthScope.APPROVALS,
-  "POST /question": AuthScope.APPROVALS,
-
-  // Observability operations
-  "GET /v1/flux": AuthScope.OBSERVE,
-
-  // Admin operations
-  "GET /global/instances": AuthScope.ADMIN,
-  "POST /global/dispose": AuthScope.ADMIN,
-  "POST /instance/dispose": AuthScope.ADMIN,
-}
-
-/**
- * Resolve the required scope for a given HTTP method + path combination.
- */
-export function resolveRequiredScope(method: string, path: string): AuthScopeValue {
-  const upperMethod = method.toUpperCase()
-
-  // Check exact and prefix matches
-  for (const [pattern, scope] of Object.entries(ROUTE_SCOPE_MAP)) {
-    const [patternMethod, patternPath] = pattern.split(" ", 2)
-    if (upperMethod !== patternMethod) continue
-
-    // Wildcard matching
-    if (patternPath.includes("*")) {
-      const regex = new RegExp("^" + patternPath.replace(/\*/g, "[^/]+") + "(/|$)")
-      if (regex.test(path)) return scope
-    } else if (path.startsWith(patternPath)) {
-      return scope
-    }
-  }
-
-  // Default: GET = read, everything else = write
-  return upperMethod === "GET" || upperMethod === "HEAD" ? AuthScope.READ : AuthScope.WRITE
-}
 
 /**
  * Check if a set of granted scopes satisfies the required scope.
@@ -300,6 +202,9 @@ export function authorizeRequestScoped(
 
   return { authorized: true }
 }
+
+export { AuthScope, resolveRequiredScope, resolveRequiredScopeInfo }
+export type { AuthScopeValue }
 
 export function isLoopbackHostname(hostname: string): boolean {
   const value = hostname.trim().toLowerCase()

--- a/packages/zee/src/server/control-plane-scope.ts
+++ b/packages/zee/src/server/control-plane-scope.ts
@@ -1,0 +1,364 @@
+export const AuthScope = {
+  /** Full administrative access */
+  ADMIN: "operator.admin",
+  /** Read-only access (list sessions, view models, read config) */
+  READ: "operator.read",
+  /** Observability access (flux events, traces, diagnostics) */
+  OBSERVE: "operator.observe",
+  /** Write access (create sessions, send messages, modify config) */
+  WRITE: "operator.write",
+  /** Approve execution requests and permissions */
+  APPROVALS: "operator.approvals",
+  /** Device pairing and gateway pairing */
+  PAIRING: "operator.pairing",
+} as const
+
+export type AuthScopeValue = (typeof AuthScope)[keyof typeof AuthScope]
+
+export type ControlPlaneRouteScopeEntry = {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+  path: string
+  scope: AuthScopeValue
+  note: string
+}
+
+export type RequiredScopeResolution = {
+  required: AuthScopeValue
+  matchedEntry?: ControlPlaneRouteScopeEntry
+  fallback: boolean
+  controlPlane: boolean
+}
+
+function entry(
+  method: ControlPlaneRouteScopeEntry["method"],
+  path: string,
+  scope: AuthScopeValue,
+  note: string,
+): ControlPlaneRouteScopeEntry {
+  return { method, path, scope, note }
+}
+
+export const CONTROL_PLANE_SCOPE_MATRIX: ControlPlaneRouteScopeEntry[] = [
+  // Observability and tracing
+  entry("GET", "/event", AuthScope.OBSERVE, "Server event stream."),
+  entry("GET", "/events", AuthScope.OBSERVE, "Global event stream."),
+  entry("GET", "/global/event", AuthScope.OBSERVE, "Global event stream."),
+  entry("GET", "/process", AuthScope.OBSERVE, "Process registry inventory."),
+  entry("GET", "/process/{id}", AuthScope.OBSERVE, "Process registry detail."),
+  entry("GET", "/process/consensus/history", AuthScope.OBSERVE, "Consensus history."),
+  entry("GET", "/process/consensus/stats", AuthScope.OBSERVE, "Consensus metrics."),
+  entry("GET", "/process/events", AuthScope.OBSERVE, "Process SSE stream."),
+  entry("GET", "/process/stats", AuthScope.OBSERVE, "Process metrics."),
+  entry("GET", "/process/swarm/{swarmId}", AuthScope.OBSERVE, "Swarm process inventory."),
+  entry("GET", "/process/workstealing/stats", AuthScope.OBSERVE, "Work-stealing metrics."),
+  entry("GET", "/session/{sessionID}/events", AuthScope.OBSERVE, "Session SSE stream."),
+  entry("GET", "/usage/cost", AuthScope.OBSERVE, "Usage cost metrics."),
+  entry("GET", "/usage/events", AuthScope.OBSERVE, "Usage event log."),
+  entry("GET", "/usage/stats", AuthScope.OBSERVE, "Usage dashboard metrics."),
+  entry("GET", "/usage/summary", AuthScope.OBSERVE, "Usage summary."),
+  entry("GET", "/usage/summary/model/{id}", AuthScope.OBSERVE, "Model usage summary."),
+  entry("GET", "/usage/summary/provider/{id}", AuthScope.OBSERVE, "Provider usage summary."),
+  entry("GET", "/usage/summary/session/{id}", AuthScope.OBSERVE, "Session usage summary."),
+  entry("GET", "/v1/flux/events", AuthScope.OBSERVE, "Flux event inspection."),
+  entry("GET", "/v1/flux/schema", AuthScope.OBSERVE, "Flux schema inspection."),
+  entry("GET", "/v1/flux/sessions/{sessionID}/path", AuthScope.OBSERVE, "Flux session path inspection."),
+  entry("GET", "/v1/flux/trace/{traceID}", AuthScope.OBSERVE, "Flux trace inspection."),
+
+  // Approval queue operations
+  entry("GET", "/permission", AuthScope.APPROVALS, "Pending permission queue."),
+  entry("POST", "/permission/{requestID}/reply", AuthScope.APPROVALS, "Permission approval response."),
+  entry("GET", "/question", AuthScope.APPROVALS, "Pending question queue."),
+  entry("POST", "/question/{requestID}/reject", AuthScope.APPROVALS, "Reject question."),
+  entry("POST", "/question/{requestID}/reply", AuthScope.APPROVALS, "Reply to question."),
+  entry(
+    "POST",
+    "/session/{sessionID}/permissions/{permissionID}",
+    AuthScope.APPROVALS,
+    "Respond to in-session permission prompt.",
+  ),
+
+  // Pairing and node lifecycle
+  entry("GET", "/gateway/node", AuthScope.PAIRING, "Paired node inventory."),
+  entry("POST", "/gateway/node/pair", AuthScope.PAIRING, "Pair new node client."),
+  entry("POST", "/gateway/node/reconnect", AuthScope.PAIRING, "Reconnect paired node client."),
+  entry("POST", "/gateway/node/revoke", AuthScope.PAIRING, "Revoke paired node."),
+  entry("POST", "/gateway/node/tool/authorize", AuthScope.PAIRING, "Authorize paired node tool request."),
+
+  // High-risk administrative surfaces
+  entry("DELETE", "/auth/{providerID}", AuthScope.ADMIN, "Remove provider credentials."),
+  entry("PUT", "/auth/{providerID}", AuthScope.ADMIN, "Set provider credentials."),
+  entry("POST", "/global/dispose", AuthScope.ADMIN, "Dispose instance."),
+  entry("POST", "/global/dispose-all", AuthScope.ADMIN, "Dispose all cached instances."),
+  entry("POST", "/global/dispose-directory", AuthScope.ADMIN, "Dispose cached instance by directory."),
+  entry("GET", "/global/instances", AuthScope.ADMIN, "Inspect cached instances."),
+  entry("POST", "/instance/dispose", AuthScope.ADMIN, "Dispose named instance."),
+  entry("DELETE", "/mcp/{name}/auth", AuthScope.ADMIN, "Remove MCP OAuth state."),
+  entry("POST", "/mcp", AuthScope.ADMIN, "Register MCP server."),
+  entry("POST", "/mcp/{name}/auth", AuthScope.ADMIN, "Start MCP OAuth."),
+  entry("POST", "/mcp/{name}/auth/authenticate", AuthScope.ADMIN, "Authenticate MCP OAuth."),
+  entry("POST", "/mcp/{name}/auth/callback", AuthScope.ADMIN, "Complete MCP OAuth."),
+  entry("POST", "/mcp/{name}/connect", AuthScope.ADMIN, "Connect MCP server."),
+  entry("POST", "/mcp/{name}/disconnect", AuthScope.ADMIN, "Disconnect MCP server."),
+  entry("POST", "/mcp/{name}/reconnect", AuthScope.ADMIN, "Reconnect MCP server."),
+  entry("POST", "/mcp/{name}/tool", AuthScope.ADMIN, "Execute MCP tool."),
+  entry("POST", "/mcp/health-check", AuthScope.ADMIN, "Health check MCP servers."),
+  entry("POST", "/mcp/reconnect-all", AuthScope.ADMIN, "Reconnect all MCP servers."),
+  entry("POST", "/process/{id}/heartbeat", AuthScope.ADMIN, "Update process heartbeat."),
+  entry("POST", "/process/consensus/propose", AuthScope.ADMIN, "Submit consensus proposal."),
+  entry("POST", "/process/consensus/vote", AuthScope.ADMIN, "Cast consensus vote."),
+  entry("POST", "/process/consensus/voter", AuthScope.ADMIN, "Register consensus voter."),
+  entry("POST", "/process/find-available", AuthScope.ADMIN, "Schedule work onto available agents."),
+  entry("POST", "/process/register", AuthScope.ADMIN, "Register process."),
+  entry("POST", "/process/workstealing/find-best", AuthScope.ADMIN, "Find best worker for task."),
+  entry("POST", "/process/workstealing/task-duration", AuthScope.ADMIN, "Record task duration."),
+  entry("POST", "/process/workstealing/workload", AuthScope.ADMIN, "Update worker workload."),
+  entry("DELETE", "/process/{id}", AuthScope.ADMIN, "Deregister process."),
+  entry("PATCH", "/process/{id}", AuthScope.ADMIN, "Update process registry record."),
+  entry("POST", "/provider/{providerID}/oauth/authorize", AuthScope.ADMIN, "Start provider OAuth."),
+  entry("POST", "/provider/{providerID}/oauth/callback", AuthScope.ADMIN, "Complete provider OAuth."),
+  entry("GET", "/pty", AuthScope.ADMIN, "Inspect PTY sessions."),
+  entry("POST", "/pty", AuthScope.ADMIN, "Create PTY session."),
+  entry("DELETE", "/pty/{ptyID}", AuthScope.ADMIN, "Destroy PTY session."),
+  entry("GET", "/pty/{ptyID}", AuthScope.ADMIN, "Inspect PTY session."),
+  entry("PUT", "/pty/{ptyID}", AuthScope.ADMIN, "Resize or update PTY session."),
+  entry("POST", "/gateway/telegram/moderation/delete", AuthScope.ADMIN, "Moderate Telegram content."),
+  entry("POST", "/gateway/whatsapp/inbound", AuthScope.ADMIN, "Receive privileged WhatsApp bridge payload."),
+  entry("POST", "/session/{sessionID}/shell", AuthScope.ADMIN, "Run shell command inside session."),
+  entry("POST", "/tui/append-prompt", AuthScope.ADMIN, "Drive TUI remotely."),
+  entry("POST", "/tui/clear-prompt", AuthScope.ADMIN, "Drive TUI remotely."),
+  entry("POST", "/tui/execute-command", AuthScope.ADMIN, "Drive TUI remotely."),
+  entry("POST", "/tui/open-help", AuthScope.ADMIN, "Drive TUI remotely."),
+  entry("POST", "/tui/open-models", AuthScope.ADMIN, "Drive TUI remotely."),
+  entry("POST", "/tui/open-sessions", AuthScope.ADMIN, "Drive TUI remotely."),
+  entry("POST", "/tui/open-themes", AuthScope.ADMIN, "Drive TUI remotely."),
+  entry("POST", "/tui/publish", AuthScope.ADMIN, "Drive TUI remotely."),
+  entry("POST", "/tui/select-session", AuthScope.ADMIN, "Drive TUI remotely."),
+  entry("POST", "/tui/show-toast", AuthScope.ADMIN, "Drive TUI remotely."),
+  entry("POST", "/tui/submit-prompt", AuthScope.ADMIN, "Drive TUI remotely."),
+  entry("DELETE", "/usage/events", AuthScope.ADMIN, "Purge usage telemetry."),
+
+  // Read-oriented operator surfaces
+  entry("GET", "/", AuthScope.READ, "List tools."),
+  entry("GET", "/agent", AuthScope.READ, "List agents."),
+  entry("GET", "/command", AuthScope.READ, "List commands."),
+  entry("GET", "/config", AuthScope.READ, "Read configuration."),
+  entry("GET", "/config/providers", AuthScope.READ, "List config providers."),
+  entry("GET", "/experimental/worktree", AuthScope.READ, "List worktrees."),
+  entry("GET", "/file", AuthScope.READ, "List files."),
+  entry("GET", "/file/content", AuthScope.READ, "Read file contents."),
+  entry("GET", "/file/status", AuthScope.READ, "Read file status."),
+  entry("GET", "/find", AuthScope.READ, "Search text."),
+  entry("GET", "/find/file", AuthScope.READ, "Search files."),
+  entry("GET", "/find/symbol", AuthScope.READ, "Search symbols."),
+  entry("GET", "/formatter", AuthScope.READ, "Inspect formatter."),
+  entry("GET", "/gateway/skills", AuthScope.READ, "Inspect gateway skills."),
+  entry("POST", "/gateway/telegram/metadata/chat", AuthScope.READ, "Fetch Telegram metadata."),
+  entry("GET", "/global/health", AuthScope.READ, "Read health."),
+  entry("GET", "/global/health/live", AuthScope.READ, "Read liveness."),
+  entry("GET", "/global/health/status", AuthScope.READ, "Read health status."),
+  entry("GET", "/global/stats", AuthScope.READ, "Read server stats."),
+  entry("GET", "/ids", AuthScope.READ, "List tool IDs."),
+  entry("GET", "/lsp", AuthScope.READ, "Inspect LSP status."),
+  entry("GET", "/mcp", AuthScope.READ, "Inspect MCP server status."),
+  entry("GET", "/mcp/experimental/resource", AuthScope.READ, "Read MCP resources."),
+  entry("GET", "/memory/{id}", AuthScope.READ, "Read memory."),
+  entry("POST", "/memory/agentic-search", AuthScope.READ, "Search memories."),
+  entry("GET", "/memory/curated", AuthScope.READ, "Read curated context."),
+  entry("GET", "/memory/health", AuthScope.READ, "Read memory health."),
+  entry("GET", "/memory/namespace/{namespace}", AuthScope.READ, "Read namespaced memories."),
+  entry("POST", "/memory/search", AuthScope.READ, "Search memories."),
+  entry("GET", "/memory/stats", AuthScope.READ, "Read memory stats."),
+  entry("GET", "/memory/tree/domains", AuthScope.READ, "Read memory domains."),
+  entry("GET", "/memory/tree/subtopics/{domain}/{topic}", AuthScope.READ, "Read memory subtopics."),
+  entry("GET", "/memory/tree/topics/{domain}", AuthScope.READ, "Read memory topics."),
+  entry("GET", "/memory/version/{memoryId}", AuthScope.READ, "Read memory version history."),
+  entry("GET", "/openapi", AuthScope.READ, "Read OpenAPI spec."),
+  entry("GET", "/path", AuthScope.READ, "Read path info."),
+  entry("GET", "/preferences/theme", AuthScope.READ, "Read theme preference."),
+  entry("GET", "/project", AuthScope.READ, "List projects."),
+  entry("GET", "/project/current", AuthScope.READ, "Read current project."),
+  entry("GET", "/provider", AuthScope.READ, "List providers."),
+  entry("GET", "/provider/auth", AuthScope.READ, "Read provider auth modes."),
+  entry("GET", "/provider/auth/status", AuthScope.READ, "Read provider auth status."),
+  entry("GET", "/session", AuthScope.READ, "List sessions."),
+  entry("GET", "/session/{sessionID}", AuthScope.READ, "Read session."),
+  entry("GET", "/session/{sessionID}/children", AuthScope.READ, "Read session children."),
+  entry("GET", "/session/{sessionID}/diff", AuthScope.READ, "Read session diff."),
+  entry("GET", "/session/{sessionID}/diff/all", AuthScope.READ, "Read full session diff."),
+  entry("GET", "/session/{sessionID}/message", AuthScope.READ, "Read session messages."),
+  entry("GET", "/session/{sessionID}/message/{messageID}", AuthScope.READ, "Read message."),
+  entry("GET", "/session/{sessionID}/todo", AuthScope.READ, "Read session todos."),
+  entry("GET", "/session/status", AuthScope.READ, "Read session status."),
+  entry("GET", "/sync", AuthScope.READ, "Read sync delta."),
+  entry("GET", "/themes", AuthScope.READ, "List themes."),
+  entry("GET", "/v1/memory/{id}", AuthScope.READ, "Read memory (v1)."),
+  entry("POST", "/v1/memory/agentic-search", AuthScope.READ, "Search memories (v1)."),
+  entry("GET", "/v1/memory/curated", AuthScope.READ, "Read curated context (v1)."),
+  entry("GET", "/v1/memory/health", AuthScope.READ, "Read memory health (v1)."),
+  entry("GET", "/v1/memory/namespace/{namespace}", AuthScope.READ, "Read namespaced memories (v1)."),
+  entry("POST", "/v1/memory/search", AuthScope.READ, "Search memories (v1)."),
+  entry("GET", "/v1/memory/stats", AuthScope.READ, "Read memory stats (v1)."),
+  entry("GET", "/v1/memory/tree/domains", AuthScope.READ, "Read memory domains (v1)."),
+  entry("GET", "/v1/memory/tree/subtopics/{domain}/{topic}", AuthScope.READ, "Read memory subtopics (v1)."),
+  entry("GET", "/v1/memory/tree/topics/{domain}", AuthScope.READ, "Read memory topics (v1)."),
+  entry("GET", "/v1/memory/version/{memoryId}", AuthScope.READ, "Read memory version history (v1)."),
+  entry("GET", "/v1/registry/palette", AuthScope.READ, "Read registry palette."),
+  entry("GET", "/v1/registry/providers", AuthScope.READ, "Read registry providers."),
+  entry("GET", "/v1/registry/skills/frontmatter", AuthScope.READ, "Read skill frontmatter registry."),
+  entry("GET", "/v1/skills/index", AuthScope.READ, "Read skills index."),
+  entry("POST", "/v1/skills/recommend", AuthScope.READ, "Recommend skills."),
+  entry("GET", "/vcs", AuthScope.READ, "Read VCS info."),
+  entry("GET", "/gateway/channels/status", AuthScope.OBSERVE, "Inspect gateway channel health."),
+  entry("GET", "/gateway/status", AuthScope.OBSERVE, "Inspect gateway health."),
+  entry("GET", "/gateway/usage", AuthScope.OBSERVE, "Inspect gateway usage metrics."),
+
+  // Mutation and workflow surfaces
+  entry("PATCH", "/config", AuthScope.WRITE, "Update configuration."),
+  entry("GET", "/cron/jobs", AuthScope.READ, "Read cron jobs."),
+  entry("GET", "/cron/status", AuthScope.READ, "Read cron scheduler status."),
+  entry("POST", "/cron/jobs", AuthScope.WRITE, "Create cron job."),
+  entry("PATCH", "/cron/jobs/{id}", AuthScope.WRITE, "Update cron job."),
+  entry("DELETE", "/cron/jobs/{id}", AuthScope.WRITE, "Delete cron job."),
+  entry("POST", "/cron/jobs/{id}/run", AuthScope.WRITE, "Run cron job."),
+  entry("POST", "/cron/wake", AuthScope.WRITE, "Wake cron scheduler."),
+  entry("POST", "/experimental/worktree", AuthScope.WRITE, "Create worktree."),
+  entry("POST", "/gateway/telegram/send", AuthScope.WRITE, "Send Telegram message."),
+  entry("POST", "/gateway/whatsapp/send", AuthScope.WRITE, "Send WhatsApp message."),
+  entry("POST", "/heartbeat/run", AuthScope.WRITE, "Run heartbeat now."),
+  entry("POST", "/heartbeat/wake", AuthScope.WRITE, "Wake heartbeat runner."),
+  entry("POST", "/log", AuthScope.WRITE, "Write operator log."),
+  entry("DELETE", "/memory/{id}", AuthScope.WRITE, "Delete memory."),
+  entry("POST", "/memory/batch", AuthScope.WRITE, "Batch store memories."),
+  entry("POST", "/memory/cleanup", AuthScope.WRITE, "Cleanup expired memories."),
+  entry("POST", "/memory/delete-where", AuthScope.WRITE, "Delete memories by filter."),
+  entry("POST", "/memory/reset", AuthScope.WRITE, "Reset memory service."),
+  entry("POST", "/memory/store", AuthScope.WRITE, "Store memory."),
+  entry("POST", "/memory/version/{memoryId}/rollback", AuthScope.WRITE, "Rollback memory version."),
+  entry("PATCH", "/preferences/theme", AuthScope.WRITE, "Update theme preference."),
+  entry("PATCH", "/project/{projectID}", AuthScope.WRITE, "Update project."),
+  entry("POST", "/session", AuthScope.WRITE, "Create session."),
+  entry("DELETE", "/session/{sessionID}", AuthScope.WRITE, "Delete session."),
+  entry("PATCH", "/session/{sessionID}", AuthScope.WRITE, "Update session."),
+  entry("POST", "/session/{sessionID}/abort", AuthScope.WRITE, "Abort session."),
+  entry("POST", "/session/{sessionID}/command", AuthScope.WRITE, "Send session command."),
+  entry("POST", "/session/{sessionID}/fork", AuthScope.WRITE, "Fork session."),
+  entry("POST", "/session/{sessionID}/handoff", AuthScope.WRITE, "Hand off session."),
+  entry("POST", "/session/{sessionID}/init", AuthScope.WRITE, "Initialize session."),
+  entry("POST", "/session/{sessionID}/message", AuthScope.WRITE, "Send message."),
+  entry("DELETE", "/session/{sessionID}/message/{messageID}/part/{partID}", AuthScope.WRITE, "Delete message part."),
+  entry("PATCH", "/session/{sessionID}/message/{messageID}/part/{partID}", AuthScope.WRITE, "Update message part."),
+  entry("PATCH", "/session/{sessionID}/mode", AuthScope.WRITE, "Update session mode."),
+  entry("POST", "/session/{sessionID}/note", AuthScope.WRITE, "Append session note."),
+  entry("POST", "/session/{sessionID}/prompt_async", AuthScope.WRITE, "Send async prompt."),
+  entry("POST", "/session/{sessionID}/revert", AuthScope.WRITE, "Revert session."),
+  entry("DELETE", "/session/{sessionID}/share", AuthScope.WRITE, "Unshare session."),
+  entry("POST", "/session/{sessionID}/share", AuthScope.WRITE, "Share session."),
+  entry("POST", "/session/{sessionID}/steer", AuthScope.WRITE, "Steer session."),
+  entry("POST", "/session/{sessionID}/summarize", AuthScope.WRITE, "Summarize session."),
+  entry("POST", "/session/{sessionID}/unrevert", AuthScope.WRITE, "Restore reverted content."),
+  entry("POST", "/stt/wisprflow", AuthScope.WRITE, "Run speech-to-text."),
+  entry("POST", "/v1/llm/stream", AuthScope.WRITE, "Run legacy LLM bridge."),
+  entry("DELETE", "/v1/memory/{id}", AuthScope.WRITE, "Delete memory (v1)."),
+  entry("POST", "/v1/memory/batch", AuthScope.WRITE, "Batch store memories (v1)."),
+  entry("POST", "/v1/memory/cleanup", AuthScope.WRITE, "Cleanup expired memories (v1)."),
+  entry("POST", "/v1/memory/delete-where", AuthScope.WRITE, "Delete memories by filter (v1)."),
+  entry("POST", "/v1/memory/reset", AuthScope.WRITE, "Reset memory service (v1)."),
+  entry("POST", "/v1/memory/store", AuthScope.WRITE, "Store memory (v1)."),
+  entry(
+    "POST",
+    "/v1/memory/version/{memoryId}/rollback",
+    AuthScope.WRITE,
+    "Rollback memory version (v1).",
+  ),
+] as const
+
+export const CONTROL_PLANE_PUBLIC_EXCEPTIONS = [
+  "OPTIONS * (CORS preflight bypasses auth middleware)",
+] as const
+
+const CONTROL_PLANE_FAMILIES = [
+  "/agent",
+  "/auth",
+  "/command",
+  "/config",
+  "/cron",
+  "/event",
+  "/events",
+  "/experimental",
+  "/file",
+  "/find",
+  "/formatter",
+  "/gateway",
+  "/global",
+  "/heartbeat",
+  "/ids",
+  "/instance",
+  "/log",
+  "/lsp",
+  "/mcp",
+  "/memory",
+  "/openapi",
+  "/path",
+  "/permission",
+  "/preferences",
+  "/process",
+  "/project",
+  "/provider",
+  "/pty",
+  "/question",
+  "/session",
+  "/stt",
+  "/sync",
+  "/themes",
+  "/tui",
+  "/usage",
+  "/v1",
+  "/vcs",
+] as const
+
+function buildPatternRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+  const withParams = escaped.replace(/\\\{[^/]+\\\}/g, "[^/]+")
+  return new RegExp(`^${withParams}$`)
+}
+
+function pathMatchesEntry(path: string, entry: ControlPlaneRouteScopeEntry): boolean {
+  return buildPatternRegex(entry.path).test(path)
+}
+
+function resolveCandidateMethods(method: string): string[] {
+  const upperMethod = method.toUpperCase()
+  return upperMethod === "HEAD" ? ["GET", "HEAD"] : [upperMethod]
+}
+
+function isControlPlaneFamily(path: string): boolean {
+  if (path === "/") return true
+  return CONTROL_PLANE_FAMILIES.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))
+}
+
+export function resolveRequiredScopeInfo(method: string, path: string): RequiredScopeResolution {
+  const candidateMethods = resolveCandidateMethods(method)
+  const matchedEntry = CONTROL_PLANE_SCOPE_MATRIX.find(
+    (entry) => candidateMethods.includes(entry.method) && pathMatchesEntry(path, entry),
+  )
+
+  if (matchedEntry) {
+    return {
+      required: matchedEntry.scope,
+      matchedEntry,
+      fallback: false,
+      controlPlane: true,
+    }
+  }
+
+  const controlPlane = isControlPlaneFamily(path)
+  return {
+    required: AuthScope.ADMIN,
+    fallback: true,
+    controlPlane,
+  }
+}
+
+export function resolveRequiredScope(method: string, path: string): AuthScopeValue {
+  return resolveRequiredScopeInfo(method, path).required
+}

--- a/packages/zee/src/server/server.ts
+++ b/packages/zee/src/server/server.ts
@@ -36,7 +36,7 @@ import {
   isAuthorized,
   isTrustedControlOrigin,
   isLoopbackHostname,
-  resolveRequiredScope,
+  resolveRequiredScopeInfo,
 } from "./auth"
 import {
   createAuthRateLimiter,
@@ -365,7 +365,8 @@ export namespace Server {
             const ip = RequestMeta.getIp(c.req.raw)
             const method = c.req.method
             const path = c.req.path
-            const required = resolveRequiredScope(method, path)
+            const scopeResolution = resolveRequiredScopeInfo(method, path)
+            const required = scopeResolution.required
             const authHeader = c.req.header("Authorization")
             const authRateLimiter = resolveAuthRateLimiter()
             const rateLimit = authRateLimiter?.check(ip)
@@ -400,6 +401,44 @@ export namespace Server {
             authRateLimiter?.reset(ip)
 
             const granted = authConfig.scopes ?? [AuthScope.ADMIN]
+            const traceID = RequestMeta.getTraceID(c.req.raw) ?? crypto.randomUUID()
+            const requestID = RequestMeta.getRequestID(c.req.raw)
+            if (scopeResolution.controlPlane) {
+              FluxRecorder.record({
+                traceID,
+                requestID,
+                direction: "internal",
+                domain: "auth",
+                kind: "auth.scope.checked",
+                status: hasScope(granted, required) ? "ok" : "denied",
+                method,
+                path,
+                route: scopeResolution.matchedEntry?.path ?? path,
+                metadata: {
+                  requiredScope: required,
+                  grantedScopes: granted,
+                  matchedPattern: scopeResolution.matchedEntry?.path,
+                  controlPlane: true,
+                  fallback: scopeResolution.fallback,
+                },
+              })
+            }
+            if (scopeResolution.controlPlane && scopeResolution.fallback) {
+              FluxRecorder.record({
+                traceID,
+                requestID,
+                direction: "internal",
+                domain: "auth",
+                kind: "auth.scope.fallback",
+                status: "error",
+                method,
+                path,
+                route: path,
+                metadata: {
+                  requiredScope: required,
+                },
+              })
+            }
             if (!hasScope(granted, required)) {
               log.warn("authz denied", {
                 status: 403,

--- a/packages/zee/test/server/auth-scope.test.ts
+++ b/packages/zee/test/server/auth-scope.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { afterAll, beforeEach, describe, expect, test } from "bun:test"
 import { reloadFlags } from "../../src/flag/flag"
 import { Server } from "../../src/server/server"
 
@@ -15,7 +15,7 @@ const ORIGINAL_ENV = {
   ZEE_SERVER_SCOPES: process.env.ZEE_SERVER_SCOPES,
 }
 
-beforeAll(() => {
+beforeEach(() => {
   process.env.ZEE_ENABLE_SERVER_AUTH = "1"
   delete process.env.ZEE_DISABLE_SERVER_AUTH
   delete process.env.ZEE_SERVER_USERNAME
@@ -82,6 +82,45 @@ describe("HTTP auth and scopes", () => {
     expect(res.status).toBe(403)
   })
 
+  test("allows approvals scope to inspect question queue", async () => {
+    process.env.ZEE_SERVER_SCOPES = "operator.approvals"
+    reloadFlags()
+    Server.App.reset()
+    const app = Server.App()
+    const res = await app.request("/question", {
+      method: "GET",
+      headers: {
+        Authorization: basicAuth("zee", "test-password"),
+      },
+    })
+    expect(res.status).toBe(200)
+  })
+
+  test("forbids read-only scope from paired-node inventory", async () => {
+    const app = Server.App()
+    const res = await app.request("/gateway/node", {
+      method: "GET",
+      headers: {
+        Authorization: basicAuth("zee", "test-password"),
+      },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  test("allows pairing scope to inspect paired-node inventory", async () => {
+    process.env.ZEE_SERVER_SCOPES = "operator.pairing"
+    reloadFlags()
+    Server.App.reset()
+    const app = Server.App()
+    const res = await app.request("/gateway/node", {
+      method: "GET",
+      headers: {
+        Authorization: basicAuth("zee", "test-password"),
+      },
+    })
+    expect(res.status).toBe(200)
+  })
+
   test("forbids non-admin scopes from listing cached instances (GET /global/instances)", async () => {
     const app = Server.App()
     const res = await app.request("/global/instances", {
@@ -108,6 +147,33 @@ describe("HTTP auth and scopes", () => {
     const app = Server.App()
     const res = await app.request("/global/dispose", {
       method: "POST",
+      headers: {
+        Authorization: basicAuth("zee", "test-password"),
+      },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  test("forbids read-only scopes from mutating provider auth credentials", async () => {
+    const app = Server.App()
+    const res = await app.request("/auth/openai", {
+      method: "PUT",
+      headers: {
+        Authorization: basicAuth("zee", "test-password"),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "api",
+        key: "test-key",
+      }),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  test("forbids read-only scopes from control-plane observability streams", async () => {
+    const app = Server.App()
+    const res = await app.request("/global/event", {
+      method: "GET",
       headers: {
         Authorization: basicAuth("zee", "test-password"),
       },

--- a/packages/zee/test/server/flux-auth-scope.test.ts
+++ b/packages/zee/test/server/flux-auth-scope.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test"
+import { FluxRecorder } from "../../src/flux"
 import { reloadFlags } from "../../src/flag/flag"
 import { Server } from "../../src/server/server"
 
@@ -49,6 +50,7 @@ describe("flux route scopes", () => {
   test("allows observe scope for flux endpoints", async () => {
     process.env.ZEE_SERVER_SCOPES = "operator.observe"
     reloadFlags()
+    const before = FluxRecorder.list({ kind: "auth.scope.checked" }).total
     const app = Server.App()
     const res = await app.request("/v1/flux/schema", {
       headers: {
@@ -56,5 +58,20 @@ describe("flux route scopes", () => {
       },
     })
     expect(res.status).toBe(200)
+    expect(FluxRecorder.list({ kind: "auth.scope.checked" }).total).toBe(before + 1)
+  })
+
+  test("emits fallback telemetry when a control-plane prefix misses the explicit matrix", async () => {
+    process.env.ZEE_SERVER_SCOPES = "operator.admin"
+    reloadFlags()
+    const before = FluxRecorder.list({ kind: "auth.scope.fallback" }).total
+    const app = Server.App()
+    const res = await app.request("/global/not-real", {
+      headers: {
+        Authorization: basicAuth("zee", "test-password"),
+      },
+    })
+    expect(res.status).toBe(404)
+    expect(FluxRecorder.list({ kind: "auth.scope.fallback" }).total).toBe(before + 1)
   })
 })


### PR DESCRIPTION
## Summary
- replace verb/prefix auth heuristics with an explicit control-plane scope matrix
- emit auth scope check and fallback telemetry for authenticated control-plane requests
- add parity coverage against OpenAPI plus hidden usage/cron/heartbeat routes and document the operator policy

## Verification
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- CI=true bun test --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh
- cd packages/zee && bun test ./src/server/auth.test.ts
- cd packages/zee && bun test test/server/gateway-node.test.ts
- cd packages/zee && bun test test/server/auth-scope.test.ts
- cd packages/zee && bun test test/server/flux-auth-scope.test.ts
- cd packages/zee && bun test test/server/auth-core.test.ts

Closes #491