### PR TITLE
feat: enforce node authorization policy matrix

### DIFF
--- a/docs/architecture/node-client-macos.md
+++ b/docs/architecture/node-client-macos.md
@@ -31,6 +31,15 @@ This document captures the reference node-client product path introduced for gat
   - `allowlist`: require tool in merged allowlist (global + node-local)
   - `full`: allow all tools (flagged by security audit)
 
+## Deterministic policy matrix
+| `securityMode` | Authorization result | Reason |
+| --- | --- | --- |
+| `deny` | deny every tool request | `Node policy is deny` |
+| `allowlist` + global match | allow | `Tool is allowlisted` |
+| `allowlist` + node-local match | allow | `Tool is allowlisted` |
+| `allowlist` + no match | deny | `Tool is not allowlisted` |
+| `full` | allow every tool request | `Node policy is full` |
+
 ## Audit integration
 - `zee security audit --deep` and `zee doctor security --deep` now include:
   - config-level node-client exposure checks
@@ -41,6 +50,7 @@ This document captures the reference node-client product path introduced for gat
   - `security.audit.checked`
   - `security.audit.finding`
 - Node lifecycle routes emit Flux `gateway.node.lifecycle` events for pair, reconnect, rotate, and revoke transitions.
+- Node tool authorization emits Flux `gateway.node.authorization` events with the tool name, decision, mode, reason, and allowlist match source (`global`, `node`, `global+node`, `none`, or `policy`).
 
 ## Follow-up hooks (iOS/Android)
 - Data model keeps `platform` as `macos|ios|android|linux|windows|unknown`.

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -29,6 +29,7 @@ export type FluxKind =
   | "gateway.rpc.request"
   | "gateway.rpc.response"
   | "gateway.node.lifecycle"
+  | "gateway.node.authorization"
   | "secret.resolved"
   | "oauth.refresh.start"
   | "oauth.refresh.success"

--- a/packages/zee/src/server/route/gateway-node.ts
+++ b/packages/zee/src/server/route/gateway-node.ts
@@ -79,6 +79,7 @@ const NodeRotateResponseSchema = z.object({
 })
 
 type NodeLifecycleAction = "pair" | "reconnect" | "rotate" | "revoke"
+type NodeAuthorizationMatch = "policy" | "global" | "node" | "global+node" | "none"
 
 function isUnauthorizedNodeLifecycleError(message: string): boolean {
   return message.includes("Invalid node token") || message.includes("Node token expired")
@@ -112,6 +113,61 @@ function recordNodeLifecycle(
       nodeId: input.nodeId,
       reason: input.reason,
       tokenVersion: input.tokenVersion,
+      securityMode: input.policy?.securityMode,
+      maxPairedNodes: input.policy?.maxPairedNodes,
+      credentialMaxAgeHours: input.policy?.credentialMaxAgeHours,
+    },
+  })
+}
+
+function resolveNodeAuthorizationMatch(
+  tool: string,
+  nodeAllowlist: string[],
+  policy: ReturnType<typeof resolveNodeClientPolicy>,
+): NodeAuthorizationMatch {
+  if (policy.securityMode !== "allowlist") return "policy"
+  const globalMatch = policy.toolAllowlist.includes(tool)
+  const nodeMatch = nodeAllowlist.includes(tool)
+  if (globalMatch && nodeMatch) return "global+node"
+  if (globalMatch) return "global"
+  if (nodeMatch) return "node"
+  return "none"
+}
+
+function recordNodeAuthorization(
+  c: Context,
+  input: {
+    status: "ok" | "error" | "denied"
+    nodeId?: string
+    tool: string
+    authorized?: boolean
+    reason: string
+    mode?: "deny" | "allowlist" | "full"
+    tokenVersion?: number
+    matchedBy?: NodeAuthorizationMatch
+    policy?: ReturnType<typeof resolveNodeClientPolicy>
+  },
+) {
+  const traceID = RequestMeta.getTraceID(c.req.raw) ?? crypto.randomUUID()
+  const requestID = RequestMeta.getRequestID(c.req.raw)
+  FluxRecorder.record({
+    traceID,
+    requestID,
+    direction: "internal",
+    domain: "gateway",
+    kind: "gateway.node.authorization",
+    status: input.status,
+    method: c.req.method,
+    path: c.req.path,
+    route: c.req.path,
+    metadata: {
+      nodeId: input.nodeId,
+      tool: input.tool,
+      authorized: input.authorized,
+      reason: input.reason,
+      mode: input.mode,
+      tokenVersion: input.tokenVersion,
+      matchedBy: input.matchedBy,
       securityMode: input.policy?.securityMode,
       maxPairedNodes: input.policy?.maxPairedNodes,
       credentialMaxAgeHours: input.policy?.credentialMaxAgeHours,
@@ -406,7 +462,7 @@ export const GatewayNodeRoute = new Hono()
             },
           },
         },
-        ...errors(400, 401),
+        ...errors(400, 401, 403),
       },
     }),
     validator("json", NodeToolAuthorizeRequestSchema),
