### PR TITLE
feat: normalize investing entities

### DIFF
--- a/docs/architecture/investing-entity-schema.md
+++ b/docs/architecture/investing-entity-schema.md
@@ -1,0 +1,81 @@
+# Investing Entity Schema
+
+Zee normalizes investing connector payloads into a canonical entity catalog so research automation can address the same company, filing, or event across filings, earnings, transcripts, market data, macro calendars, and news.
+
+## Canonical kinds
+
+The schema supports these entity kinds:
+
+- `company`
+- `instrument`
+- `filing`
+- `event`
+- `thesis`
+- `catalyst`
+- `risk`
+- `valuation_case`
+
+Current ingestion connectors emit `company`, `instrument`, `filing`, and `event`. The remaining kinds are reserved for later research-orchestration issues.
+
+## Identifier strategy
+
+Canonical IDs are deterministic, lowercase, and prefix-scoped by entity kind:
+
+- `company:equity:aapl`
+- `instrument:equity:aapl`
+- `filing:equity:aapl:10-k:2026-02-01`
+- `event:earnings:aapl:q4-2025:2026-01-28t00-00-00-000z`
+- `event:news:msft:story-1`
+
+Rules:
+
+1. The leftmost segment is always the canonical kind or subtype family.
+2. Equity-linked entities normalize the ticker to uppercase for display and lowercase for ID segments.
+3. Connector-native identifiers such as filing dates, transcript/article IDs, URLs, and event codes are preserved in `identifiers.external` and `lineage.sourceId`.
+4. Related entities link through `relatedIds`, plus `identifiers.company` and `identifiers.instrument` where applicable.
+
+## Lineage contract
+
+Every normalized entity carries lineage metadata:
+
+- `source`
+  - one of `filings`, `earnings`, `transcripts`, `market`, `macro`, `news`, `manual`, or `derived`
+- `sourceType`
+  - connector-specific subtype such as `sec_filing`, `earnings_analysis`, `market_snapshot`, `transcript`, `news`, or `macro_calendar`
+- `sourceId`
+  - the stable upstream record identifier or synthesized connector key
+- `parentIds`
+  - canonical parent references such as company/instrument IDs
+- `collectedAt`
+  - when Zee ingested the upstream payload
+- `evidence`
+  - selected source facts such as ticker, filing form, quarter label, or URL
+
+## Persistence and operator checks
+
+- Catalog path: `~/.local/state/zee/investing-entity-catalog.json`
+- Connector run state: `~/.local/state/zee/investing-ingestion.json`
+
+CLI:
+
+```bash
+zee investing entity status
+zee investing entity status --json
+zee investing ingest status
+```
+
+`zee investing entity status` reports total catalog size plus counts by kind and lineage source.
+
+## Telemetry
+
+Flux events emitted for this slice:
+
+- `investing.entity.normalized`
+  - emitted whenever a connector batch is normalized into the catalog
+  - metadata includes `batchCount`, `inserted`, `updated`, `batchKinds`, `countsByKind`, and `countsByLineageSource`
+- `investing.ingestion.run`
+  - now includes `normalizedEntityCount` and `normalizedKinds`
+
+## Compatibility note
+
+The normalized catalog is the canonical ID and lineage layer for investing ingestion. It does not replace existing answer-level provenance blocks in session transcripts, which still describe which tools were used to answer a question.

--- a/docs/architecture/investing-ingestion-platform.md
+++ b/docs/architecture/investing-ingestion-platform.md
@@ -2,6 +2,8 @@
 
 Zee's investing ingestion platform registers long-lived connector jobs inside the always-on daemon so research data stays fresh without depending on GitHub Actions or external cron.
 
+Canonical entity and lineage details live in `docs/architecture/investing-entity-schema.md`.
+
 ## Connector coverage
 
 Built-in connectors:
@@ -30,6 +32,7 @@ Default cadences:
 - Each connector is registered as a global scheduler task with an immediate first run plus recurring cadence.
 - Scheduled runs are bound to the daemon's project instance so connector executions use the same config context as the rest of Zee.
 - Connector state is persisted at `~/.local/state/zee/investing-ingestion.json`.
+- Normalized research entities are persisted at `~/.local/state/zee/investing-entity-catalog.json`.
 
 ## Operator commands
 
@@ -39,6 +42,7 @@ zee investing ingest status --json
 zee investing ingest run
 zee investing ingest run filings
 zee investing ingest schedule
