### PR TITLE
feat: add node exposure drift alerts

### DIFF
--- a/docs/architecture/gateway-control-plane.md
+++ b/docs/architecture/gateway-control-plane.md
@@ -105,11 +105,13 @@ Deep audit operator checks:
 - policy drift: active paired nodes above `maxPairedNodes` or while `securityMode=full`
 - state integrity: unknown node statuses, missing token hashes, duplicate token hashes
 - audit trail completeness: active nodes missing `lastSeenAt`, revoked nodes missing `revokedAt` or `revokeReason`
+- node exposure alerts now carry operator runbooks; see `docs/architecture/node-exposure-incident-runbook.md`
 
 Audit telemetry:
 
 - `security.audit.checked`: summary event with error/warning totals plus paired-node metrics
 - `security.audit.finding`: one event per audit finding code for downstream dashboards or release gates
+- `security.audit.alert`: one event per node exposure drift alert with runbook step counts for operator dashboards
 
 ## Telegram Channel-Native Action Pack
 

--- a/docs/architecture/node-client-macos.md
+++ b/docs/architecture/node-client-macos.md
@@ -49,8 +49,10 @@ This document captures the reference node-client product path introduced for gat
 - Both deep-audit commands emit Flux events:
   - `security.audit.checked`
   - `security.audit.finding`
+  - `security.audit.alert`
 - Node lifecycle routes emit Flux `gateway.node.lifecycle` events for pair, reconnect, rotate, and revoke transitions.
 - Node tool authorization emits Flux `gateway.node.authorization` events with the tool name, decision, mode, reason, and allowlist match source (`global`, `node`, `global+node`, `none`, or `policy`).
+- Node exposure drift alerts point operators to `docs/architecture/node-exposure-incident-runbook.md`.
 
 ## Follow-up hooks (iOS/Android)
 - Data model keeps `platform` as `macos|ios|android|linux|windows|unknown`.

--- a/docs/architecture/node-exposure-incident-runbook.md
+++ b/docs/architecture/node-exposure-incident-runbook.md
@@ -1,0 +1,30 @@
+# Node Exposure Incident Runbook
+
+Use this runbook when `zee security audit --deep --strict` or `zee doctor security --deep --strict` surfaces node exposure drift alerts.
+
+## Alert classes
+
+- `node_client_exposure_feature_disabled`
+  - Active paired nodes still exist while `gateway.nodeClient.enabled=false`.
+- `node_client_exposure_limit_drift`
+  - Active paired nodes exceed `gateway.nodeClient.maxPairedNodes`.
+- `node_client_exposure_full_mode`
+  - Active paired nodes are operating while `gateway.nodeClient.securityMode=full`.
+
+## Immediate response
+
+1. Run `zee security audit --deep --strict` and capture the current alert payload.
+2. Inspect paired node inventory via `GET /gateway/node?includeRevoked=true` from an authenticated operator session.
+3. Compare the active node list with the approved operator/device inventory.
+
+## Containment actions
+
+1. Revoke stale or unapproved nodes with `POST /gateway/node/revoke`.
+2. If policy drift is configuration-driven, restore the intended `gateway.nodeClient` policy before reauthorizing any node.
+3. After downgrading from `securityMode=full`, rotate every active node credential with `POST /gateway/node/rotate`.
+
+## Recovery
+
+1. Re-run `zee doctor security --deep --strict` until the alert set is empty.
+2. Confirm `gateway.node.authorization` telemetry shows only expected allow/deny decisions after the incident.
+3. Record the remediation outcome in the operator incident log with the final audit output.

