### PR TITLE
feat: align control-plane auth semantics

### DIFF
--- a/docs/architecture/control-ui-primary.md
+++ b/docs/architecture/control-ui-primary.md
@@ -39,6 +39,9 @@ These workflows are covered by API-surface tests to keep the web operator path s
 ## Security Guidance (Proxied Deployment)
 
 - Keep server auth enabled for non-loopback binds (`ZEE_ENABLE_SERVER_AUTH=1`, `ZEE_SERVER_PASSWORD`).
+- Use token-mode Control UI auth by default for browser clients:
+  - `Authorization: Bearer <token>`
+  - `X-Zee-Token: <token>`
 - Keep Control UI auth downgrade flags disabled unless explicitly break-glass acknowledged.
 - Terminate TLS at the reverse proxy and keep trusted origins explicit (`gateway.controlUi.trustedOrigins`).
 - Use:

--- a/docs/architecture/gateway-control-plane.md
+++ b/docs/architecture/gateway-control-plane.md
@@ -87,6 +87,14 @@ zee security audit
 zee doctor security
 ```
 
+Header semantics:
+
+- token mode: use `Authorization: Bearer <token>` or `X-Zee-Token: <token>` for browser-originated Control UI requests.
+- password downgrade: Basic auth is only accepted for browser-originated Control UI requests when `mode: "password"` or `allowPasswordOnly: true`.
+- denial challenge follows policy:
+  - token mode returns `WWW-Authenticate: Bearer realm="zee"`
+  - password mode returns `WWW-Authenticate: Basic realm="zee"`
+
 For non-loopback deployments, terminate TLS at a reverse proxy and keep `trustedOrigins` explicit.
 
 ## Telegram Channel-Native Action Pack

--- a/packages/zee/src/cli/cmd/tui/worker.ts
+++ b/packages/zee/src/cli/cmd/tui/worker.ts
@@ -9,7 +9,7 @@ import { Config } from "@/config/config"
 import { GlobalBus } from "@/bus/global"
 import { createZeeClient } from "@zee/sdk"
 import type { BunWebSocketData } from "hono/bun"
-import { Flag } from "@/flag/flag"
+import { getAuthorizationHeaderFor as getServerAuthorizationHeader } from "@/server/auth"
 
 await Log.init({
   print: process.argv.includes("--print-logs"),
@@ -160,8 +160,5 @@ export const rpc = {
 Rpc.listen(rpc)
 
 function getAuthorizationHeader(): string | undefined {
-  const password = Flag.ZEE_SERVER_PASSWORD
-  if (!password) return undefined
-  const username = Flag.ZEE_SERVER_USERNAME ?? "zee"
-  return `Basic ${btoa(`${username}:${password}`)}`
+  return getServerAuthorizationHeader()
 }

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -32,6 +32,7 @@ export type FluxKind =
   | "oauth.refresh.success"
   | "oauth.refresh.fail"
   | "auth.legacy_payload.accepted"
+  | "auth.policy.checked"
   | "auth.scope.checked"
   | "auth.scope.fallback"
   | "agent.legacy_tools_alias.used"

--- a/packages/zee/src/server/auth.ts
+++ b/packages/zee/src/server/auth.ts
@@ -38,6 +38,23 @@ export type ControlUiPolicy = {
   trustedOrigins: string[]
 }
 
+export type ServerAuthScheme = "none" | "basic" | "bearer" | "x-zee-token" | "unsupported"
+export type ServerAuthReason =
+  | "missing_credentials"
+  | "missing_server_password"
+  | "invalid_credentials"
+  | "password_required"
+  | "token_required"
+  | "unsupported_scheme"
+
+export type ServerAuthDecision = {
+  authorized: boolean
+  challenge: string
+  scheme: ServerAuthScheme
+  reason?: ServerAuthReason
+  policy: ControlUiPolicy
+}
+
 function asObject(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
   return value as Record<string, unknown>
@@ -134,10 +151,95 @@ export async function getServerRuntimeConfig(directory = process.cwd()): Promise
 }
 
 export function getAuthorizationHeader(): string | undefined {
-  const { disabled, password, username } = getAuthConfig()
-  if (disabled || !password) return undefined
+  return getAuthorizationHeaderFor()
+}
+
+function buildBasicAuthorizationHeader(username: string, password: string): string {
   const token = Buffer.from(`${username}:${password}`, "utf-8").toString("base64")
   return `Basic ${token}`
+}
+
+function buildBearerAuthorizationHeader(password: string): string {
+  return `Bearer ${password}`
+}
+
+function resolvePreferredAuthScheme(policy: ControlUiPolicy): Exclude<ServerAuthScheme, "none" | "x-zee-token" | "unsupported"> {
+  return policy.mode === "password" ? "basic" : "bearer"
+}
+
+function resolveAuthChallenge(policy: ControlUiPolicy): string {
+  return resolvePreferredAuthScheme(policy) === "basic" ? 'Basic realm="zee"' : 'Bearer realm="zee"'
+}
+
+function resolveTokenHeader(tokenHeader: string | undefined): string | undefined {
+  const value = tokenHeader?.trim()
+  return value ? value : undefined
+}
+
+function resolveServerAuthInput(
+  authorizationHeader: string | undefined,
+  tokenHeader: string | undefined,
+): {
+  scheme: ServerAuthScheme
+  username?: string
+  secret?: string
+} {
+  const explicitToken = resolveTokenHeader(tokenHeader)
+  if (explicitToken) {
+    return {
+      scheme: "x-zee-token",
+      secret: explicitToken,
+    }
+  }
+
+  const bearer = extractBearerToken(authorizationHeader)
+  if (bearer) {
+    return {
+      scheme: "bearer",
+      secret: bearer,
+    }
+  }
+
+  const basic = extractBasicCredentials(authorizationHeader)
+  if (basic) {
+    return {
+      scheme: "basic",
+      username: basic.username,
+      secret: basic.password,
+    }
+  }
+
+  if (!authorizationHeader) {
+    return {
+      scheme: "none",
+    }
+  }
+
+  return {
+    scheme: "unsupported",
+  }
+}
+
+function isBrowserOrigin(origin: string | undefined): boolean {
+  return typeof origin === "string" && origin.trim().length > 0
+}
+
+function requiresTokenScheme(policy: ControlUiPolicy, origin: string | undefined): boolean {
+  return isBrowserOrigin(origin) && policy.required && policy.mode === "token" && !policy.allowPasswordOnly
+}
+
+function requiresPasswordScheme(policy: ControlUiPolicy, origin: string | undefined): boolean {
+  return isBrowserOrigin(origin) && policy.required && policy.mode === "password"
+}
+
+export function getAuthorizationHeaderFor(runtimeConfig?: unknown): string | undefined {
+  const { disabled, password, username } = getAuthConfig(runtimeConfig)
+  if (disabled || !password) return undefined
+
+  const policy = resolveControlUiPolicy(runtimeConfig)
+  return resolvePreferredAuthScheme(policy) === "basic"
+    ? buildBasicAuthorizationHeader(username, password)
+    : buildBearerAuthorizationHeader(password)
 }
 
 export function authorizeRequest(request: Request): Request {
@@ -158,19 +260,106 @@ export function createAuthorizedFetch(fetchFn: typeof fetch): typeof fetch {
 }
 
 export function isAuthorized(authorizationHeader?: string, runtimeConfig?: unknown): boolean {
-  const { disabled, password, username: expectedUsername } = getAuthConfig(runtimeConfig)
-  if (disabled) return true
-  if (!password) return false
-  if (!authorizationHeader) return false
+  return resolveServerAuthDecision({
+    authorizationHeader,
+    runtimeConfig,
+  }).authorized
+}
 
-  // Allow bearer-token style auth (common for non-browser clients).
-  // Token must match the configured server password.
-  const bearer = extractBearerToken(authorizationHeader)
-  if (bearer) return timingSafeEqual(bearer, password)
+export function resolveServerAuthDecision(input: {
+  authorizationHeader?: string
+  tokenHeader?: string
+  origin?: string
+  runtimeConfig?: unknown
+}): ServerAuthDecision {
+  const { disabled, password, username: expectedUsername } = getAuthConfig(input.runtimeConfig)
+  const policy = resolveControlUiPolicy(input.runtimeConfig)
+  const challenge = resolveAuthChallenge(policy)
 
-  const basic = extractBasicCredentials(authorizationHeader)
-  if (!basic) return false
-  return timingSafeEqual(basic.username, expectedUsername) && timingSafeEqual(basic.password, password)
+  if (disabled) {
+    return {
+      authorized: true,
+      challenge,
+      scheme: "none",
+      policy,
+    }
+  }
+
+  if (!password) {
+    return {
+      authorized: false,
+      challenge,
+      scheme: "none",
+      reason: "missing_server_password",
+      policy,
+    }
+  }
+
+  const candidate = resolveServerAuthInput(input.authorizationHeader, input.tokenHeader)
+
+  if (candidate.scheme === "none") {
+    return {
+      authorized: false,
+      challenge,
+      scheme: candidate.scheme,
+      reason: "missing_credentials",
+      policy,
+    }
+  }
+
+  if (requiresTokenScheme(policy, input.origin) && candidate.scheme === "basic") {
+    return {
+      authorized: false,
+      challenge,
+      scheme: candidate.scheme,
+      reason: "token_required",
+      policy,
+    }
+  }
+
+  if (
+    requiresPasswordScheme(policy, input.origin) &&
+    (candidate.scheme === "bearer" || candidate.scheme === "x-zee-token")
+  ) {
+    return {
+      authorized: false,
+      challenge,
+      scheme: candidate.scheme,
+      reason: "password_required",
+      policy,
+    }
+  }
+
+  if (candidate.scheme === "unsupported") {
+    return {
+      authorized: false,
+      challenge,
+      scheme: candidate.scheme,
+      reason: "unsupported_scheme",
+      policy,
+    }
+  }
+
+  if (candidate.scheme === "basic") {
+    const authorized =
+      timingSafeEqual(candidate.username ?? "", expectedUsername) && timingSafeEqual(candidate.secret ?? "", password)
+    return {
+      authorized,
+      challenge,
+      scheme: candidate.scheme,
+      ...(authorized ? {} : { reason: "invalid_credentials" as const }),
+      policy,
+    }
+  }
+
+  const authorized = timingSafeEqual(candidate.secret ?? "", password)
+  return {
+    authorized,
+    challenge,
+    scheme: candidate.scheme,
+    ...(authorized ? {} : { reason: "invalid_credentials" as const }),
+    policy,
+  }
 }
 
 /**
@@ -189,7 +378,7 @@ export function authorizeRequestScoped(
   if (config.disabled) return { authorized: true }
 
   // Check authentication
-  if (!isAuthorized(authHeader, runtimeConfig)) {
+  if (!resolveServerAuthDecision({ authorizationHeader: authHeader, runtimeConfig }).authorized) {
     return { authorized: false, reason: "Authentication required" }
   }
 

--- a/packages/zee/src/server/server.ts
+++ b/packages/zee/src/server/server.ts
@@ -33,9 +33,9 @@ import {
   getAuthConfig,
   getServerRuntimeConfig,
   hasScope,
-  isAuthorized,
   isTrustedControlOrigin,
   isLoopbackHostname,
+  resolveServerAuthDecision,
   resolveRequiredScopeInfo,
 } from "./auth"
 import {
@@ -368,8 +368,17 @@ export namespace Server {
             const scopeResolution = resolveRequiredScopeInfo(method, path)
             const required = scopeResolution.required
             const authHeader = c.req.header("Authorization")
+            const tokenHeader = c.req.header("x-zee-token")
             const authRateLimiter = resolveAuthRateLimiter()
             const rateLimit = authRateLimiter?.check(ip)
+            const authDecision = resolveServerAuthDecision({
+              authorizationHeader: authHeader,
+              tokenHeader,
+              origin,
+              runtimeConfig,
+            })
+            const traceID = RequestMeta.getTraceID(c.req.raw) ?? crypto.randomUUID()
+            const requestID = RequestMeta.getRequestID(c.req.raw)
 
             if (rateLimit && !rateLimit.allowed) {
               log.warn("auth rate limited", {
@@ -385,7 +394,29 @@ export namespace Server {
               return c.text("Too Many Requests", 429)
             }
 
-            if (!isAuthorized(authHeader, runtimeConfig)) {
+            if (scopeResolution.controlPlane) {
+              FluxRecorder.record({
+                traceID,
+                requestID,
+                direction: "internal",
+                domain: "auth",
+                kind: "auth.policy.checked",
+                status: authDecision.authorized ? "ok" : "denied",
+                method,
+                path,
+                route: scopeResolution.matchedEntry?.path ?? path,
+                metadata: {
+                  authMode: authDecision.policy.mode,
+                  allowPasswordOnly: authDecision.policy.allowPasswordOnly,
+                  challenge: authDecision.challenge,
+                  scheme: authDecision.scheme,
+                  reason: authDecision.reason,
+                  trustedOrigin: Boolean(origin),
+                },
+              })
+            }
+
+            if (!authDecision.authorized) {
               authRateLimiter?.recordFailure(ip)
               log.warn("auth denied", {
                 status: 401,
@@ -393,16 +424,16 @@ export namespace Server {
                 method,
                 path,
                 required,
+                scheme: authDecision.scheme,
+                reason: authDecision.reason,
               })
-              c.header("WWW-Authenticate", 'Basic realm="zee"')
+              c.header("WWW-Authenticate", authDecision.challenge)
               return c.text("Unauthorized", 401)
             }
 
             authRateLimiter?.reset(ip)
 
             const granted = authConfig.scopes ?? [AuthScope.ADMIN]
-            const traceID = RequestMeta.getTraceID(c.req.raw) ?? crypto.randomUUID()
-            const requestID = RequestMeta.getRequestID(c.req.raw)
             if (scopeResolution.controlPlane) {
               FluxRecorder.record({
                 traceID,

--- a/packages/zee/test/cli/attach-shared-auth.test.ts
+++ b/packages/zee/test/cli/attach-shared-auth.test.ts
@@ -65,7 +65,7 @@ describe("attachTui remote auth flow", () => {
     expect(calls.length).toBe(2)
     expect(promptPasswordMock).toHaveBeenCalledTimes(1)
     expect(calls[0]!.headers.get("Authorization")).toBeNull()
-    expect(calls[1]!.headers.get("Authorization")).toBe(`Basic ${Buffer.from("zee:secret-password").toString("base64")}`)
+    expect(calls[1]!.headers.get("Authorization")).toBe("Bearer secret-password")
     expect(tuiMock).toHaveBeenCalledTimes(1)
   })
 
@@ -89,7 +89,7 @@ describe("attachTui remote auth flow", () => {
     })
 
     expect(calls.length).toBe(1)
-    expect(calls[0]!.headers.get("Authorization")).toBe(`Basic ${Buffer.from("zee:from-flag").toString("base64")}`)
+    expect(calls[0]!.headers.get("Authorization")).toBe("Bearer from-flag")
     expect(promptPasswordMock).toHaveBeenCalledTimes(0)
     expect(tuiMock).toHaveBeenCalledTimes(1)
   })
@@ -102,7 +102,7 @@ describe("attachTui remote auth flow", () => {
     reloadFlags()
 
     const expectedPassword = "p05-parity-password"
-    const expectedAuth = `Basic ${Buffer.from(`zee:${expectedPassword}`).toString("base64")}`
+    const expectedAuth = `Bearer ${expectedPassword}`
     promptPasswordMock.mockImplementation(async () => expectedPassword)
 
     const calls: Request[] = []

--- a/packages/zee/test/server/auth-core.test.ts
+++ b/packages/zee/test/server/auth-core.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test"
 import { reloadFlags } from "../../src/flag/flag"
-import { isAuthorized } from "../../src/server/auth"
+import { getAuthorizationHeaderFor, isAuthorized, resolveServerAuthDecision } from "../../src/server/auth"
 
 const ORIGINAL_ENV = {
   ZEE_ENABLE_SERVER_AUTH: process.env.ZEE_ENABLE_SERVER_AUTH,
@@ -44,3 +44,148 @@ describe("isAuthorized", () => {
   })
 })
 
+describe("resolveServerAuthDecision", () => {
+  test("requires token-style auth for trusted browser origins in token mode", () => {
+    const token = Buffer.from("zee:test-password", "utf-8").toString("base64")
+    const decision = resolveServerAuthDecision({
+      authorizationHeader: `Basic ${token}`,
+      origin: "https://control.example.com",
+      runtimeConfig: {
+        gateway: {
+          controlUi: {
+            auth: {
+              required: true,
+              mode: "token",
+              allowPasswordOnly: false,
+            },
+          },
+        },
+      },
+    })
+
+    expect(decision.authorized).toBe(false)
+    expect(decision.reason).toBe("token_required")
+    expect(decision.challenge).toBe('Bearer realm="zee"')
+  })
+
+  test("accepts bearer and X-Zee-Token for trusted browser origins in token mode", () => {
+    const runtimeConfig = {
+      gateway: {
+        controlUi: {
+          auth: {
+            required: true,
+            mode: "token",
+            allowPasswordOnly: false,
+          },
+        },
+      },
+    }
+
+    expect(
+      resolveServerAuthDecision({
+        authorizationHeader: "Bearer test-password",
+        origin: "https://control.example.com",
+        runtimeConfig,
+      }),
+    ).toMatchObject({
+      authorized: true,
+      scheme: "bearer",
+    })
+
+    expect(
+      resolveServerAuthDecision({
+        tokenHeader: "test-password",
+        origin: "https://control.example.com",
+        runtimeConfig,
+      }),
+    ).toMatchObject({
+      authorized: true,
+      scheme: "x-zee-token",
+    })
+  })
+
+  test("allows password downgrade for browser requests only when explicitly configured", () => {
+    const token = Buffer.from("zee:test-password", "utf-8").toString("base64")
+    const decision = resolveServerAuthDecision({
+      authorizationHeader: `Basic ${token}`,
+      origin: "https://control.example.com",
+      runtimeConfig: {
+        gateway: {
+          controlUi: {
+            auth: {
+              required: true,
+              mode: "token",
+              allowPasswordOnly: true,
+            },
+          },
+        },
+      },
+    })
+
+    expect(decision.authorized).toBe(true)
+    expect(decision.scheme).toBe("basic")
+  })
+
+  test("requires basic auth for trusted browser origins in password mode", () => {
+    const denied = resolveServerAuthDecision({
+      authorizationHeader: "Bearer test-password",
+      origin: "https://control.example.com",
+      runtimeConfig: {
+        gateway: {
+          controlUi: {
+            auth: {
+              required: true,
+              mode: "password",
+            },
+          },
+        },
+      },
+    })
+
+    expect(denied.authorized).toBe(false)
+    expect(denied.reason).toBe("password_required")
+    expect(denied.challenge).toBe('Basic realm="zee"')
+
+    const token = Buffer.from("zee:test-password", "utf-8").toString("base64")
+    expect(
+      resolveServerAuthDecision({
+        authorizationHeader: `Basic ${token}`,
+        origin: "https://control.example.com",
+        runtimeConfig: {
+          gateway: {
+            controlUi: {
+              auth: {
+                required: true,
+                mode: "password",
+              },
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      authorized: true,
+      scheme: "basic",
+    })
+  })
+})
+
+describe("getAuthorizationHeaderFor", () => {
+  test("defaults to bearer auth for token-mode clients", () => {
+    expect(getAuthorizationHeaderFor()).toBe("Bearer test-password")
+  })
+
+  test("uses basic auth when password mode is requested explicitly", () => {
+    const token = Buffer.from("zee:test-password", "utf-8").toString("base64")
+    expect(
+      getAuthorizationHeaderFor({
+        gateway: {
+          controlUi: {
+            auth: {
+              mode: "password",
+            },
+          },
+        },
+      }),
+    ).toBe(`Basic ${token}`)
+  })
+})

--- a/packages/zee/test/server/control-ui-origin.test.ts
+++ b/packages/zee/test/server/control-ui-origin.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { Config } from "../../src/config/config"
+import { FluxRecorder } from "../../src/flux"
 import { reloadFlags } from "../../src/flag/flag"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
@@ -75,7 +76,7 @@ afterAll(async () => {
 })
 
 describe("control UI trusted origins", () => {
-  test("enforces control UI auth from config for browser requests even without env auth enablement", async () => {
+  test("enforces token auth from config for browser requests even without env auth enablement", async () => {
     delete process.env.ZEE_ENABLE_SERVER_AUTH
     delete process.env.ZEE_DISABLE_SERVER_AUTH
     process.env.ZEE_SERVER_PASSWORD = "test-password"
@@ -84,23 +85,40 @@ describe("control UI trusted origins", () => {
     Server.reset()
 
     const app = Server.App()
+    const before = FluxRecorder.list({ kind: "auth.policy.checked" }).total
 
     const denied = await app.request("/global/health/live", {
-      method: "GET",
-      headers: {
-        Origin: "https://control.example.com",
-      },
-    })
-    expect(denied.status).toBe(401)
-
-    const allowed = await app.request("/global/health/live", {
       method: "GET",
       headers: {
         Origin: "https://control.example.com",
         Authorization: basicAuth("zee", "test-password"),
       },
     })
+    expect(denied.status).toBe(401)
+    expect(denied.headers.get("WWW-Authenticate")).toBe('Bearer realm="zee"')
+
+    const allowed = await app.request("/global/health/live", {
+      method: "GET",
+      headers: {
+        Origin: "https://control.example.com",
+        Authorization: "Bearer test-password",
+      },
+    })
     expect(allowed.status).toBe(200)
+    expect(FluxRecorder.list({ kind: "auth.policy.checked" }).total).toBe(before + 2)
+  })
+
+  test("accepts X-Zee-Token for trusted browser origins in token mode", async () => {
+    const app = Server.App()
+    const res = await app.request("/global/health/live", {
+      method: "GET",
+      headers: {
+        Origin: "https://control.example.com",
+        "x-zee-token": "test-password",
+      },
+    })
+
+    expect(res.status).toBe(200)
   })
 
   test("forbids browser-originated requests from untrusted origins", async () => {
@@ -116,14 +134,14 @@ describe("control UI trusted origins", () => {
     expect(res.status).toBe(403)
   })
 
-  test("allows trusted browser origins and loopback origins", async () => {
+  test("allows trusted browser origins and loopback origins with token auth", async () => {
     const app = Server.App()
 
     const trusted = await app.request("/global/health/live", {
       method: "GET",
       headers: {
         Origin: "https://control.example.com",
-        Authorization: basicAuth("zee", "test-password"),
+        Authorization: "Bearer test-password",
       },
     })
     expect(trusted.status).toBe(200)
@@ -132,7 +150,7 @@ describe("control UI trusted origins", () => {
       method: "GET",
       headers: {
         Origin: "http://localhost:5173",
-        Authorization: basicAuth("zee", "test-password"),
+        Authorization: "Bearer test-password",
       },
     })
     expect(local.status).toBe(200)


### PR DESCRIPTION
## Summary
- enforce token-vs-password auth semantics for browser-originated control-plane requests
- emit auth policy telemetry and policy-aware WWW-Authenticate challenges
- align shared CLI auth helpers, docs, and tests with token-mode defaults

## Testing
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- cd packages/zee && bun run typecheck
- cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh

Closes #492