+zee investing entity status
 ```
 
 `zee investing ingest schedule` is mainly for an already-running resident process or debugging. The supported production path is the always-on daemon, which keeps the scheduler alive after registration.
@@ -91,10 +95,14 @@ The platform emits Flux events for dashboards and release gates:
 - `investing.ingestion.schedule`
   - emitted once per enabled connector when the daemon registers schedules
 - `investing.ingestion.run`
-  - emitted on every connector run with `ok` or `error` status, duration, request counts, and connector metadata
+  - emitted on every connector run with `ok` or `error` status, duration, request counts, normalized entity counts, and connector metadata
+- `investing.entity.normalized`
+  - emitted for each normalized connector batch with catalog upsert counts and entity-kind/source metrics
 
 Recommended operator checks:
 
 1. `zee investing ingest status --json` to inspect last-run timestamps and failure state.
-2. Flux queries filtered to `domain=investing`.
-3. Review `investing-ingestion.json` when reconciling connector freshness or repeated failures.
+2. `zee investing entity status --json` to inspect catalog totals and lineage-source counts.
+3. Flux queries filtered to `domain=investing`.
+4. Review `investing-ingestion.json` when reconciling connector freshness or repeated failures.
+5. Review `investing-entity-catalog.json` when reconciling canonical IDs or lineage metadata.

--- a/docs/architecture/openclaw-opencode-financial-roadmap.md
+++ b/docs/architecture/openclaw-opencode-financial-roadmap.md
@@ -54,6 +54,7 @@ Exit criteria:
 - Persist unified research memory graph with queryable lineage.
 - Standardize identifier strategy across instruments and sources.
 - Operator runbook for connector scheduling and telemetry: `docs/architecture/investing-ingestion-platform.md`.
+- Canonical entity and lineage contract: `docs/architecture/investing-entity-schema.md`.
 
 Exit criteria:
 - Data freshness SLAs defined and monitored.

--- a/packages/zee/src/cli/cmd/investing.ts
+++ b/packages/zee/src/cli/cmd/investing.ts
@@ -1,5 +1,6 @@
 import type { Argv } from "yargs"
 import { cmd } from "./cmd"
+import { getInvestingEntityCatalogStatus } from "@/investing/entities"
 import {
   INVESTING_CONNECTOR_KINDS,
   getInvestingIngestionStatus,
@@ -32,7 +33,7 @@ const InvestingIngestStatusCommand = cmd({
           ? new Date(connector.lastFinishedAt).toISOString()
           : "never"
       console.log(
-        `- ${connector.connector}: enabled=${connector.enabled} every=${connector.scheduleMinutes}m lastStatus=${connector.lastStatus} items=${connector.itemCount} requests=${connector.requestCount} lastRun=${lastRun}`,
+        `- ${connector.connector}: enabled=${connector.enabled} every=${connector.scheduleMinutes}m lastStatus=${connector.lastStatus} items=${connector.itemCount} requests=${connector.requestCount} normalized=${connector.normalizedEntityCount} lastRun=${lastRun}`,
       )
     }
   },
@@ -61,10 +62,40 @@ const InvestingIngestRunCommand = cmd({
     }
     for (const result of results) {
       console.log(
-        `- ${result.connector}: status=${result.lastStatus} items=${result.itemCount} requests=${result.requestCount} durationMs=${result.lastDurationMs}${result.error ? ` error=${result.error}` : ""}`,
+        `- ${result.connector}: status=${result.lastStatus} items=${result.itemCount} requests=${result.requestCount} normalized=${result.normalizedEntityCount} durationMs=${result.lastDurationMs}${result.error ? ` error=${result.error}` : ""}`,
       )
     }
   },
+})
+
+const InvestingEntityStatusCommand = cmd({
+  command: "status",
+  describe: "show normalized investing entity catalog status",
+  builder: (yargs: Argv) =>
+    yargs.option("json", {
+      type: "boolean",
+      default: false,
+      describe: "output as JSON",
+    }),
+  handler: async (args: { json?: boolean }) => {
+    const status = await getInvestingEntityCatalogStatus()
+    if (args.json) {
+      console.log(JSON.stringify(status, null, 2))
+      return
+    }
+
+    const updatedAt = status.updatedAt > 0 ? new Date(status.updatedAt).toISOString() : "never"
+    console.log(`entities: total=${status.totalEntities} updatedAt=${updatedAt}`)
+    console.log(`- by kind: ${JSON.stringify(status.countsByKind)}`)
+    console.log(`- by lineage source: ${JSON.stringify(status.countsByLineageSource)}`)
+  },
+})
+
+const InvestingEntityCommand = cmd({
+  command: "entity",
+  describe: "normalized financial entity catalog",
+  builder: (yargs: Argv) => yargs.command(InvestingEntityStatusCommand).demandCommand(),
+  async handler() {},
 })
 
 const InvestingIngestScheduleCommand = cmd({
@@ -103,6 +134,6 @@ const InvestingIngestCommand = cmd({
 export const InvestingCommand = cmd({
   command: "investing",
   describe: "investing platform operations",
-  builder: (yargs: Argv) => yargs.command(InvestingIngestCommand).demandCommand(),
+  builder: (yargs: Argv) => yargs.command(InvestingIngestCommand).command(InvestingEntityCommand).demandCommand(),
   async handler() {},
 })

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -42,6 +42,7 @@ export type FluxKind =
   | "security.audit.checked"
   | "security.audit.finding"
   | "security.audit.alert"
+  | "investing.entity.normalized"
   | "investing.ingestion.run"
   | "investing.ingestion.schedule"
   | "agent.legacy_tools_alias.used"

--- a/packages/zee/src/investing/entities.ts
+++ b/packages/zee/src/investing/entities.ts
@@ -1,0 +1,699 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import type { EarningsAnalysis, Filing, MarketData } from "@zee/investing-sdk"
+import z from "zod"
+import { FluxRecorder } from "@/flux"
+import { Global } from "@/global"
+
+const ENTITY_SCHEMA_VERSION = 1 as const
+const ENTITY_STATE_FILE = path.join(Global.Path.state, "investing-entity-catalog.json")
+
+export const INVESTING_ENTITY_KINDS = [
+  "company",
+  "instrument",
+  "filing",
+  "event",
+  "thesis",
+  "catalyst",
+  "risk",
+  "valuation_case",
+] as const
+
+export const INVESTING_LINEAGE_SOURCES = [
+  "filings",
+  "earnings",
+  "transcripts",
+  "market",
+  "macro",
+  "news",
+  "manual",
+  "derived",
+] as const
+
+export type InvestingEntityKind = (typeof INVESTING_ENTITY_KINDS)[number]
+export type InvestingLineageSource = (typeof INVESTING_LINEAGE_SOURCES)[number]
+
+export const InvestingEntityKindSchema = z.enum(INVESTING_ENTITY_KINDS)
+export const InvestingLineageSourceSchema = z.enum(INVESTING_LINEAGE_SOURCES)
+
+export const InvestingEntityEvidenceSchema = z.object({
+  label: z.string(),
+  value: z.string(),
+  url: z.string().optional(),
+})
+
+export const InvestingEntityLineageSchema = z.object({
+  source: InvestingLineageSourceSchema,
+  sourceType: z.string(),
+  sourceId: z.string(),
+  parentIds: z.array(z.string()).default([]),
+  collectedAt: z.string(),
+  evidence: z.array(InvestingEntityEvidenceSchema).default([]),
+})
+
+export const NormalizedInvestingEntitySchema = z.object({
+  id: z.string(),
+  version: z.literal(ENTITY_SCHEMA_VERSION),
+  kind: InvestingEntityKindSchema,
+  subtype: z.string().optional(),
+  title: z.string(),
+  asOf: z.string(),
+  identifiers: z.object({
+    canonical: z.string(),
+    symbol: z.string().optional(),
+    company: z.string().optional(),
+    instrument: z.string().optional(),
+    external: z.record(z.string(), z.string()).default({}),
+  }),
+  relatedIds: z.array(z.string()).default([]),
+  tags: z.array(z.string()).default([]),
+  attributes: z.record(z.string(), z.unknown()).default({}),
+  lineage: InvestingEntityLineageSchema,
+})
+
+export const InvestingEntityCatalogSchema = z.object({
+  version: z.literal(ENTITY_SCHEMA_VERSION),
+  updatedAt: z.number().int().nonnegative(),
+  entities: z.record(z.string(), NormalizedInvestingEntitySchema),
+})
+
+export type NormalizedInvestingEntity = z.infer<typeof NormalizedInvestingEntitySchema>
+type InvestingEntityCatalog = z.infer<typeof InvestingEntityCatalogSchema>
+
+export type InvestingEntityCatalogStatus = {
+  version: 1
+  updatedAt: number
+  totalEntities: number
+  countsByKind: Record<InvestingEntityKind, number>
+  countsByLineageSource: Record<InvestingLineageSource, number>
+}
+
+export type InvestingEntityCatalogUpdate = InvestingEntityCatalogStatus & {
+  batchCount: number
+  inserted: number
+  updated: number
+  batchKinds: InvestingEntityKind[]
+}
+
+type GenericRecord = Record<string, unknown>
+
+function asRecord(value: unknown): GenericRecord | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  return value as GenericRecord
+}
+
+function asRecords(value: unknown): GenericRecord[] {
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is GenericRecord => Boolean(asRecord(entry)))
+  }
+  const record = asRecord(value)
+  if (!record) return []
+  for (const key of ["items", "results", "records", "data", "articles", "news", "transcripts", "events"]) {
+    const nested = record[key]
+    if (Array.isArray(nested)) {
+      return nested.filter((entry): entry is GenericRecord => Boolean(asRecord(entry)))
+    }
+  }
+  return [record]
+}
+
+function normalizeSegment(value: unknown, fallback = "unknown"): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(Math.trunc(value))
+  }
+  if (typeof value !== "string") return fallback
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return normalized || fallback
+}
+
+function uppercaseSymbol(symbol: string | undefined): string | undefined {
+  const normalized = symbol?.trim().toUpperCase()
+  return normalized ? normalized : undefined
+}
+
+function extractString(record: GenericRecord, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === "string" && value.trim()) return value.trim()
+  }
+  return undefined
+}
+
+function toIsoString(value: unknown, fallback: string): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString()
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = new Date(value)
+    if (Number.isFinite(parsed.getTime())) return parsed.toISOString()
+  }
+  return fallback
+}
+
+function unique<T>(items: T[]): T[] {
+  return [...new Set(items)]
+}
+
+function companyId(symbol: string) {
+  return `company:equity:${normalizeSegment(symbol)}`
+}
+
+function instrumentId(symbol: string) {
+  return `instrument:equity:${normalizeSegment(symbol)}`
+}
+
+function withDefaultCounts<const T extends readonly string[]>(items: T): Record<T[number], number> {
+  return Object.fromEntries(items.map((item) => [item, 0])) as Record<T[number], number>
+}
+
+function dedupeEntities(entities: NormalizedInvestingEntity[]): NormalizedInvestingEntity[] {
+  const byId = new Map<string, NormalizedInvestingEntity>()
+  for (const entity of entities) {
+    byId.set(entity.id, entity)
+  }
+  return [...byId.values()]
+}
+
+function createBaseEntity(input: {
+  id: string
+  kind: InvestingEntityKind
+  subtype?: string
+  title: string
+  asOf: string
+  symbol?: string
+  company?: string
+  instrument?: string
+  external?: Record<string, string>
+  relatedIds?: string[]
+  tags?: string[]
+  attributes?: Record<string, unknown>
+  lineage: z.infer<typeof InvestingEntityLineageSchema>
+}): NormalizedInvestingEntity {
+  return NormalizedInvestingEntitySchema.parse({
+    id: input.id,
+    version: ENTITY_SCHEMA_VERSION,
+    kind: input.kind,
+    subtype: input.subtype,
+    title: input.title,
+    asOf: input.asOf,
+    identifiers: {
+      canonical: input.id,
+      symbol: input.symbol,
+      company: input.company,
+      instrument: input.instrument,
+      external: input.external ?? {},
+    },
+    relatedIds: input.relatedIds ?? [],
+    tags: input.tags ?? [],
+    attributes: input.attributes ?? {},
+    lineage: input.lineage,
+  })
+}
+
+function createCompanyEntity(input: {
+  symbol: string
+  collectedAt: string
+  source: InvestingLineageSource
+  sourceId: string
+  title?: string
+  attributes?: Record<string, unknown>
+}): NormalizedInvestingEntity {
+  const symbol = input.symbol.toUpperCase()
+  const id = companyId(symbol)
+  return createBaseEntity({
+    id,
+    kind: "company",
+    title: input.title ?? symbol,
+    asOf: input.collectedAt,
+    symbol,
+    company: id,
+    external: {
+      ticker: symbol,
+    },
+    attributes: {
+      symbol,
+      ...(input.attributes ?? {}),
+    },
+    tags: ["equity"],
+    lineage: {
+      source: input.source,
+      sourceType: "company",
+      sourceId: input.sourceId,
+      collectedAt: input.collectedAt,
+      parentIds: [],
+      evidence: [{ label: "ticker", value: symbol }],
+    },
+  })
+}
+
+function createInstrumentEntity(input: {
+  symbol: string
+  collectedAt: string
+  source: InvestingLineageSource
+  sourceId: string
+  attributes?: Record<string, unknown>
+}): NormalizedInvestingEntity {
+  const symbol = input.symbol.toUpperCase()
+  const relatedCompanyId = companyId(symbol)
+  const id = instrumentId(symbol)
+  return createBaseEntity({
+    id,
+    kind: "instrument",
+    title: symbol,
+    asOf: input.collectedAt,
+    symbol,
+    company: relatedCompanyId,
+    instrument: id,
+    external: {
+      ticker: symbol,
+    },
+    relatedIds: [relatedCompanyId],
+    attributes: {
+      symbol,
+      assetClass: "equity",
+      ...(input.attributes ?? {}),
+    },
+    tags: ["equity"],
+    lineage: {
+      source: input.source,
+      sourceType: "instrument",
+      sourceId: input.sourceId,
+      collectedAt: input.collectedAt,
+      parentIds: [relatedCompanyId],
+      evidence: [{ label: "ticker", value: symbol }],
+    },
+  })
+}
+
+function normalizeFilings(symbol: string, filings: Filing[], collectedAt: string): NormalizedInvestingEntity[] {
+  const normalizedSymbol = symbol.toUpperCase()
+  const relatedCompanyId = companyId(normalizedSymbol)
+  const relatedInstrumentId = instrumentId(normalizedSymbol)
+  const entities: NormalizedInvestingEntity[] = [
+    createCompanyEntity({
+      symbol: normalizedSymbol,
+      collectedAt,
+      source: "filings",
+      sourceId: normalizedSymbol,
+    }),
+    createInstrumentEntity({
+      symbol: normalizedSymbol,
+      collectedAt,
+      source: "filings",
+      sourceId: normalizedSymbol,
+    }),
+  ]
+
+  for (const filing of filings) {
+    const asOf = toIsoString(filing.filedDate, collectedAt)
+    const sourceId = `${normalizedSymbol}:${filing.formType}:${filing.filedDate}`
+    entities.push(
+      createBaseEntity({
+        id: `filing:equity:${normalizeSegment(normalizedSymbol)}:${normalizeSegment(filing.formType)}:${normalizeSegment(filing.filedDate)}`,
+        kind: "filing",
+        title: `${normalizedSymbol} ${filing.formType}`,
+        asOf,
+        symbol: normalizedSymbol,
+        company: relatedCompanyId,
+        instrument: relatedInstrumentId,
+        external: {
+          formType: filing.formType,
+          filedDate: filing.filedDate,
+          ...(filing.url ? { url: filing.url } : {}),
+        },
+        relatedIds: [relatedCompanyId, relatedInstrumentId],
+        attributes: {
+          symbol: normalizedSymbol,
+          formType: filing.formType,
+          filedDate: filing.filedDate,
+          periodEnd: filing.periodEnd,
+          description: filing.description,
+          url: filing.url,
+        },
+        tags: ["sec", filing.formType.toLowerCase()],
+        lineage: {
+          source: "filings",
+          sourceType: "sec_filing",
+          sourceId,
+          collectedAt,
+          parentIds: [relatedCompanyId, relatedInstrumentId],
+          evidence: [
+            { label: "formType", value: filing.formType },
+            { label: "filedDate", value: filing.filedDate },
+            ...(filing.url ? [{ label: "url", value: filing.url, url: filing.url }] : []),
+          ],
+        },
+      }),
+    )
+  }
+
+  return dedupeEntities(entities)
+}
+
+function normalizeEarnings(symbol: string, analysis: EarningsAnalysis, collectedAt: string): NormalizedInvestingEntity[] {
+  const normalizedSymbol = symbol.toUpperCase()
+  const relatedCompanyId = companyId(normalizedSymbol)
+  const relatedInstrumentId = instrumentId(normalizedSymbol)
+  const entities: NormalizedInvestingEntity[] = [
+    createCompanyEntity({
+      symbol: normalizedSymbol,
+      collectedAt,
+      source: "earnings",
+      sourceId: normalizedSymbol,
+    }),
+    createInstrumentEntity({
+      symbol: normalizedSymbol,
+      collectedAt,
+      source: "earnings",
+      sourceId: normalizedSymbol,
+    }),
+  ]
+
+  analysis.quarters.forEach((quarter, index) => {
+    const record = asRecord(quarter) ?? {}
+    const quarterLabel =
+      extractString(record, "quarter", "fiscalQuarter", "label", "period") ?? `quarter-${index + 1}`
+    const asOf = toIsoString(record.date ?? record.reportDate ?? record.periodEnd, collectedAt)
+    const sourceId = `${normalizedSymbol}:${quarterLabel}:${asOf}`
+
+    entities.push(
+      createBaseEntity({
+        id: `event:earnings:${normalizeSegment(normalizedSymbol)}:${normalizeSegment(quarterLabel)}:${normalizeSegment(asOf)}`,
+        kind: "event",
+        subtype: "earnings",
+        title: `${normalizedSymbol} earnings ${quarterLabel}`,
+        asOf,
+        symbol: normalizedSymbol,
+        company: relatedCompanyId,
+        instrument: relatedInstrumentId,
+        external: {
+          quarter: quarterLabel,
+        },
+        relatedIds: [relatedCompanyId, relatedInstrumentId],
+        attributes: {
+          symbol: normalizedSymbol,
+          quarter: quarterLabel,
+          summary: {
+            epsGrowthYoy: analysis.epsGrowthYoy,
+            avgEpsSurprisePercent: analysis.avgEpsSurprisePercent,
+            beatRate: analysis.beatRate,
+            earningsConsistency: analysis.earningsConsistency,
+          },
+          quarterData: quarter,
+        },
+        tags: ["earnings"],
+        lineage: {
+          source: "earnings",
+          sourceType: "earnings_analysis",
+          sourceId,
+          collectedAt,
+          parentIds: [relatedCompanyId, relatedInstrumentId],
+          evidence: [
+            { label: "quarter", value: quarterLabel },
+            { label: "symbol", value: normalizedSymbol },
+          ],
+        },
+      }),
+    )
+  })
+
+  return dedupeEntities(entities)
+}
+
+function normalizeMarket(symbol: string, marketData: MarketData, collectedAt: string): NormalizedInvestingEntity[] {
+  const normalizedSymbol = symbol.toUpperCase()
+  const relatedCompanyId = companyId(normalizedSymbol)
+  const relatedInstrumentId = instrumentId(normalizedSymbol)
+  const asOf = toIsoString(marketData.timestamp, collectedAt)
+  return dedupeEntities([
+    createCompanyEntity({
+      symbol: normalizedSymbol,
+      collectedAt,
+      source: "market",
+      sourceId: normalizedSymbol,
+    }),
+    createInstrumentEntity({
+      symbol: normalizedSymbol,
+      collectedAt,
+      source: "market",
+      sourceId: normalizedSymbol,
+      attributes: {
+        price: marketData.price,
+        marketCap: marketData.marketCap,
+      },
+    }),
+    createBaseEntity({
+      id: `event:market_snapshot:${normalizeSegment(normalizedSymbol)}:${normalizeSegment(asOf)}`,
+      kind: "event",
+      subtype: "market_snapshot",
+      title: `${normalizedSymbol} market snapshot`,
+      asOf,
+      symbol: normalizedSymbol,
+      company: relatedCompanyId,
+      instrument: relatedInstrumentId,
+      relatedIds: [relatedCompanyId, relatedInstrumentId],
+      attributes: {
+        ...marketData,
+      },
+      tags: ["market"],
+      lineage: {
+        source: "market",
+        sourceType: "market_snapshot",
+        sourceId: `${normalizedSymbol}:${asOf}`,
+        collectedAt,
+        parentIds: [relatedCompanyId, relatedInstrumentId],
+        evidence: [{ label: "timestamp", value: asOf }],
+      },
+    }),
+  ])
+}
+
+function createUnstructuredEventEntities(input: {
+  source: "transcripts" | "news" | "macro"
+  subtype: string
+  records: GenericRecord[]
+  collectedAt: string
+}): NormalizedInvestingEntity[] {
+  const entities: NormalizedInvestingEntity[] = []
+
+  input.records.forEach((record, index) => {
+    const symbol = uppercaseSymbol(extractString(record, "symbol", "ticker", "companySymbol"))
+    const title =
+      extractString(record, "title", "headline", "name", "description", "event") ??
+      `${input.subtype} ${index + 1}`
+    const asOf = toIsoString(
+      record.publishedAt ?? record.timestamp ?? record.date ?? record.datetime ?? record.lastUpdate,
+      input.collectedAt,
+    )
+    const country = extractString(record, "country", "region")
+    const code = extractString(record, "code", "id", "uuid", "eventCode")
+    const sourceId =
+      extractString(record, "id", "uuid", "transcriptId", "articleId", "url") ??
+      [symbol ?? country ?? "global", code ?? title, asOf].map((part) => normalizeSegment(part)).join(":")
+
+    let relatedIds: string[] = []
+    let company: string | undefined
+    let instrument: string | undefined
+    if (symbol) {
+      company = companyId(symbol)
+      instrument = instrumentId(symbol)
+      relatedIds = [company, instrument]
+      entities.push(
+        createCompanyEntity({
+          symbol,
+          collectedAt: input.collectedAt,
+          source: input.source,
+          sourceId,
+          title: symbol,
+        }),
+      )
+      entities.push(
+        createInstrumentEntity({
+          symbol,
+          collectedAt: input.collectedAt,
+          source: input.source,
+          sourceId,
+        }),
+      )
+    }
+
+    entities.push(
+      createBaseEntity({
+        id: `event:${normalizeSegment(input.subtype)}:${normalizeSegment(symbol ?? country ?? "global")}:${normalizeSegment(sourceId)}`,
+        kind: "event",
+        subtype: input.subtype,
+        title,
+        asOf,
+        symbol,
+        company,
+        instrument,
+        relatedIds,
+        external: {
+          ...(country ? { country } : {}),
+          ...(extractString(record, "url") ? { url: extractString(record, "url")! } : {}),
+        },
+        attributes: {
+          ...record,
+        },
+        tags: unique([input.subtype, symbol ? "equity" : "macro"]),
+        lineage: {
+          source: input.source,
+          sourceType: input.subtype,
+          sourceId,
+          collectedAt: input.collectedAt,
+          parentIds: relatedIds,
+          evidence: [
+            { label: "title", value: title },
+            ...(extractString(record, "url") ? [{ label: "url", value: extractString(record, "url")!, url: extractString(record, "url")! }] : []),
+          ],
+        },
+      }),
+    )
+  })
+
+  return dedupeEntities(entities)
+}
+
+export function normalizeInvestingConnectorEntities(input: {
+  connector: "filings" | "earnings" | "transcripts" | "market" | "macro" | "news"
+  symbol?: string
+  data: unknown
+  collectedAt?: string
+}): NormalizedInvestingEntity[] {
+  const collectedAt = toIsoString(input.collectedAt ?? Date.now(), new Date().toISOString())
+  switch (input.connector) {
+    case "filings":
+      return input.symbol ? normalizeFilings(input.symbol, Array.isArray(input.data) ? (input.data as Filing[]) : [], collectedAt) : []
+    case "earnings":
+      return input.symbol && asRecord(input.data)
+        ? normalizeEarnings(input.symbol, input.data as EarningsAnalysis, collectedAt)
+        : []
+    case "market":
+      return input.symbol && asRecord(input.data)
+        ? normalizeMarket(input.symbol, input.data as MarketData, collectedAt)
+        : []
+    case "macro":
+      return createUnstructuredEventEntities({
+        source: "macro",
+        subtype: "macro_calendar",
+        records: asRecords(input.data),
+        collectedAt,
+      })
+    case "transcripts":
+      return createUnstructuredEventEntities({
+        source: "transcripts",
+        subtype: "transcript",
+        records: asRecords(input.data),
+        collectedAt,
+      })
+    case "news":
+      return createUnstructuredEventEntities({
+        source: "news",
+        subtype: "news",
+        records: asRecords(input.data),
+        collectedAt,
+      })
+  }
+}
+
+function defaultCatalog(): InvestingEntityCatalog {
+  return {
+    version: ENTITY_SCHEMA_VERSION,
+    updatedAt: 0,
+    entities: {},
+  }
+}
+
+async function readCatalog(stateFile = ENTITY_STATE_FILE): Promise<InvestingEntityCatalog> {
+  const raw = await fs.readFile(stateFile, "utf8").catch(() => "")
+  if (!raw) return defaultCatalog()
+  try {
+    return InvestingEntityCatalogSchema.parse(JSON.parse(raw))
+  } catch {
+    return defaultCatalog()
+  }
+}
+
+async function writeCatalog(state: InvestingEntityCatalog, stateFile = ENTITY_STATE_FILE): Promise<void> {
+  await fs.mkdir(path.dirname(stateFile), { recursive: true })
+  await fs.writeFile(stateFile, JSON.stringify(state, null, 2) + "\n", "utf8")
+}
+
+function summarizeCatalog(state: InvestingEntityCatalog): InvestingEntityCatalogStatus {
+  const countsByKind = withDefaultCounts(INVESTING_ENTITY_KINDS)
+  const countsByLineageSource = withDefaultCounts(INVESTING_LINEAGE_SOURCES)
+
+  for (const entity of Object.values(state.entities)) {
+    countsByKind[entity.kind] += 1
+    countsByLineageSource[entity.lineage.source] += 1
+  }
+
+  return {
+    version: ENTITY_SCHEMA_VERSION,
+    updatedAt: state.updatedAt,
+    totalEntities: Object.keys(state.entities).length,
+    countsByKind,
+    countsByLineageSource,
+  }
+}
+
+export async function upsertInvestingEntities(input: {
+  entities: NormalizedInvestingEntity[]
+  stateFile?: string
+}): Promise<InvestingEntityCatalogUpdate> {
+  const state = await readCatalog(input.stateFile)
+  let inserted = 0
+  let updated = 0
+  const batchKinds = new Set<InvestingEntityKind>()
+
+  for (const candidate of input.entities) {
+    const entity = NormalizedInvestingEntitySchema.parse(candidate)
+    batchKinds.add(entity.kind)
+    if (state.entities[entity.id]) updated += 1
+    else inserted += 1
+    state.entities[entity.id] = entity
+  }
+
+  state.updatedAt = Date.now()
+  await writeCatalog(state, input.stateFile)
+  const status = summarizeCatalog(state)
+  const batchKindList = [...batchKinds].sort()
+
+  FluxRecorder.record({
+    traceID: crypto.randomUUID(),
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.entity.normalized",
+    status: "ok",
+    method: "normalizer",
+    path: "catalog",
+    route: "investing-entity-catalog",
+    metadata: {
+      batchCount: input.entities.length,
+      inserted,
+      updated,
+      totalEntities: status.totalEntities,
+      batchKinds: batchKindList,
+      countsByKind: status.countsByKind,
+      countsByLineageSource: status.countsByLineageSource,
+    },
+  })
+
+  return {
+    ...status,
+    batchCount: input.entities.length,
+    inserted,
+    updated,
+    batchKinds: batchKindList,
+  }
+}
+
+export async function getInvestingEntityCatalogStatus(options: {
+  stateFile?: string
+} = {}): Promise<InvestingEntityCatalogStatus> {
+  return summarizeCatalog(await readCatalog(options.stateFile))
+}

--- a/packages/zee/src/investing/ingestion.ts
+++ b/packages/zee/src/investing/ingestion.ts
@@ -8,6 +8,11 @@ import { Investing as InvestingPaths } from "@/paths"
 import { Instance } from "@/project/instance"
 import { Scheduler } from "@/scheduler"
 import { Log } from "@/util/log"
+import {
+  normalizeInvestingConnectorEntities,
+  upsertInvestingEntities,
+  type NormalizedInvestingEntity,
+} from "@/investing/entities"
 
 const log = Log.create({ service: "investing:ingestion" })
 
@@ -36,6 +41,8 @@ export type InvestingConnectorRunRecord = {
   lastStatus: InvestingConnectorRunStatus
   itemCount: number
   requestCount: number
+  normalizedEntityCount: number
+  normalizedKinds: string[]
   details: string[]
   error?: string
 }
@@ -68,6 +75,7 @@ export type InvestingIngestionStatus = {
 type ConnectorRunSummary = {
   itemCount: number
   requestCount: number
+  entities?: NormalizedInvestingEntity[]
   details?: string[]
 }
 
@@ -172,6 +180,7 @@ async function createInvestingClient(config: unknown): Promise<InvestingClient> 
 
 async function runRawListEndpoint(
   client: InvestingClient,
+  connector: "transcripts" | "news",
   endpointPath: string,
   lookbackDays: number,
 ): Promise<ConnectorRunSummary> {
@@ -184,6 +193,10 @@ async function runRawListEndpoint(
     itemCount: countItems(response.data),
     requestCount: 1,
     details: [endpointPath],
+    entities: normalizeInvestingConnectorEntities({
+      connector,
+      data: response.data,
+    }),
   }
 }
 
@@ -191,49 +204,78 @@ const BUILTIN_CONNECTORS: Record<InvestingConnectorKind, InvestingConnectorExecu
   filings: async ({ client, config }) => {
     let itemCount = 0
     let requestCount = 0
+    const entities: NormalizedInvestingEntity[] = []
     for (const symbol of config.symbols) {
       const response = await client.accounting.getFilings(symbol)
       requestCount += 1
       if (!response.success) throw new Error(response.error ?? `filings connector failed for ${symbol}`)
       itemCount += Array.isArray(response.data) ? response.data.length : 0
+      entities.push(
+        ...normalizeInvestingConnectorEntities({
+          connector: "filings",
+          symbol,
+          data: response.data,
+        }),
+      )
     }
     return {
       itemCount,
       requestCount,
+      entities,
       details: config.symbols,
     }
   },
   earnings: async ({ client, config }) => {
     let itemCount = 0
     let requestCount = 0
+    const entities: NormalizedInvestingEntity[] = []
     const quarters = config.quarters ?? 8
     for (const symbol of config.symbols) {
       const response = await client.research.getEarnings(symbol, quarters)
       requestCount += 1
       if (!response.success) throw new Error(response.error ?? `earnings connector failed for ${symbol}`)
       itemCount += Array.isArray(response.data?.quarters) ? response.data.quarters.length : 0
+      entities.push(
+        ...normalizeInvestingConnectorEntities({
+          connector: "earnings",
+          symbol,
+          data: response.data,
+        }),
+      )
     }
     return {
       itemCount,
       requestCount,
+      entities,
       details: config.symbols,
     }
   },
   transcripts: async ({ client, config }) => {
-    return runRawListEndpoint(client, config.endpointPath ?? DEFAULT_ENDPOINT_PATHS.transcripts!, config.lookbackDays ?? 7)
+    return runRawListEndpoint(client, "transcripts", config.endpointPath ?? DEFAULT_ENDPOINT_PATHS.transcripts!, config.lookbackDays ?? 7)
   },
   market: async ({ client, config }) => {
     let itemCount = 0
     let requestCount = 0
+    const entities: NormalizedInvestingEntity[] = []
     for (const symbol of config.symbols) {
       const response = await client.market.getData(symbol)
       requestCount += 1
       if (!response.success) throw new Error(response.error ?? `market connector failed for ${symbol}`)
       itemCount += response.data ? 1 : 0
+      if (response.data) {
+        entities.push(
+          ...normalizeInvestingConnectorEntities({
+            connector: "market",
+            symbol,
+            data: response.data,
+          }),
+        )
+      }
     }
     return {
       itemCount,
       requestCount,
+      entities,
       details: config.symbols,
     }
   },
@@ -243,11 +285,15 @@ const BUILTIN_CONNECTORS: Record<InvestingConnectorKind, InvestingConnectorExecu
     return {
       itemCount: Array.isArray(response.data) ? response.data.length : 0,
       requestCount: 1,
+      entities: normalizeInvestingConnectorEntities({
+        connector: "macro",
+        data: response.data,
+      }),
       details: ["calendar"],
     }
   },
   news: async ({ client, config }) => {
-    return runRawListEndpoint(client, config.endpointPath ?? DEFAULT_ENDPOINT_PATHS.news!, config.lookbackDays ?? 3)
+    return runRawListEndpoint(client, "news", config.endpointPath ?? DEFAULT_ENDPOINT_PATHS.news!, config.lookbackDays ?? 3)
   },
 }
 
@@ -291,6 +337,7 @@ export async function executeInvestingConnectorRun(input: {
   client: InvestingClient
   executor?: InvestingConnectorExecutor
   stateFile?: string
+  entityStateFile?: string
   now?: number
 }): Promise<InvestingConnectorRunRecord> {
   const startedAt = input.now ?? Date.now()
@@ -302,6 +349,12 @@ export async function executeInvestingConnectorRun(input: {
       client: input.client,
       config: input.config,
     })
+    const normalized = summary.entities?.length
+      ? await upsertInvestingEntities({
+          entities: summary.entities,
+          stateFile: input.entityStateFile,
+        })
+      : undefined
     const finishedAt = Date.now()
     const record: InvestingConnectorRunRecord = {
       connector: input.connector,
@@ -315,6 +368,8 @@ export async function executeInvestingConnectorRun(input: {
       lastStatus: "ok",
       itemCount: summary.itemCount,
       requestCount: summary.requestCount,
+      normalizedEntityCount: normalized?.batchCount ?? 0,
+      normalizedKinds: normalized?.batchKinds ?? [],
       details: summary.details ?? [],
     }
     state.connectors[input.connector] = record
@@ -333,6 +388,8 @@ export async function executeInvestingConnectorRun(input: {
         connector: input.connector,
         itemCount: record.itemCount,
         requestCount: record.requestCount,
+        normalizedEntityCount: record.normalizedEntityCount,
+        normalizedKinds: record.normalizedKinds,
         scheduleMinutes: record.scheduleMinutes,
         coverageSymbols: record.coverageSymbols,
         endpointPath: record.endpointPath,
@@ -354,6 +411,8 @@ export async function executeInvestingConnectorRun(input: {
       lastStatus: "error",
       itemCount: 0,
       requestCount: 0,
+      normalizedEntityCount: 0,
+      normalizedKinds: [],
       details: [],
       error: message,
     }
@@ -388,6 +447,7 @@ export async function runInvestingConnector(
   options: {
     config?: unknown
     stateFile?: string
+    entityStateFile?: string
   } = {},
 ): Promise<InvestingConnectorRunRecord> {
   const rawConfig = options.config ?? (await Config.get())
@@ -400,6 +460,7 @@ export async function runInvestingConnector(
       config: connectorConfig,
       client,
       stateFile: options.stateFile,
+      entityStateFile: options.entityStateFile,
     })
   } finally {
     await client.disconnect().catch(() => {})
@@ -409,6 +470,7 @@ export async function runInvestingConnector(
 export async function runEnabledInvestingConnectors(options: {
   config?: unknown
   stateFile?: string
+  entityStateFile?: string
   connectors?: InvestingConnectorKind[]
 } = {}): Promise<InvestingConnectorRunRecord[]> {
   const rawConfig = options.config ?? (await Config.get())
@@ -427,6 +489,7 @@ export async function runEnabledInvestingConnectors(options: {
           config: resolved.connectors[connector],
           client,
           stateFile: options.stateFile,
+          entityStateFile: options.entityStateFile,
         }),
       )
     }
@@ -459,6 +522,8 @@ export async function getInvestingIngestionStatus(options: {
         lastStatus: "ok",
         itemCount: 0,
         requestCount: 0,
+        normalizedEntityCount: 0,
+        normalizedKinds: [],
         details: [],
       }
       return {
@@ -478,6 +543,7 @@ export function registerInvestingIngestionSchedules(input: {
   directory?: string
   rawConfig?: unknown
   stateFile?: string
+  entityStateFile?: string
   register?: RegisterTask
   runConnector?: (connector: InvestingConnectorKind) => Promise<unknown>
 }): Array<{ connector: InvestingConnectorKind; taskId: string; scheduleMinutes: number }> {
@@ -490,6 +556,7 @@ export function registerInvestingIngestionSchedules(input: {
         await runInvestingConnector(connector, {
           config: input.rawConfig,
           stateFile: input.stateFile,
+          entityStateFile: input.entityStateFile,
         })
       if (input.directory) {
         return await Instance.provide({

--- a/packages/zee/test/investing/entities.test.ts
+++ b/packages/zee/test/investing/entities.test.ts
@@ -1,0 +1,175 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { FluxRecorder } from "../../src/flux"
+import {
+  getInvestingEntityCatalogStatus,
+  normalizeInvestingConnectorEntities,
+  upsertInvestingEntities,
+} from "../../src/investing/entities"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe("normalizeInvestingConnectorEntities", () => {
+  test("creates stable filing, company, and instrument identifiers", () => {
+    const entities = normalizeInvestingConnectorEntities({
+      connector: "filings",
+      symbol: "AAPL",
+      collectedAt: "2026-03-15T10:00:00.000Z",
+      data: [
+        {
+          formType: "10-K",
+          filedDate: "2026-02-01",
+          periodEnd: "2025-12-31",
+          description: "Annual report",
+          url: "https://example.com/10k",
+        },
+      ],
+    })
+
+    expect(entities.map((entity) => entity.id)).toEqual([
+      "company:equity:aapl",
+      "instrument:equity:aapl",
+      "filing:equity:aapl:10-k:2026-02-01",
+    ])
+
+    const filing = entities.find((entity) => entity.kind === "filing")
+    expect(filing).toMatchObject({
+      title: "AAPL 10-K",
+      identifiers: {
+        symbol: "AAPL",
+        company: "company:equity:aapl",
+        instrument: "instrument:equity:aapl",
+      },
+      lineage: {
+        source: "filings",
+        sourceType: "sec_filing",
+        sourceId: "AAPL:10-K:2026-02-01",
+        parentIds: ["company:equity:aapl", "instrument:equity:aapl"],
+      },
+    })
+  })
+
+  test("normalizes unstructured news records into event lineage", () => {
+    const entities = normalizeInvestingConnectorEntities({
+      connector: "news",
+      collectedAt: "2026-03-15T11:00:00.000Z",
+      data: {
+        articles: [
+          {
+            id: "story-1",
+            symbol: "msft",
+            headline: "Microsoft expands cloud capacity",
+            publishedAt: "2026-03-14T18:30:00Z",
+            url: "https://example.com/story-1",
+          },
+        ],
+      },
+    })
+
+    const newsEvent = entities.find((entity) => entity.subtype === "news")
+    expect(newsEvent).toMatchObject({
+      id: "event:news:msft:story-1",
+      title: "Microsoft expands cloud capacity",
+      identifiers: {
+        symbol: "MSFT",
+        company: "company:equity:msft",
+        instrument: "instrument:equity:msft",
+      },
+      lineage: {
+        source: "news",
+        sourceType: "news",
+        sourceId: "story-1",
+      },
+    })
+  })
+})
+
+describe("investing entity catalog", () => {
+  test("persists catalog updates and emits normalization telemetry", async () => {
+    await using dir = await tmpdir()
+    const stateFile = path.join(dir.path, "investing-entity-catalog.json")
+    const recordSpy = spyOn(FluxRecorder, "record")
+
+    const filingBatch = normalizeInvestingConnectorEntities({
+      connector: "filings",
+      symbol: "NVDA",
+      collectedAt: "2026-03-15T09:00:00.000Z",
+      data: [
+        {
+          formType: "8-K",
+          filedDate: "2026-03-10",
+          periodEnd: "2026-03-10",
+          description: "Current report",
+        },
+      ],
+    })
+
+    const first = await upsertInvestingEntities({
+      entities: filingBatch,
+      stateFile,
+    })
+
+    expect(first).toMatchObject({
+      batchCount: 3,
+      inserted: 3,
+      updated: 0,
+      totalEntities: 3,
+    })
+    expect(first.countsByKind.filing).toBe(1)
+    expect(first.countsByLineageSource.filings).toBe(3)
+    expect(recordSpy).toHaveBeenCalledTimes(1)
+    expect(recordSpy.mock.calls[0]?.[0]).toMatchObject({
+      domain: "investing",
+      kind: "investing.entity.normalized",
+      status: "ok",
+      metadata: {
+        batchCount: 3,
+        inserted: 3,
+        updated: 0,
+      },
+    })
+
+    const second = await upsertInvestingEntities({
+      entities: normalizeInvestingConnectorEntities({
+        connector: "market",
+        symbol: "NVDA",
+        collectedAt: "2026-03-15T09:30:00.000Z",
+        data: {
+          symbol: "NVDA",
+          price: 900,
+          change: 5,
+          changePercent: 0.6,
+          volume: 123456,
+          timestamp: "2026-03-15T09:30:00Z",
+        },
+      }),
+      stateFile,
+    })
+
+    expect(second.inserted).toBe(1)
+    expect(second.updated).toBe(2)
+    expect(second.totalEntities).toBe(4)
+    expect(second.countsByKind.event).toBe(1)
+
+    const status = await getInvestingEntityCatalogStatus({ stateFile })
+    expect(status.totalEntities).toBe(4)
+    expect(status.countsByKind.company).toBe(1)
+    expect(status.countsByKind.instrument).toBe(1)
+    expect(status.countsByKind.filing).toBe(1)
+    expect(status.countsByKind.event).toBe(1)
+
+    const onDisk = JSON.parse(await fs.readFile(stateFile, "utf8")) as {
+      entities: Record<string, unknown>
+    }
+    expect(Object.keys(onDisk.entities).sort()).toEqual([
+      "company:equity:nvda",
+      "event:market_snapshot:nvda:2026-03-15t09-30-00-000z",
+      "filing:equity:nvda:8-k:2026-03-10",
+      "instrument:equity:nvda",
+    ])
+  })
+})

--- a/packages/zee/test/investing/ingestion.test.ts
+++ b/packages/zee/test/investing/ingestion.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises"
 import path from "node:path"
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { FluxRecorder } from "../../src/flux"
+import { normalizeInvestingConnectorEntities } from "../../src/investing/entities"
 import {
   executeInvestingConnectorRun,
   getInvestingIngestionStatus,
@@ -70,6 +71,7 @@ describe("executeInvestingConnectorRun", () => {
   test("persists successful runs and emits telemetry", async () => {
     await using dir = await tmpdir()
     const stateFile = path.join(dir.path, "investing-ingestion.json")
+    const entityStateFile = path.join(dir.path, "investing-entities.json")
     const recordSpy = spyOn(FluxRecorder, "record")
     const startedAt = 1_700_000_000_000
 
@@ -83,11 +85,28 @@ describe("executeInvestingConnectorRun", () => {
         quarters: 8,
       },
       stateFile,
+      entityStateFile,
       now: startedAt,
       executor: async () => ({
         itemCount: 4,
         requestCount: 1,
         details: ["AAPL"],
+        entities: normalizeInvestingConnectorEntities({
+          connector: "earnings",
+          symbol: "AAPL",
+          collectedAt: "2026-03-15T10:00:00.000Z",
+          data: {
+            symbol: "AAPL",
+            quarters: [{ quarter: "Q4 2025", reportDate: "2026-01-28" }],
+            epsGrowthYoy: 12,
+            epsGrowth3yrCagr: 8,
+            avgEpsSurprisePercent: 5,
+            beatRate: 0.8,
+            consecutiveBeats: 4,
+            earningsVolatility: 0.1,
+            earningsConsistency: 0.9,
+          },
+        }),
       }),
     })
 
@@ -97,12 +116,23 @@ describe("executeInvestingConnectorRun", () => {
       itemCount: 4,
       requestCount: 1,
       coverageSymbols: ["AAPL"],
+      normalizedEntityCount: 3,
+      normalizedKinds: ["company", "event", "instrument"],
       details: ["AAPL"],
     })
     expect(result.lastStartedAt).toBe(startedAt)
     expect(result.lastFinishedAt).toBeGreaterThanOrEqual(startedAt)
-    expect(recordSpy).toHaveBeenCalledTimes(1)
+    expect(recordSpy).toHaveBeenCalledTimes(2)
     expect(recordSpy.mock.calls[0]?.[0]).toMatchObject({
+      domain: "investing",
+      kind: "investing.entity.normalized",
+      status: "ok",
+      metadata: {
+        batchCount: 3,
+        inserted: 3,
+      },
+    })
+    expect(recordSpy.mock.calls[1]?.[0]).toMatchObject({
       domain: "investing",
       kind: "investing.ingestion.run",
       status: "ok",
@@ -111,6 +141,7 @@ describe("executeInvestingConnectorRun", () => {
         connector: "earnings",
         itemCount: 4,
         requestCount: 1,
+        normalizedEntityCount: 3,
       },
     })
 
@@ -122,6 +153,7 @@ describe("executeInvestingConnectorRun", () => {
       lastStatus: "ok",
       itemCount: 4,
       requestCount: 1,
+      normalizedEntityCount: 3,
       coverageSymbols: ["AAPL"],
     })
   })
@@ -174,6 +206,7 @@ describe("executeInvestingConnectorRun", () => {
       lastStatus: "error",
       itemCount: 0,
       requestCount: 0,
+      normalizedEntityCount: 0,
       error: "news endpoint unavailable",
     })
   })
@@ -200,6 +233,8 @@ describe("getInvestingIngestionStatus", () => {
               lastStatus: "ok",
               itemCount: 7,
               requestCount: 2,
+              normalizedEntityCount: 5,
+              normalizedKinds: ["company", "filing", "instrument"],
               details: ["OLD"],
             },
           },
@@ -241,6 +276,7 @@ describe("getInvestingIngestionStatus", () => {
       lastStatus: "ok",
       itemCount: 7,
       requestCount: 2,
+      normalizedEntityCount: 5,
     })
     expect(market).toMatchObject({
       connector: "market",
@@ -250,6 +286,7 @@ describe("getInvestingIngestionStatus", () => {
       lastFinishedAt: 0,
       itemCount: 0,
       requestCount: 0,
+      normalizedEntityCount: 0,
     })
   })
 })


### PR DESCRIPTION
## Summary
- add a canonical investing entity catalog with deterministic IDs, lineage metadata, and Flux normalization telemetry
- normalize filings, earnings, transcripts, market, macro, and news connector payloads into the catalog during ingestion runs
- document the entity schema and expose operator status through `zee investing entity status`

## Testing
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- cd packages/zee && bun test ./test/investing/entities.test.ts
- cd packages/zee && bun test ./test/investing/ingestion.test.ts
- cd packages/zee && bun run typecheck
- cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh

Closes #498