--- a/packages/zee/src/cli/cmd/doctor.ts
+++ b/packages/zee/src/cli/cmd/doctor.ts
@@ -182,10 +182,19 @@ const DoctorSecurityCommand = cmd({
         (report.metrics.activeNodesMissingLastSeen ?? 0) > 0 ||
         (report.metrics.revokedNodesMissingTimestamp ?? 0) > 0 ||
         (report.metrics.revokedNodesMissingReason ?? 0) > 0
-      ) {
+        ) {
         console.log(
           `security node-state anomalies: unknownStatus=${report.metrics.unknownStatusNodes ?? 0} duplicateTokenHashes=${report.metrics.duplicateTokenHashes ?? 0} missingTokenHashes=${report.metrics.missingTokenHashes ?? 0} activeMissingLastSeen=${report.metrics.activeNodesMissingLastSeen ?? 0} revokedMissingTimestamp=${report.metrics.revokedNodesMissingTimestamp ?? 0} revokedMissingReason=${report.metrics.revokedNodesMissingReason ?? 0}`,
         )
+      }
+      if (report.alerts.length > 0) {
+        console.log("security alerts:")
+        for (const alert of report.alerts) {
+          console.log(`- [${alert.severity}] ${alert.code}: ${alert.message}`)
+          for (const [index, step] of alert.runbook.entries()) {
+            console.log(`  ${index + 1}. ${step}`)
+          }
+        }
       }
       if (report.findings.length === 0) {
         console.log("security: healthy")

--- a/packages/zee/src/cli/cmd/security.ts
+++ b/packages/zee/src/cli/cmd/security.ts
@@ -60,10 +60,19 @@ const SecurityAuditCommand = cmd({
         (report.metrics.activeNodesMissingLastSeen ?? 0) > 0 ||
         (report.metrics.revokedNodesMissingTimestamp ?? 0) > 0 ||
         (report.metrics.revokedNodesMissingReason ?? 0) > 0
-      ) {
+        ) {
         console.log(
           `security node-state anomalies: unknownStatus=${report.metrics.unknownStatusNodes ?? 0} duplicateTokenHashes=${report.metrics.duplicateTokenHashes ?? 0} missingTokenHashes=${report.metrics.missingTokenHashes ?? 0} activeMissingLastSeen=${report.metrics.activeNodesMissingLastSeen ?? 0} revokedMissingTimestamp=${report.metrics.revokedNodesMissingTimestamp ?? 0} revokedMissingReason=${report.metrics.revokedNodesMissingReason ?? 0}`,
         )
+      }
+      if (report.alerts.length > 0) {
+        console.log("security alerts:")
+        for (const alert of report.alerts) {
+          console.log(`- [${alert.severity}] ${alert.code}: ${alert.message}`)
+          for (const [index, step] of alert.runbook.entries()) {
+            console.log(`  ${index + 1}. ${step}`)
+          }
+        }
       }
       if (report.findings.length === 0) {
         console.log("security: no findings")

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -40,6 +40,7 @@ export type FluxKind =
   | "auth.scope.fallback"
   | "security.audit.checked"
   | "security.audit.finding"
+  | "security.audit.alert"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"
   | "provider.fallback.used"

--- a/packages/zee/src/security/control-ui-audit.ts
+++ b/packages/zee/src/security/control-ui-audit.ts
@@ -13,12 +13,21 @@ export type SecurityAuditFinding = {
   remediation?: string
 }
 
+export type SecurityAuditAlert = {
+  severity: SecurityAuditSeverity
+  code: string
+  message: string
+  findingCodes: string[]
+  runbook: string[]
+}
+
 export type SecurityAuditReport = {
   ok: boolean
   errors: number
   warnings: number
   checked: string[]
   findings: SecurityAuditFinding[]
+  alerts: SecurityAuditAlert[]
   metrics: SecurityAuditMetrics
 }
 
@@ -36,6 +45,8 @@ export type SecurityAuditMetrics = {
   revokedNodesMissingReason?: number
   nodeClientEnabled?: boolean
   nodeClientSecurityMode?: "deny" | "allowlist" | "full"
+  alertCount?: number
+  nodeExposureAlertCount?: number
 }
 
 export type SecurityAuditTelemetrySource = "security.audit" | "doctor.security" | "v3.release"
@@ -83,6 +94,7 @@ function hasBreakGlassAcknowledgement(configValue: unknown): boolean {
 function summarizeFindings(
   checked: string[],
   findings: SecurityAuditFinding[],
+  alerts: SecurityAuditAlert[] = [],
   metrics: Partial<SecurityAuditMetrics> = {},
 ): SecurityAuditReport {
   const errors = findings.filter((item) => item.severity === "error").length
@@ -93,10 +105,12 @@ function summarizeFindings(
     warnings,
     checked,
     findings,
+    alerts,
     metrics: {
+      ...metrics,
       checkedCount: checked.length,
       findingCount: findings.length,
-      ...metrics,
+      alertCount: alerts.length,
     },
   }
 }
@@ -141,6 +155,27 @@ export function emitSecurityAuditTelemetry(input: SecurityAuditTelemetryInput): 
         severity: finding.severity,
         code: finding.code,
         hasRemediation: Boolean(finding.remediation),
+      },
+    })
+  }
+
+  for (const alert of input.report.alerts) {
+    FluxRecorder.record({
+      traceID,
+      direction: "internal",
+      domain: "security",
+      kind: "security.audit.alert",
+      status: alert.severity === "error" ? "error" : "denied",
+      method: "CLI",
+      path: input.source,
+      route: input.source,
+      metadata: {
+        source: input.source,
+        deep: input.deep,
+        severity: alert.severity,
+        code: alert.code,
+        findingCodes: alert.findingCodes,
+        runbookSteps: alert.runbook.length,
       },
     })
   }
@@ -355,6 +390,7 @@ export async function auditControlUiSecurityDeep(config: unknown): Promise<Secur
     "gateway.nodeClient.state.revokeMetadata",
   ]
   const findings = [...base.findings]