@@ -415,6 +471,16 @@ export const GatewayNodeRoute = new Hono()
       const cfg = await Config.get()
       const policy = resolveNodeClientPolicy(cfg)
       if (!policy.enabled) {
+        recordNodeAuthorization(c, {
+          status: "denied",
+          nodeId: input.nodeId,
+          tool: input.tool,
+          authorized: false,
+          reason: "node-client pairing disabled by policy",
+          mode: policy.securityMode,
+          matchedBy: "none",
+          policy,
+        })
         return c.json({ error: "Node-client pairing is disabled by policy (gateway.nodeClient.enabled=false)." }, 403)
       }
       try {
@@ -424,9 +490,30 @@ export const GatewayNodeRoute = new Hono()
           tool: input.tool,
           policy,
         })
+        recordNodeAuthorization(c, {
+          status: result.authorized ? "ok" : "denied",
+          nodeId: result.node.id,
+          tool: input.tool,
+          authorized: result.authorized,
+          reason: result.reason,
+          mode: result.mode,
+          tokenVersion: result.node.tokenVersion,
+          matchedBy: resolveNodeAuthorizationMatch(input.tool, result.node.toolAllowlist, policy),
+          policy,
+        })
         return c.json(result)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
+        recordNodeAuthorization(c, {
+          status: isUnauthorizedNodeLifecycleError(message) ? "denied" : "error",
+          nodeId: input.nodeId,
+          tool: input.tool,
+          authorized: false,
+          reason: message,
+          mode: policy.securityMode,
+          matchedBy: "none",
+          policy,
+        })
         return c.json({ error: message }, isUnauthorizedNodeLifecycleError(message) ? 401 : 400)
       }
     },

