### PR TITLE
feat: harden node credential rotation lifecycle

### DIFF
--- a/docs/architecture/control-plane-scope-matrix.md
+++ b/docs/architecture/control-plane-scope-matrix.md
@@ -50,6 +50,7 @@ Approved in-repo on `2026-03-15`.
   - `GET /gateway/node`
   - `POST /gateway/node/pair`
   - `POST /gateway/node/reconnect`
+  - `POST /gateway/node/rotate`
   - `POST /gateway/node/revoke`
   - `POST /gateway/node/tool/authorize`
 - Privileged remote execution stays `operator.admin`:

--- a/docs/architecture/node-client-macos.md
+++ b/docs/architecture/node-client-macos.md
@@ -7,6 +7,7 @@ This document captures the reference node-client product path introduced for gat
 - API lifecycle:
   - `POST /gateway/node/pair`
   - `POST /gateway/node/reconnect`
+  - `POST /gateway/node/rotate`
   - `POST /gateway/node/revoke`
   - `POST /gateway/node/tool/authorize`
   - `GET /gateway/node`
@@ -16,11 +17,14 @@ This document captures the reference node-client product path introduced for gat
   - `gateway.nodeClient.allowRemotePairing`
   - `gateway.nodeClient.toolAllowlist`
   - `gateway.nodeClient.maxPairedNodes`
+  - `gateway.nodeClient.credentialMaxAgeHours`
 
 ## Security behavior
 - Pairing is blocked when `gateway.nodeClient.enabled=false`.
 - On non-loopback server bind, pairing requires `allowRemotePairing=true`.
 - Tokens are stored hashed (SHA-256), never in plaintext.
+- Active node credentials expire after `credentialMaxAgeHours` and must be refreshed via `POST /gateway/node/rotate`.
+- Credential rotation increments `tokenVersion` and records `tokenIssuedAt` / `tokenRotatedAt` for operator auditability.
 - Revoked nodes cannot reconnect or authorize tools.
 - Tool authorization enforces policy mode:
   - `deny`: always deny
@@ -36,6 +40,7 @@ This document captures the reference node-client product path introduced for gat
 - Both deep-audit commands emit Flux events:
   - `security.audit.checked`
   - `security.audit.finding`
+- Node lifecycle routes emit Flux `gateway.node.lifecycle` events for pair, reconnect, rotate, and revoke transitions.
 
 ## Follow-up hooks (iOS/Android)
 - Data model keeps `platform` as `macos|ios|android|linux|windows|unknown`.

--- a/packages/zee/src/config/config.ts
+++ b/packages/zee/src/config/config.ts
@@ -1197,6 +1197,12 @@ export namespace Config {
             .describe("Allow non-loopback remote pairing requests"),
           toolAllowlist: z.array(z.string()).optional().describe("Allowed tools when `securityMode=allowlist`"),
           maxPairedNodes: z.number().int().positive().optional().describe("Maximum active paired nodes"),
+          credentialMaxAgeHours: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Maximum credential age before paired nodes must rotate their reconnect token"),
         })
         .optional()
         .describe("Reference desktop node-client policy and pairing controls"),

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -28,6 +28,7 @@ export type FluxKind =
   | "gateway.auth.denied"
   | "gateway.rpc.request"
   | "gateway.rpc.response"
+  | "gateway.node.lifecycle"
   | "secret.resolved"
   | "oauth.refresh.start"
   | "oauth.refresh.success"