+  const alerts: SecurityAuditAlert[] = []
 
   try {
     const { getNodeClientRegistry, resolveNodeClientPolicy } = await import("@/gateway/node-client-registry")
@@ -368,6 +404,17 @@ export async function auditControlUiSecurityDeep(config: unknown): Promise<Secur
         message: `There are ${snapshot.active} active paired nodes while gateway.nodeClient.enabled is false.`,
         remediation: "Reconcile state: either enable nodeClient policy or revoke stale paired nodes.",
       })
+      alerts.push({
+        severity: "warning",
+        code: "node_client_exposure_feature_disabled",
+        message: `Active paired nodes remain present while gateway.nodeClient.enabled is false (${snapshot.active} active).`,
+        findingCodes: ["node_client_state_present_but_feature_disabled"],
+        runbook: [
+          "Run `zee security audit --deep --strict` and save the current alert output.",
+          "List paired nodes with `GET /gateway/node?includeRevoked=true` from an authenticated operator session.",
+          "Either re-enable `gateway.nodeClient.enabled` or revoke the stale paired nodes before closing the incident.",
+        ],
+      })
     }
 
     if (snapshot.active > policy.maxPairedNodes) {
@@ -377,6 +424,17 @@ export async function auditControlUiSecurityDeep(config: unknown): Promise<Secur
         message: `Active paired nodes (${snapshot.active}) exceed maxPairedNodes (${policy.maxPairedNodes}).`,
         remediation: "Revoke unused nodes or increase maxPairedNodes after explicit risk review.",
       })
+      alerts.push({
+        severity: "error",
+        code: "node_client_exposure_limit_drift",
+        message: `Active paired nodes exceed the configured ceiling (${snapshot.active}/${policy.maxPairedNodes}).`,
+        findingCodes: ["node_client_active_nodes_exceed_limit"],
+        runbook: [
+          "Identify stale nodes via `GET /gateway/node?includeRevoked=true` and compare with the approved inventory.",
+          "Revoke unexpected nodes first, then decide whether `maxPairedNodes` needs a reviewed increase.",
+          "Repeat `zee doctor security --deep --strict` until the active-node count is back within policy.",
+        ],
+      })
     }
 
     if (snapshot.active > 0 && policy.securityMode === "full") {
@@ -385,6 +443,17 @@ export async function auditControlUiSecurityDeep(config: unknown): Promise<Secur
         code: "node_client_active_nodes_with_full_mode",
         message: `There are ${snapshot.active} active nodes while securityMode=full.`,
         remediation: "Move to allowlist mode and rotate pair tokens after policy downgrade.",
+      })
+      alerts.push({
+        severity: "error",
+        code: "node_client_exposure_full_mode",
+        message: `Active paired nodes are operating under unrestricted full mode (${snapshot.active} active).`,
+        findingCodes: ["node_client_active_nodes_with_full_mode"],
+        runbook: [
+          "Downgrade `gateway.nodeClient.securityMode` from `full` to `allowlist` with an explicit tool allowlist.",
+          "Rotate each active node credential with `POST /gateway/node/rotate` after the policy downgrade.",
+          "Re-run the deep security audit and confirm no active nodes remain under `securityMode=full`.",
+        ],
       })
     }
 
@@ -435,7 +504,7 @@ export async function auditControlUiSecurityDeep(config: unknown): Promise<Secur
       })
     }
 
-    return summarizeFindings(checked, findings, {
+    return summarizeFindings(checked, findings, alerts, {
       ...base.metrics,
       activePairedNodes: snapshot.active,
       revokedPairedNodes: snapshot.revoked,
@@ -448,6 +517,7 @@ export async function auditControlUiSecurityDeep(config: unknown): Promise<Secur
       revokedNodesMissingReason: snapshot.revokedMissingReason,
       nodeClientEnabled: policy.enabled,
       nodeClientSecurityMode: policy.securityMode,
+      nodeExposureAlertCount: alerts.length,
     })
   } catch (error) {
     findings.push({
@@ -458,5 +528,5 @@ export async function auditControlUiSecurityDeep(config: unknown): Promise<Secur
     })
   }
 
-  return summarizeFindings(checked, findings, base.metrics)
+  return summarizeFindings(checked, findings, alerts, base.metrics)
 }