--- a/packages/zee/test/server/gateway-node.test.ts
+++ b/packages/zee/test/server/gateway-node.test.ts
@@ -92,14 +92,19 @@ afterAll(async () => {
 })
 
 describe("gateway node routes", () => {
-  test("pairs a node and enforces allowlist authorization deterministically", async () => {
+  test("enforces a deterministic deny/allowlist/full authorization matrix and emits telemetry", async () => {
+    const before = FluxRecorder.list({ kind: "gateway.node.authorization" }).total
     const app = Server.App()
     const pairResponse = await app.request("/gateway/node/pair", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ label: "Desk", platform: "linux" }),
+      body: JSON.stringify({
+        label: "Desk",
+        platform: "linux",
+        toolAllowlist: ["zee_invest_api"],
+      }),
     })
 
     expect(pairResponse.status).toBe(200)
@@ -108,7 +113,7 @@ describe("gateway node routes", () => {
     expect(typeof paired.token).toBe("string")
     expect(paired.policy.credentialMaxAgeHours).toBe(24)
 
-    const allowed = await app.request("/gateway/node/tool/authorize", {
+    const allowlistGlobal = await app.request("/gateway/node/tool/authorize", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -120,14 +125,14 @@ describe("gateway node routes", () => {
       }),
     })
 
-    expect(allowed.status).toBe(200)
-    expect(await allowed.json()).toMatchObject({
+    expect(allowlistGlobal.status).toBe(200)
+    expect(await allowlistGlobal.json()).toMatchObject({
       authorized: true,
       mode: "allowlist",
       reason: "Tool is allowlisted",
     })
 
-    const denied = await app.request("/gateway/node/tool/authorize", {
+    const allowlistNode = await app.request("/gateway/node/tool/authorize", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -139,12 +144,136 @@ describe("gateway node routes", () => {
       }),
     })
 
-    expect(denied.status).toBe(200)
-    expect(await denied.json()).toMatchObject({
+    expect(allowlistNode.status).toBe(200)
+    expect(await allowlistNode.json()).toMatchObject({
+      authorized: true,
+      mode: "allowlist",
+      reason: "Tool is allowlisted",
+    })
+
+    const allowlistDenied = await app.request("/gateway/node/tool/authorize", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        nodeId: paired.node.id,
+        token: paired.token,
+        tool: "zee_invest_unknown",
+      }),
+    })
+
+    expect(allowlistDenied.status).toBe(200)
+    expect(await allowlistDenied.json()).toMatchObject({
       authorized: false,
       mode: "allowlist",
       reason: "Tool is not allowlisted",
     })
+
+    await writeGlobalConfig({
+      gateway: {
+        nodeClient: {
+          enabled: true,
+          securityMode: "deny",
+          toolAllowlist: ["zee_invest_research"],
+          allowRemotePairing: false,
+          maxPairedNodes: 3,
+          credentialMaxAgeHours: 24,
+        },
+      },
+    })
+
+    const denyApp = Server.App()
+    const denyResponse = await denyApp.request("/gateway/node/tool/authorize", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        nodeId: paired.node.id,
+        token: paired.token,
+        tool: "zee_invest_research",
+      }),
+    })
+
+    expect(denyResponse.status).toBe(200)
+    expect(await denyResponse.json()).toMatchObject({
+      authorized: false,
+      mode: "deny",
+      reason: "Node policy is deny",
+    })
+
+    await writeGlobalConfig({
+      gateway: {
+        nodeClient: {
+          enabled: true,
+          securityMode: "full",
+          allowRemotePairing: false,
+          maxPairedNodes: 3,
+          credentialMaxAgeHours: 24,
+        },
+      },
+    })
+
+    const fullApp = Server.App()
+    const fullResponse = await fullApp.request("/gateway/node/tool/authorize", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        nodeId: paired.node.id,
+        token: paired.token,
+        tool: "zee_invest_anything",
+      }),
+    })
+
+    expect(fullResponse.status).toBe(200)
+    expect(await fullResponse.json()).toMatchObject({
+      authorized: true,
+      mode: "full",
+      reason: "Node policy is full",
+    })
+
+    const authorizationEvents = FluxRecorder.list({ kind: "gateway.node.authorization" })
+    expect(authorizationEvents.total).toBe(before + 5)
+    expect(authorizationEvents.events.slice(-5).map((event) => event.metadata)).toMatchObject([
+      {
+        authorized: true,
+        mode: "allowlist",
+        tool: "zee_invest_research",
+        reason: "Tool is allowlisted",
+        matchedBy: "global",
+      },
+      {
+        authorized: true,
+        mode: "allowlist",
+        tool: "zee_invest_api",
+        reason: "Tool is allowlisted",
+        matchedBy: "node",
+      },
+      {
+        authorized: false,
+        mode: "allowlist",
+        tool: "zee_invest_unknown",
+        reason: "Tool is not allowlisted",
+        matchedBy: "none",
+      },
+      {
+        authorized: false,
+        mode: "deny",
+        tool: "zee_invest_research",
+        reason: "Node policy is deny",
+        matchedBy: "policy",
+      },
+      {
+        authorized: true,
+        mode: "full",
+        tool: "zee_invest_anything",
+        reason: "Node policy is full",
+        matchedBy: "policy",
+      },
+    ])
   })
 
   test("rotates node credentials, invalidates the old token, and emits lifecycle telemetry", async () => {
@@ -302,6 +431,7 @@ describe("gateway node routes", () => {
   })
 
   test("rejects reconnect and tool authorization when node-client policy is disabled", async () => {
+    const before = FluxRecorder.list({ kind: "gateway.node.authorization" }).total
     const app = Server.App()
     const pairResponse = await app.request("/gateway/node/pair", {
       method: "POST",
@@ -350,6 +480,15 @@ describe("gateway node routes", () => {
     })
 
     expect(authorize.status).toBe(403)
+    const authorizationEvents = FluxRecorder.list({ kind: "gateway.node.authorization" })
+    expect(authorizationEvents.total).toBe(before + 1)
+    expect(authorizationEvents.events.at(-1)?.metadata).toMatchObject({
+      authorized: false,
+      mode: "deny",
+      tool: "zee_invest_research",
+      reason: "node-client pairing disabled by policy",
+      matchedBy: "none",
+    })
   })
 
   test("allows operators to revoke stale nodes even after the feature is disabled", async () => {


### PR DESCRIPTION
## Summary
- emit explicit gateway node authorization telemetry for allow, deny, and auth-failure outcomes
- enforce and document a deterministic deny/allowlist/full policy matrix for node tool authorization
- add matrix coverage for global allowlist, node-local allowlist, deny mode, full mode, and disabled-policy denial

## Local CI
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh

Closes #495