--- a/packages/zee/src/gateway/node-client-registry.ts
+++ b/packages/zee/src/gateway/node-client-registry.ts
@@ -15,6 +15,7 @@ export type NodeClientPolicy = {
   allowRemotePairing: boolean
   toolAllowlist: string[]
   maxPairedNodes: number
+  credentialMaxAgeHours: number
 }
 
 export type NodeClientAuditSnapshot = {
@@ -35,6 +36,9 @@ export type NodeClientRecord = {
   platform: NodeClientPlatform
   createdAt: number
   updatedAt: number
+  tokenIssuedAt: number
+  tokenVersion: number
+  tokenRotatedAt?: number
   lastSeenAt?: number
   status: "paired" | "revoked"
   revokedAt?: number
@@ -55,6 +59,7 @@ const DEFAULT_POLICY: NodeClientPolicy = {
   allowRemotePairing: false,
   toolAllowlist: [],
   maxPairedNodes: 10,
+  credentialMaxAgeHours: 24 * 30,
 }
 
 function asObject(value: unknown): Record<string, unknown> | undefined {
@@ -82,6 +87,29 @@ function sanitizeLabel(label: string): string {
 
 function hasFiniteTimestamp(value: unknown): boolean {
   return typeof value === "number" && Number.isFinite(value)
+}
+
+function credentialAgeExceeded(record: NodeClientRecord, policy: NodeClientPolicy, now = Date.now()): boolean {
+  return now - record.tokenIssuedAt > policy.credentialMaxAgeHours * 60 * 60 * 1000
+}
+
+function normalizeRecord(record: NodeClientRecord): NodeClientRecord {
+  const fallbackIssuedAt = hasFiniteTimestamp(record.updatedAt)
+    ? record.updatedAt
+    : hasFiniteTimestamp(record.createdAt)
+      ? record.createdAt
+      : Date.now()
+  const tokenIssuedAt = hasFiniteTimestamp(record.tokenIssuedAt) ? record.tokenIssuedAt : fallbackIssuedAt
+  const tokenVersion =
+    typeof record.tokenVersion === "number" && Number.isFinite(record.tokenVersion) && record.tokenVersion > 0
+      ? Math.floor(record.tokenVersion)
+      : 1
+
+  return {
+    ...record,
+    tokenIssuedAt,
+    tokenVersion,
+  }
 }
 
 function hashToken(token: string): string {
@@ -112,12 +140,19 @@ export function resolveNodeClientPolicy(config: unknown): NodeClientPolicy {
       ? Math.max(1, Math.floor(maxPairedNodesRaw))
       : DEFAULT_POLICY.maxPairedNodes
 
+  const credentialMaxAgeHoursRaw = nodeClient.credentialMaxAgeHours
+  const credentialMaxAgeHours =
+    typeof credentialMaxAgeHoursRaw === "number" && Number.isFinite(credentialMaxAgeHoursRaw)
+      ? Math.max(1, Math.floor(credentialMaxAgeHoursRaw))
+      : DEFAULT_POLICY.credentialMaxAgeHours
+
   return {
     enabled: resolveBool(nodeClient.enabled, DEFAULT_POLICY.enabled),
     securityMode: resolveSecurityMode(nodeClient.securityMode),
     allowRemotePairing: resolveBool(nodeClient.allowRemotePairing, DEFAULT_POLICY.allowRemotePairing),
     toolAllowlist: resolveStringArray(nodeClient.toolAllowlist),
     maxPairedNodes,
+    credentialMaxAgeHours,
   }
 }
 
@@ -129,9 +164,12 @@ export class NodeClientRegistry {
     if (!raw) return { version: 1, nodes: {} }
     try {
       const parsed = JSON.parse(raw) as NodeClientState
+      const nodes = Object.fromEntries(
+        Object.entries(parsed?.nodes ?? {}).map(([nodeId, record]) => [nodeId, normalizeRecord(record as NodeClientRecord)]),
+      )
       return {
         version: 1,
-        nodes: parsed?.nodes ?? {},
+        nodes,
       }
     } catch {
       return { version: 1, nodes: {} }
@@ -151,13 +189,23 @@ export class NodeClientRegistry {
     return record
   }
 
-  private assertToken(record: NodeClientRecord, token: string): void {
+  private assertToken(
+    record: NodeClientRecord,
+    token: string,
+    policy: NodeClientPolicy,
+    options: {
+      allowExpired?: boolean
+    } = {},
+  ): void {
     const tokenHash = hashToken(token)
     if (!tokenEquals(record.tokenHash, tokenHash)) {
       throw new Error("Invalid node token")
     }
     if (record.status === "revoked") {
       throw new Error(`Node is revoked: ${record.id}`)
+    }
+    if (!options.allowExpired && credentialAgeExceeded(record, policy)) {
+      throw new Error(`Node token expired: ${record.id}`)
     }
   }
 
@@ -185,6 +233,8 @@ export class NodeClientRegistry {
       id,
       label: sanitizeLabel(input.label) || "unnamed-node",
       platform: input.platform,
+      tokenIssuedAt: now,
+      tokenVersion: 1,
       status: "paired",
       createdAt: now,
       updatedAt: now,
@@ -201,10 +251,10 @@ export class NodeClientRegistry {
     return { node: sanitizeRecord(record), token }
   }
 
-  async reconnect(input: { nodeId: string; token: string }): Promise<ReturnType<typeof sanitizeRecord>> {
+  async reconnect(input: { nodeId: string; token: string; policy: NodeClientPolicy }): Promise<ReturnType<typeof sanitizeRecord>> {
     const state = await this.readState()
     const record = this.findRecord(state, input.nodeId)
-    this.assertToken(record, input.token)
+    this.assertToken(record, input.token, input.policy)
 
     const now = Date.now()
     record.lastSeenAt = now
@@ -213,6 +263,30 @@ export class NodeClientRegistry {
     await this.writeState(state)
 
     return sanitizeRecord(record)
+  }
+
+  async rotateToken(
+    input: { nodeId: string; token: string; policy: NodeClientPolicy },
+  ): Promise<{ node: ReturnType<typeof sanitizeRecord>; token: string }> {
+    const state = await this.readState()
+    const record = this.findRecord(state, input.nodeId)
+    this.assertToken(record, input.token, input.policy, { allowExpired: true })
+
+    const now = Date.now()
+    const nextToken = randomBytes(24).toString("hex")
+    record.tokenHash = hashToken(nextToken)
+    record.tokenIssuedAt = now
+    record.tokenRotatedAt = now
+    record.tokenVersion += 1
+    record.updatedAt = now
+    state.nodes[record.id] = record
+    await this.writeState(state)
+    log.info("Node token rotated", { id: record.id, tokenVersion: record.tokenVersion })
+
+    return {
+      node: sanitizeRecord(record),
+      token: nextToken,
+    }
   }
 
   async revoke(input: { nodeId: string; reason?: string }): Promise<ReturnType<typeof sanitizeRecord>> {
@@ -253,7 +327,7 @@ export class NodeClientRegistry {
   }> {
     const state = await this.readState()
     const record = this.findRecord(state, input.nodeId)
-    this.assertToken(record, input.token)
+    this.assertToken(record, input.token, input.policy)
 
     const mode = input.policy.securityMode
     if (mode === "deny") {

--- a/packages/zee/src/server/auth.test.ts
+++ b/packages/zee/src/server/auth.test.ts
@@ -11,6 +11,7 @@ describe("resolveRequiredScope", () => {
   test("maps gateway node pairing routes to pairing scope", () => {
     expect(resolveRequiredScope("POST", "/gateway/node/pair")).toBe(AuthScope.PAIRING)
     expect(resolveRequiredScope("POST", "/gateway/node/reconnect")).toBe(AuthScope.PAIRING)
+    expect(resolveRequiredScope("POST", "/gateway/node/rotate")).toBe(AuthScope.PAIRING)
     expect(resolveRequiredScope("POST", "/gateway/node/revoke")).toBe(AuthScope.PAIRING)
     expect(resolveRequiredScope("POST", "/gateway/node/tool/authorize")).toBe(AuthScope.PAIRING)
   })

--- a/packages/zee/src/server/control-plane-scope.ts
+++ b/packages/zee/src/server/control-plane-scope.ts
@@ -81,6 +81,7 @@ export const CONTROL_PLANE_SCOPE_MATRIX: ControlPlaneRouteScopeEntry[] = [
   entry("GET", "/gateway/node", AuthScope.PAIRING, "Paired node inventory."),
   entry("POST", "/gateway/node/pair", AuthScope.PAIRING, "Pair new node client."),
   entry("POST", "/gateway/node/reconnect", AuthScope.PAIRING, "Reconnect paired node client."),
+  entry("POST", "/gateway/node/rotate", AuthScope.PAIRING, "Rotate paired node credential."),
   entry("POST", "/gateway/node/revoke", AuthScope.PAIRING, "Revoke paired node."),
   entry("POST", "/gateway/node/tool/authorize", AuthScope.PAIRING, "Authorize paired node tool request."),
 

--- a/packages/zee/src/server/route/gateway-node.ts
+++ b/packages/zee/src/server/route/gateway-node.ts
@@ -1,10 +1,12 @@
-import { Hono } from "hono"
+import { Hono, type Context } from "hono"
 import { describeRoute, resolver, validator } from "hono-openapi"
 import { z } from "zod"
+import { FluxRecorder } from "@/flux"
 import { Config } from "../../config/config"
 import { errors } from "../error"
 import { isLoopbackHostname } from "../auth"
 import { Log } from "../../util/log"
+import { RequestMeta } from "../request-meta"
 import { getNodeClientRegistry, resolveNodeClientPolicy } from "@/gateway/node-client-registry"
 
 const log = Log.create({ service: "server:gateway-node" })
@@ -17,6 +19,9 @@ const NodePublicRecordSchema = z.object({
   platform: NodePlatformSchema,
   createdAt: z.number(),
   updatedAt: z.number(),
+  tokenIssuedAt: z.number(),
+  tokenVersion: z.number(),
+  tokenRotatedAt: z.number().optional(),
   lastSeenAt: z.number().optional(),
   status: z.enum(["paired", "revoked"]),
   revokedAt: z.number().optional(),
@@ -38,10 +43,16 @@ const NodePairResponseSchema = z.object({
   policy: z.object({
     securityMode: z.enum(["deny", "allowlist", "full"]),
     maxPairedNodes: z.number(),
+    credentialMaxAgeHours: z.number(),
   }),
 })
 
 const NodeReconnectRequestSchema = z.object({
+  nodeId: z.string().min(1),
+  token: z.string().min(1),
+})
+
+const NodeRotateRequestSchema = z.object({
   nodeId: z.string().min(1),
   token: z.string().min(1),
 })
@@ -56,6 +67,57 @@ const NodeToolAuthorizeRequestSchema = z.object({
   token: z.string().min(1),
   tool: z.string().min(1),
 })
+
+const NodeRotateResponseSchema = z.object({
+  node: NodePublicRecordSchema,
+  token: z.string(),
+  policy: z.object({
+    securityMode: z.enum(["deny", "allowlist", "full"]),
+    maxPairedNodes: z.number(),
+    credentialMaxAgeHours: z.number(),
+  }),
+})
+
+type NodeLifecycleAction = "pair" | "reconnect" | "rotate" | "revoke"
+
+function isUnauthorizedNodeLifecycleError(message: string): boolean {
+  return message.includes("Invalid node token") || message.includes("Node token expired")
+}
+
+function recordNodeLifecycle(
+  c: Context,
+  input: {
+    action: NodeLifecycleAction
+    status: "ok" | "error" | "denied"
+    nodeId?: string
+    reason?: string
+    tokenVersion?: number
+    policy?: ReturnType<typeof resolveNodeClientPolicy>
+  },
+) {
+  const traceID = RequestMeta.getTraceID(c.req.raw) ?? crypto.randomUUID()
+  const requestID = RequestMeta.getRequestID(c.req.raw)
+  FluxRecorder.record({
+    traceID,
+    requestID,
+    direction: "internal",
+    domain: "gateway",
+    kind: "gateway.node.lifecycle",
+    status: input.status,
+    method: c.req.method,
+    path: c.req.path,
+    route: c.req.path,
+    metadata: {
+      action: input.action,
+      nodeId: input.nodeId,
+      reason: input.reason,
+      tokenVersion: input.tokenVersion,
+      securityMode: input.policy?.securityMode,
+      maxPairedNodes: input.policy?.maxPairedNodes,
+      credentialMaxAgeHours: input.policy?.credentialMaxAgeHours,
+    },
+  })
+}
 
 export const GatewayNodeRoute = new Hono()
   .post(
@@ -82,11 +144,23 @@ export const GatewayNodeRoute = new Hono()
       const cfg = await Config.get()
       const policy = resolveNodeClientPolicy(cfg)
       if (!policy.enabled) {
+        recordNodeLifecycle(c, {
+          action: "pair",
+          status: "denied",
+          reason: "node-client pairing disabled by policy",
+          policy,
+        })
         return c.json({ error: "Node-client pairing is disabled by policy (gateway.nodeClient.enabled=false)." }, 403)
       }
 
       const hostname = typeof cfg?.server?.hostname === "string" ? cfg.server.hostname : "127.0.0.1"
       if (!policy.allowRemotePairing && !isLoopbackHostname(hostname)) {
+        recordNodeLifecycle(c, {
+          action: "pair",
+          status: "denied",
+          reason: "remote pairing disabled on non-loopback bind",
+          policy,
+        })
         return c.json(
           {
             error:
@@ -108,17 +182,31 @@ export const GatewayNodeRoute = new Hono()
           },
           policy,
         )
+        recordNodeLifecycle(c, {
+          action: "pair",
+          status: "ok",
+          nodeId: paired.node.id,
+          tokenVersion: paired.node.tokenVersion,
+          policy,
+        })
         return c.json({
           node: paired.node,
           token: paired.token,
           policy: {
             securityMode: policy.securityMode,
             maxPairedNodes: policy.maxPairedNodes,
+            credentialMaxAgeHours: policy.credentialMaxAgeHours,
           },
         })
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         log.warn("Node pairing denied", { message })
+        recordNodeLifecycle(c, {
+          action: "pair",
+          status: "error",
+          reason: message,
+          policy,
+        })
         return c.json({ error: message }, 400)
       }
     },
@@ -147,15 +235,104 @@ export const GatewayNodeRoute = new Hono()
       const input = c.req.valid("json")
       const policy = resolveNodeClientPolicy(await Config.get())
       if (!policy.enabled) {
+        recordNodeLifecycle(c, {
+          action: "reconnect",
+          status: "denied",
+          nodeId: input.nodeId,
+          reason: "node-client pairing disabled by policy",
+          policy,
+        })
         return c.json({ error: "Node-client pairing is disabled by policy (gateway.nodeClient.enabled=false)." }, 403)
       }
       const registry = getNodeClientRegistry()
       try {
-        const node = await registry.reconnect({ nodeId: input.nodeId, token: input.token })
+        const node = await registry.reconnect({ nodeId: input.nodeId, token: input.token, policy })
+        recordNodeLifecycle(c, {
+          action: "reconnect",
+          status: "ok",
+          nodeId: node.id,
+          tokenVersion: node.tokenVersion,
+          policy,
+        })
         return c.json(node)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
-        return c.json({ error: message }, message.includes("Invalid node token") ? 401 : 400)
+        recordNodeLifecycle(c, {
+          action: "reconnect",
+          status: isUnauthorizedNodeLifecycleError(message) ? "denied" : "error",
+          nodeId: input.nodeId,
+          reason: message,
+          policy,
+        })
+        return c.json({ error: message }, isUnauthorizedNodeLifecycleError(message) ? 401 : 400)
+      }
+    },
+  )
+  .post(
+    "/node/rotate",
+    describeRoute({
+      summary: "Rotate paired node credential",
+      description: "Validate the current node credential and issue a replacement reconnect token.",
+      operationId: "gateway.node.rotate",
+      tags: ["Gateway"],
+      responses: {
+        200: {
+          description: "Node credential rotated",
+          content: {
+            "application/json": {
+              schema: resolver(NodeRotateResponseSchema),
+            },
+          },
+        },
+        ...errors(400, 401, 403),
+      },
+    }),
+    validator("json", NodeRotateRequestSchema),
+    async (c) => {
+      const input = c.req.valid("json")
+      const policy = resolveNodeClientPolicy(await Config.get())
+      if (!policy.enabled) {
+        recordNodeLifecycle(c, {
+          action: "rotate",
+          status: "denied",
+          nodeId: input.nodeId,
+          reason: "node-client pairing disabled by policy",
+          policy,
+        })
+        return c.json({ error: "Node-client pairing is disabled by policy (gateway.nodeClient.enabled=false)." }, 403)
+      }
+      try {
+        const rotated = await getNodeClientRegistry().rotateToken({
+          nodeId: input.nodeId,
+          token: input.token,
+          policy,
+        })
+        recordNodeLifecycle(c, {
+          action: "rotate",
+          status: "ok",
+          nodeId: rotated.node.id,
+          tokenVersion: rotated.node.tokenVersion,
+          policy,
+        })
+        return c.json({
+          node: rotated.node,
+          token: rotated.token,
+          policy: {
+            securityMode: policy.securityMode,
+            maxPairedNodes: policy.maxPairedNodes,
+            credentialMaxAgeHours: policy.credentialMaxAgeHours,
+          },
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        recordNodeLifecycle(c, {
+          action: "rotate",
+          status: isUnauthorizedNodeLifecycleError(message) ? "denied" : "error",
+          nodeId: input.nodeId,
+          reason: message,
+          policy,
+        })
+        return c.json({ error: message }, isUnauthorizedNodeLifecycleError(message) ? 401 : 400)
       }
     },
   )
@@ -181,8 +358,29 @@ export const GatewayNodeRoute = new Hono()
     validator("json", NodeRevokeRequestSchema),
     async (c) => {
       const input = c.req.valid("json")
-      const node = await getNodeClientRegistry().revoke({ nodeId: input.nodeId, reason: input.reason })
-      return c.json(node)
+      const policy = resolveNodeClientPolicy(await Config.get())
+      try {
+        const node = await getNodeClientRegistry().revoke({ nodeId: input.nodeId, reason: input.reason })
+        recordNodeLifecycle(c, {
+          action: "revoke",
+          status: "ok",
+          nodeId: node.id,
+          tokenVersion: node.tokenVersion,
+          reason: node.revokeReason,
+          policy,
+        })
+        return c.json(node)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        recordNodeLifecycle(c, {
+          action: "revoke",
+          status: "error",
+          nodeId: input.nodeId,
+          reason: message,
+          policy,
+        })
+        return c.json({ error: message }, 400)
+      }
     },
   )
   .post(
@@ -229,7 +427,7 @@ export const GatewayNodeRoute = new Hono()
         return c.json(result)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
-        return c.json({ error: message }, message.includes("Invalid node token") ? 401 : 400)
+        return c.json({ error: message }, isUnauthorizedNodeLifecycleError(message) ? 401 : 400)
       }
     },
   )

--- a/packages/zee/test/server/gateway-node.test.ts
+++ b/packages/zee/test/server/gateway-node.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { Config } from "../../src/config/config"
+import { FluxRecorder } from "../../src/flux"
 import { resetNodeClientRegistry } from "../../src/gateway/node-client-registry"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
@@ -28,6 +29,22 @@ async function writeGlobalConfig(contents: Record<string, unknown>) {
   resetNodeClientRegistry()
 }
 
+async function mutateNodeClientState(
+  updater: (state: {
+    version: number
+    nodes: Record<string, Record<string, unknown>>
+  }) => void,
+) {
+  const stateFile = path.join(isolatedStateDir, "gateway-node-clients.json")
+  const state = JSON.parse(await fs.readFile(stateFile, "utf8")) as {
+    version: number
+    nodes: Record<string, Record<string, unknown>>
+  }
+  updater(state)
+  await fs.writeFile(stateFile, JSON.stringify(state, null, 2), "utf8")
+  resetNodeClientRegistry()
+}
+
 beforeAll(async () => {
   isolatedConfigDir = await fs.mkdtemp(path.join(os.tmpdir(), "zee-gateway-node-config-"))
   isolatedStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "zee-gateway-node-state-"))
@@ -39,6 +56,8 @@ beforeAll(async () => {
 })
 
 beforeEach(async () => {
+  await fs.rm(path.join(isolatedStateDir, "gateway-node-clients.json"), { force: true }).catch(() => {})
+  resetNodeClientRegistry()
   await writeGlobalConfig({
     gateway: {
       nodeClient: {
@@ -47,6 +66,7 @@ beforeEach(async () => {
         toolAllowlist: ["zee_invest_research"],
         allowRemotePairing: false,
         maxPairedNodes: 3,
+        credentialMaxAgeHours: 24,
       },
     },
   })
@@ -86,6 +106,7 @@ describe("gateway node routes", () => {
     const paired = await pairResponse.json()
     expect(paired.node.label).toBe("Desk")
     expect(typeof paired.token).toBe("string")
+    expect(paired.policy.credentialMaxAgeHours).toBe(24)
 
     const allowed = await app.request("/gateway/node/tool/authorize", {
       method: "POST",
@@ -126,6 +147,160 @@ describe("gateway node routes", () => {
     })
   })
 
+  test("rotates node credentials, invalidates the old token, and emits lifecycle telemetry", async () => {
+    const app = Server.App()
+    const before = FluxRecorder.list({ kind: "gateway.node.lifecycle" }).total
+
+    const pairResponse = await app.request("/gateway/node/pair", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ label: "Desk", platform: "linux" }),
+    })
+
+    expect(pairResponse.status).toBe(200)
+    const paired = await pairResponse.json()
+
+    const rotateResponse = await app.request("/gateway/node/rotate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        nodeId: paired.node.id,
+        token: paired.token,
+      }),
+    })
+
+    expect(rotateResponse.status).toBe(200)
+    const rotated = await rotateResponse.json()
+    expect(rotated.node.tokenVersion).toBe(2)
+    expect(rotated.token).not.toBe(paired.token)
+
+    const staleReconnect = await app.request("/gateway/node/reconnect", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        nodeId: paired.node.id,
+        token: paired.token,
+      }),
+    })
+
+    expect(staleReconnect.status).toBe(401)
+
+    const refreshedReconnect = await app.request("/gateway/node/reconnect", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        nodeId: paired.node.id,
+        token: rotated.token,
+      }),
+    })
+
+    expect(refreshedReconnect.status).toBe(200)
+    expect(await refreshedReconnect.json()).toMatchObject({
+      id: paired.node.id,
+      tokenVersion: 2,
+    })
+    expect(FluxRecorder.list({ kind: "gateway.node.lifecycle" }).total).toBe(before + 4)
+  })
+
+  test("requires credential rotation before reconnect or tool authorization when a token ages out", async () => {
+    await writeGlobalConfig({
+      gateway: {
+        nodeClient: {
+          enabled: true,
+          securityMode: "allowlist",
+          toolAllowlist: ["zee_invest_research"],
+          allowRemotePairing: false,
+          maxPairedNodes: 3,
+          credentialMaxAgeHours: 1,
+        },
+      },
+    })
+
+    const app = Server.App()
+    const pairResponse = await app.request("/gateway/node/pair", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ label: "Desk", platform: "linux" }),
+    })
+
+    expect(pairResponse.status).toBe(200)
+    const paired = await pairResponse.json()
+
+    await mutateNodeClientState((state) => {
+      state.nodes[paired.node.id]!.tokenIssuedAt = Date.now() - 2 * 60 * 60 * 1000
+    })
+
+    const expiredReconnect = await app.request("/gateway/node/reconnect", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        nodeId: paired.node.id,
+        token: paired.token,
+      }),
+    })
+
+    expect(expiredReconnect.status).toBe(401)
+    expect(await expiredReconnect.json()).toMatchObject({
+      error: `Node token expired: ${paired.node.id}`,
+    })
+
+    const expiredAuthorize = await app.request("/gateway/node/tool/authorize", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        nodeId: paired.node.id,
+        token: paired.token,
+        tool: "zee_invest_research",
+      }),
+    })
+
+    expect(expiredAuthorize.status).toBe(401)
+    expect(await expiredAuthorize.json()).toMatchObject({
+      error: `Node token expired: ${paired.node.id}`,
+    })
+
+    const rotateResponse = await app.request("/gateway/node/rotate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        nodeId: paired.node.id,
+        token: paired.token,
+      }),
+    })
+
+    expect(rotateResponse.status).toBe(200)
+    const rotated = await rotateResponse.json()
+
+    const refreshedReconnect = await app.request("/gateway/node/reconnect", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        nodeId: paired.node.id,
+        token: rotated.token,
+      }),
+    })
+
+    expect(refreshedReconnect.status).toBe(200)
+  })
+
   test("rejects reconnect and tool authorization when node-client policy is disabled", async () => {
     const app = Server.App()
     const pairResponse = await app.request("/gateway/node/pair", {
@@ -135,6 +310,7 @@ describe("gateway node routes", () => {
       },
       body: JSON.stringify({ label: "Desk", platform: "linux" }),
     })
+    expect(pairResponse.status).toBe(200)
     const paired = await pairResponse.json()
 
     await writeGlobalConfig({
@@ -185,6 +361,7 @@ describe("gateway node routes", () => {
       },
       body: JSON.stringify({ label: "Desk", platform: "linux" }),
     })
+    expect(pairResponse.status).toBe(200)
     const paired = await pairResponse.json()
 
     await writeGlobalConfig({


### PR DESCRIPTION
## Summary
- add credential max-age enforcement and token rotation to the gateway node lifecycle
- emit lifecycle telemetry for pair, reconnect, rotate, and revoke flows
- document the rotate endpoint and cover expiry plus rotation behavior in tests

## Local CI
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh

Closes #494