--- a/packages/zee/test/security/control-ui-audit.test.ts
+++ b/packages/zee/test/security/control-ui-audit.test.ts
@@ -115,6 +115,78 @@ describe("auditControlUiSecurityDeep", () => {
     expect(codes).toContain("node_client_duplicate_token_hash")
     expect(codes).toContain("node_client_active_nodes_missing_last_seen")
     expect(codes).toContain("node_client_revoked_metadata_incomplete")
+    expect(report.alerts).toHaveLength(0)
+  })
+
+  test("builds node exposure alerts with incident runbooks for deep drift conditions", async () => {
+    await writeNodeRegistryState({
+      version: 1,
+      nodes: {
+        active_one: {
+          id: "active_one",
+          label: "Desk",
+          platform: "linux",
+          createdAt: 1,
+          updatedAt: 2,
+          status: "paired",
+          metadata: {},
+          toolAllowlist: [],
+          tokenHash: "hash-one",
+          lastSeenAt: 2,
+        },
+        active_two: {
+          id: "active_two",
+          label: "Laptop",
+          platform: "macos",
+          createdAt: 1,
+          updatedAt: 3,
+          status: "paired",
+          metadata: {},
+          toolAllowlist: [],
+          tokenHash: "hash-two",
+          lastSeenAt: 3,
+        },
+      },
+    })
+
+    const report = await auditControlUiSecurityDeep({
+      gateway: {
+        nodeClient: {
+          enabled: false,
+          securityMode: "full",
+          maxPairedNodes: 1,
+        },
+      },
+    })
+
+    expect(report.metrics).toMatchObject({
+      activePairedNodes: 2,
+      totalPairedNodes: 2,
+      alertCount: 3,
+      nodeExposureAlertCount: 3,
+      nodeClientEnabled: false,
+      nodeClientSecurityMode: "full",
+    })
+
+    expect(report.alerts).toHaveLength(3)
+    expect(report.alerts.map((alert) => alert.code)).toEqual([
+      "node_client_exposure_feature_disabled",
+      "node_client_exposure_limit_drift",
+      "node_client_exposure_full_mode",
+    ])
+    expect(report.alerts[0]).toMatchObject({
+      severity: "warning",
+      findingCodes: ["node_client_state_present_but_feature_disabled"],
+    })
+    expect(report.alerts[1]).toMatchObject({
+      severity: "error",
+      findingCodes: ["node_client_active_nodes_exceed_limit"],
+    })
+    expect(report.alerts[2]).toMatchObject({
+      severity: "error",
+      findingCodes: ["node_client_active_nodes_with_full_mode"],
+    })
+    expect(report.alerts.every((alert) => alert.runbook.length >= 3)).toBe(true)
   })
 
   test("emits flux telemetry for audit summaries and findings", async () => {
@@ -159,6 +231,7 @@ describe("auditControlUiSecurityDeep", () => {
 
     const beforeChecked = FluxRecorder.list({ kind: "security.audit.checked" }).total
     const beforeFindings = FluxRecorder.list({ kind: "security.audit.finding" }).total
+    const beforeAlerts = FluxRecorder.list({ kind: "security.audit.alert" }).total
 
     const { traceID } = emitSecurityAuditTelemetry({
       source: "security.audit",
@@ -169,9 +242,10 @@ describe("auditControlUiSecurityDeep", () => {
 
     expect(FluxRecorder.list({ kind: "security.audit.checked" }).total).toBe(beforeChecked + 1)
     expect(FluxRecorder.list({ kind: "security.audit.finding" }).total).toBe(beforeFindings + report.findings.length)
+    expect(FluxRecorder.list({ kind: "security.audit.alert" }).total).toBe(beforeAlerts + report.alerts.length)
 
     const events = FluxRecorder.trace(traceID)
-    expect(events).toHaveLength(report.findings.length + 1)
+    expect(events).toHaveLength(report.findings.length + report.alerts.length + 1)
     expect(events[0]).toMatchObject({
       kind: "security.audit.checked",
       domain: "security",
@@ -191,5 +265,16 @@ describe("auditControlUiSecurityDeep", () => {
         code: report.findings[0]?.code,
       },
     })
+    if (report.alerts.length > 0) {
+      expect(events.at(-1)).toMatchObject({
+        kind: "security.audit.alert",
+        domain: "security",
+        metadata: {
+          source: "security.audit",
+          deep: true,
+          code: report.alerts.at(-1)?.code,
+        },
+      })
+    }
   })
 })


### PR DESCRIPTION
## Summary
- promote deep node-exposure drift conditions into explicit audit alerts with incident runbooks
- emit security audit alert telemetry and surface alert runbooks in security and doctor CLI output
- document the node exposure incident workflow for operators

## Local CI
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh

Closes #496