### PR TITLE
feat(#500): add investing research workflow planner

### DIFF
--- a/docs/architecture/investing-research-planner.md
+++ b/docs/architecture/investing-research-planner.md
@@ -1,0 +1,114 @@
+# Investing Research Planner
+
+Zee's investing research planner gives Stanley a repeatable way to break multi-step research objectives into explicit tasks, persist plan state locally, and emit telemetry for operators.
+
+## Scope
+
+The planner is designed for research setup and decomposition, not final synthesis. It answers:
+
+- what workflow should this objective follow?
+- which tasks should run next?
+- which tool surfaces are expected for each task?
+- what is the current state of the workflow?
+
+Persisted plans live at `~/.local/state/zee/investing/research-plans.json`.
+
+## Tool surface
+
+The planner is exposed as `zee:invest-planner`.
+
+Supported actions:
+
+- `create`
+  - inputs: `objective`, optional `workflow`, optional `symbols`
+- `read`
+  - inputs: `planId`
+- `list`
+  - inputs: optional `status`, optional `limit`
+- `update`
+  - inputs: `planId`, `taskId`, `status`, optional `note`
+
+Example payloads:
+
+```json
+{
+  "action": "create",
+  "objective": "Prepare a pre-earnings preview for NVDA",
+  "symbols": ["NVDA"]
+}
+```
+
+```json
+{
+  "action": "update",
+  "planId": "research-plan-1234abcd5678",
+  "taskId": "expectation-map",
+  "status": "completed",
+  "note": "Consensus and guideposts captured"
+}
+```
+
+## Workflow templates
+
+Supported workflow kinds:
+
+- `company-brief`
+- `earnings-preview`
+- `earnings-review`
+- `thesis-refresh`
+- `valuation-refresh`
+- `event-follow-up`
+- `peer-compare`
+
+If the caller does not specify a workflow, Zee infers one from the objective text. Each workflow emits a fixed task template with:
+
+- `id`
+- `phase`
+- `title`
+- `description`
+- `toolIds`
+- `dependsOn`
+- `deliverable`
+- `status`
+
+The planner auto-starts the first task and auto-advances the next dependency-ready task when the current one is marked `completed`.
+
+## Task design
+
+The templates intentionally point Stanley toward the existing investing tool surface:
+
+- `zee:invest-status`
+- `zee:invest-research`
+- `zee:invest-sec-filings`
+- `zee:invest-market-data`
+- `zee:invest-estimates`
+- `zee:invest-insider-trades`
+- `zee:invest-segments`
+- `zee:invest-scratchpad`
+
+That keeps workflow decomposition aligned with the actual tool inventory instead of creating planner-only steps that cannot be executed.
+
+## Telemetry
+
+The planner emits Flux events under `domain=investing`:
+
+- `investing.research.plan`
+  - emitted when a plan is created
+  - metadata includes workflow kind, objective, symbols, phases, and task count
+- `investing.research.plan.task`
+  - emitted when a task status changes
+  - metadata includes plan status, task status, task id/title, symbols, and optional operator note
+
+Recommended checks:
+
+1. Query Flux for `kind=investing.research.plan` to track research intake volume by workflow.
+2. Query Flux for `kind=investing.research.plan.task` to find blocked tasks and stalled workflows.
+3. Inspect `research-plans.json` when reconciling planner state with a live research session.
+
+## Operating loop
+
+1. Create a plan at the start of any multi-step research objective.
+2. Execute the active task using the listed investing tools.
+3. Update the task status as evidence is gathered.
+4. Let the planner auto-advance the next dependency-ready task.
+5. Use `list` or `read` to resume work across sessions.

--- a/docs/architecture/openclaw-opencode-financial-roadmap.md
+++ b/docs/architecture/openclaw-opencode-financial-roadmap.md
@@ -67,6 +67,7 @@ Exit criteria:
 - Implement thesis generation/update loops, valuation packs, catalyst and risk tracking.
 - Add portfolio-linked daily and earnings briefing pipelines.
 - Add quality evaluation harness (factuality, consistency, timeliness).
+- Research workflow planner and task decomposition runbook: `docs/architecture/investing-research-planner.md`.
 
 Exit criteria:
 - End-to-end automated research run produces usable analyst packet.

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -48,6 +48,8 @@ export type FluxKind =
   | "investing.ingestion.backfill"
   | "investing.ingestion.run"
   | "investing.ingestion.schedule"
+  | "investing.research.plan"
+  | "investing.research.plan.task"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"
   | "provider.fallback.used"

--- a/packages/zee/test/investing/research-planner.test.ts
+++ b/packages/zee/test/investing/research-planner.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import fs from "node:fs/promises"
+import { FluxRecorder } from "../../src/flux"
+import { tmpdir } from "../fixture/fixture"
+import {
+  createInvestingResearchPlan,
+  getInvestingResearchPlan,
+  getInvestingResearchPlanStateFile,
+  listInvestingResearchPlans,
+  updateInvestingResearchTask,
+} from "../../../../src/domain/investing/planner"
+import { researchPlannerTool } from "../../../../src/domain/investing/tools"
+import { registerInvestingTools } from "../../../../src/mcp/domain/index"
+import { getToolRegistry, resetToolRegistry } from "../../../../src/mcp/registry"
+
+function makeToolContext() {
+  return {
+    sessionId: "session-1",
+    messageId: "message-1",
+    agent: "zee",
+    abort: new AbortController().signal,
+    metadata: () => {},
+  }
+}
+
+async function withPlannerState<T>(fn: () => Promise<T>): Promise<T> {
+  await using dir = await tmpdir()
+  const originalStateHome = process.env.XDG_STATE_HOME
+  process.env.XDG_STATE_HOME = dir.path
+  try {
+    return await fn()
+  } finally {
+    if (originalStateHome === undefined) {
+      delete process.env.XDG_STATE_HOME
+    } else {
+      process.env.XDG_STATE_HOME = originalStateHome
+    }
+    resetToolRegistry()
+  }
+}
+
+describe("investing research planner", () => {
+  test("creates and persists a repeatable earnings preview plan with telemetry", async () => {
+    await withPlannerState(async () => {
+      const recordSpy = spyOn(FluxRecorder, "record")
+
+      const plan = createInvestingResearchPlan({
+        objective: "Prepare a pre-earnings preview for NVDA",
+      })
+
+      expect(plan.workflow).toBe("earnings-preview")
+      expect(plan.symbols).toEqual(["NVDA"])
+      expect(plan.status).toBe("active")
+      expect(plan.tasks[0]?.status).toBe("in_progress")
+      expect(plan.tasks[0]?.id).toBe("coverage-check")
+      expect(getInvestingResearchPlan(plan.id)?.id).toBe(plan.id)
+
+      const persisted = JSON.parse(await fs.readFile(getInvestingResearchPlanStateFile(), "utf8")) as {
+        plans: Array<{ id: string }>
+      }
+      expect(persisted.plans[0]?.id).toBe(plan.id)
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.research.plan")).toBe(true)
+    })
+  })
+
+  test("updates task state and auto-advances the next dependency-ready step", async () => {
+    await withPlannerState(async () => {
+      const recordSpy = spyOn(FluxRecorder, "record")
+      const plan = createInvestingResearchPlan({
+        objective: "Refresh the thesis on AAPL",
+      })
+
+      const updated = updateInvestingResearchTask({
+        planId: plan.id,
+        taskId: "coverage-check",
+        status: "completed",
+        note: "Coverage confirmed and session opened",
+      })
+
+      expect(updated.tasks.find((task) => task.id === "coverage-check")?.status).toBe("completed")
+      expect(updated.tasks.find((task) => task.id === "source-refresh")?.status).toBe("in_progress")
+      expect(updated.status).toBe("active")
+      expect(updated.tasks.find((task) => task.id === "coverage-check")?.note).toBe(
+        "Coverage confirmed and session opened",
+      )
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.research.plan.task")).toBe(true)
+    })
+  })
+
+  test("tool surface can create, read, and list persisted plans", async () => {
+    await withPlannerState(async () => {
+      const runtime = await researchPlannerTool.init()
+      const ctx = makeToolContext()
+
+      const created = await runtime.execute(
+        {
+          action: "create",
+          objective: "Compare MSFT and GOOGL",
+          symbols: ["msft", "googl"],
+        },
+        ctx,
+      )
+      const createdPlan = JSON.parse(created.output) as { id: string; workflow: string; symbols: string[] }
+
+      expect(createdPlan.workflow).toBe("peer-compare")
+      expect(createdPlan.symbols).toEqual(["MSFT", "GOOGL"])
+
+      const loaded = await runtime.execute(
+        {
+          action: "read",
+          planId: createdPlan.id,
+        },
+        ctx,
+      )
+      expect(JSON.parse(loaded.output)).toMatchObject({
+        id: createdPlan.id,
+      })
+
+      const listed = await runtime.execute(
+        {
+          action: "list",
+          limit: 5,
+        },
+        ctx,
+      )
+      const listedPayload = JSON.parse(listed.output) as {
+        count: number
+        plans: Array<{ id: string }>
+      }
+      expect(listedPayload.count).toBeGreaterThan(0)
+      expect(listedPayload.plans.some((plan) => plan.id === createdPlan.id)).toBe(true)
+
+      expect(listInvestingResearchPlans({ limit: 5 }).some((plan) => plan.id === createdPlan.id)).toBe(true)
+    })
+  })
+
+  test("MCP domain registration exposes the full investing planner tool set", async () => {
+    await withPlannerState(async () => {
+      registerInvestingTools()
+      const registry = getToolRegistry()
+
+      expect(registry.has("zee:invest-market-data")).toBe(true)
+      expect(registry.has("zee:invest-scratchpad")).toBe(true)
+      expect(registry.has("zee:invest-planner")).toBe(true)
+    })
+  })
+})

--- a/src/agent/assistants.ts
+++ b/src/agent/assistants.ts
@@ -98,6 +98,7 @@ export const ZEE_AGENT_CONFIG: AgentConfig = {
     "zee:invest-market-data": true,
     "zee:invest-portfolio": true,
     "zee:invest-research": true,
+    "zee:invest-planner": true,
     "zee:invest-sec-filings": true,
     "zee:invest-nautilus": true,
     "zee:invest-estimates": true,

--- a/src/awareness/tool-catalog.ts
+++ b/src/awareness/tool-catalog.ts
@@ -46,6 +46,7 @@ const AGENT_PRIMARY_TOOLS: Record<string, string[]> = {
     "zee:invest-nautilus",
     "zee:invest-sec-filings",
     "zee:invest-research",
+    "zee:invest-planner",
     "zee:invest-estimates",
     "zee:invest-insider-trades",
     "zee:invest-segments",

--- a/src/domain/investing/planner.ts
+++ b/src/domain/investing/planner.ts
@@ -1,0 +1,623 @@
+/**
+ * Investing Research Workflow Planner
+ *
+ * Creates repeatable multi-step research plans for Stanley-style workflows,
+ * persists them locally, and emits telemetry for operator visibility.
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { FluxRecorder } from "../../../packages/zee/src/flux";
+import { Log } from "../../../packages/zee/src/util/log";
+
+const log = Log.create({ service: "investing:research-planner" });
+
+export const INVESTING_RESEARCH_WORKFLOW_KINDS = [
+  "company-brief",
+  "earnings-preview",
+  "earnings-review",
+  "thesis-refresh",
+  "valuation-refresh",
+  "event-follow-up",
+  "peer-compare",
+] as const;
+
+export type InvestingResearchWorkflowKind = (typeof INVESTING_RESEARCH_WORKFLOW_KINDS)[number];
+
+export const INVESTING_RESEARCH_TASK_PHASES = ["intake", "data", "analysis", "synthesis"] as const;
+
+export type InvestingResearchTaskPhase = (typeof INVESTING_RESEARCH_TASK_PHASES)[number];
+
+export const INVESTING_RESEARCH_PLAN_STATUSES = ["active", "completed", "blocked"] as const;
+
+export type InvestingResearchPlanStatus = (typeof INVESTING_RESEARCH_PLAN_STATUSES)[number];
+
+export const INVESTING_RESEARCH_TASK_STATUSES = ["pending", "in_progress", "completed", "blocked"] as const;
+
+export type InvestingResearchTaskStatus = (typeof INVESTING_RESEARCH_TASK_STATUSES)[number];
+
+export interface InvestingResearchTask {
+  id: string;
+  phase: InvestingResearchTaskPhase;
+  title: string;
+  description: string;
+  toolIds: string[];
+  dependsOn: string[];
+  deliverable: string;
+  status: InvestingResearchTaskStatus;
+  note?: string;
+}
+
+export interface InvestingResearchPlan {
+  id: string;
+  objective: string;
+  workflow: InvestingResearchWorkflowKind;
+  symbols: string[];
+  status: InvestingResearchPlanStatus;
+  createdAt: string;
+  updatedAt: string;
+  tasks: InvestingResearchTask[];
+}
+
+type PlannerState = {
+  version: 1;
+  plans: InvestingResearchPlan[];
+};
+
+export type CreateInvestingResearchPlanInput = {
+  objective: string;
+  workflow?: InvestingResearchWorkflowKind;
+  symbols?: string[];
+};
+
+export type UpdateInvestingResearchTaskInput = {
+  planId: string;
+  taskId: string;
+  status: InvestingResearchTaskStatus;
+  note?: string;
+};
+
+function getPlannerStateDir(): string {
+  const stateDir = process.env.XDG_STATE_HOME
+    ? path.join(process.env.XDG_STATE_HOME, "zee")
+    : path.join(os.homedir(), ".local", "state", "zee");
+  return path.join(stateDir, "investing");
+}
+
+export function getInvestingResearchPlanStateFile(): string {
+  return path.join(getPlannerStateDir(), "research-plans.json");
+}
+
+function ensurePlannerStateDir(): void {
+  mkdirSync(getPlannerStateDir(), { recursive: true });
+}
+
+function readPlannerState(): PlannerState {
+  const filePath = getInvestingResearchPlanStateFile();
+  if (!existsSync(filePath)) {
+    return { version: 1, plans: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as PlannerState;
+    return {
+      version: 1,
+      plans: Array.isArray(parsed.plans) ? parsed.plans : [],
+    };
+  } catch (error) {
+    log.warn("failed to read research planner state", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { version: 1, plans: [] };
+  }
+}
+
+function writePlannerState(state: PlannerState): void {
+  ensurePlannerStateDir();
+  writeFileSync(getInvestingResearchPlanStateFile(), JSON.stringify(state, null, 2) + "\n", "utf-8");
+}
+
+function normalizeSymbols(symbols?: string[]): string[] {
+  const inferred = (symbols ?? [])
+    .map((symbol) => symbol.trim().toUpperCase())
+    .filter((symbol) => /^[A-Z][A-Z0-9.\-]{0,9}$/.test(symbol));
+
+  return Array.from(new Set(inferred));
+}
+
+function extractSymbolsFromObjective(objective: string): string[] {
+  const matches = objective.match(/\b[A-Z]{1,5}(?:\.[A-Z])?\b/g) ?? [];
+  return normalizeSymbols(matches);
+}
+
+export function inferInvestingResearchWorkflow(
+  objective: string,
+  explicit?: InvestingResearchWorkflowKind,
+): InvestingResearchWorkflowKind {
+  if (explicit) return explicit;
+
+  const normalized = objective.toLowerCase();
+  if (normalized.includes("earnings") && (normalized.includes("preview") || normalized.includes("pre-earnings"))) {
+    return "earnings-preview";
+  }
+  if (normalized.includes("peer") || normalized.includes("compare") || normalized.includes("comp")) {
+    return "peer-compare";
+  }
+  if (
+    normalized.includes("earnings") &&
+    (/\breview\b/.test(normalized) || normalized.includes("reaction") || /\bpost\b/.test(normalized))
+  ) {
+    return "earnings-review";
+  }
+  if (normalized.includes("earnings") || normalized.includes("preview")) {
+    return "earnings-preview";
+  }
+  if (normalized.includes("valuation") || normalized.includes("dcf") || normalized.includes("price target")) {
+    return "valuation-refresh";
+  }
+  if (normalized.includes("event") || normalized.includes("8-k") || normalized.includes("catalyst")) {
+    return "event-follow-up";
+  }
+  if (normalized.includes("thesis") || normalized.includes("refresh")) {
+    return "thesis-refresh";
+  }
+  return "company-brief";
+}
+
+function buildTask(input: {
+  id: string;
+  phase: InvestingResearchTaskPhase;
+  title: string;
+  description: string;
+  toolIds: string[];
+  dependsOn?: string[];
+  deliverable: string;
+}): InvestingResearchTask {
+  return {
+    id: input.id,
+    phase: input.phase,
+    title: input.title,
+    description: input.description,
+    toolIds: input.toolIds,
+    dependsOn: input.dependsOn ?? [],
+    deliverable: input.deliverable,
+    status: "pending",
+  };
+}
+
+function symbolLabel(symbols: string[]): string {
+  return symbols.length > 0 ? symbols.join(", ") : "coverage universe";
+}
+
+function baseTasks(symbols: string[]): InvestingResearchTask[] {
+  const scope = symbolLabel(symbols);
+  return [
+    buildTask({
+      id: "coverage-check",
+      phase: "intake",
+      title: "Confirm research scope and fresh data coverage",
+      description: `Verify ingestion health, entity coverage, and primary symbols for ${scope}.`,
+      toolIds: ["zee:invest-status", "zee:invest-scratchpad"],
+      deliverable: "Open research session with symbols, gaps, and dependencies logged.",
+    }),
+    buildTask({
+      id: "source-refresh",
+      phase: "data",
+      title: "Pull primary source delta",
+      description: `Collect the latest filings, research context, and recent data changes for ${scope}.`,
+      toolIds: ["zee:invest-sec-filings", "zee:invest-research"],
+      dependsOn: ["coverage-check"],
+      deliverable: "Primary source delta captured with timestamps and source notes.",
+    }),
+  ];
+}
+
+function companyBriefTasks(symbols: string[]): InvestingResearchTask[] {
+  const scope = symbolLabel(symbols);
+  return [
+    ...baseTasks(symbols),
+    buildTask({
+      id: "business-map",
+      phase: "analysis",
+      title: "Map business model and segment structure",
+      description: `Summarize revenue mix, segment exposure, and business model drivers for ${scope}.`,
+      toolIds: ["zee:invest-segments", "zee:invest-research"],
+      dependsOn: ["source-refresh"],
+      deliverable: "Business map with segment drivers and open questions.",
+    }),
+    buildTask({
+      id: "market-baseline",
+      phase: "analysis",
+      title: "Establish market and estimate baseline",
+      description: `Capture price action, consensus expectations, and baseline financial framing for ${scope}.`,
+      toolIds: ["zee:invest-market-data", "zee:invest-estimates"],
+      dependsOn: ["source-refresh"],
+      deliverable: "Market baseline with price context and estimate anchors.",
+    }),
+    buildTask({
+      id: "brief-synthesis",
+      phase: "synthesis",
+      title: "Produce company brief",
+      description: `Synthesize business, financial, and risk observations into a concise research brief for ${scope}.`,
+      toolIds: ["zee:invest-scratchpad"],
+      dependsOn: ["business-map", "market-baseline"],
+      deliverable: "Company brief with bull, bear, and follow-up questions.",
+    }),
+  ];
+}
+
+function earningsPreviewTasks(symbols: string[]): InvestingResearchTask[] {
+  const scope = symbolLabel(symbols);
+  return [
+    ...baseTasks(symbols),
+    buildTask({
+      id: "expectation-map",
+      phase: "analysis",
+      title: "Map consensus and management setup",
+      description: `Capture consensus expectations, management guideposts, and recent estimate changes for ${scope}.`,
+      toolIds: ["zee:invest-estimates", "zee:invest-research"],
+      dependsOn: ["source-refresh"],
+      deliverable: "Expectation map with what the market is already pricing.",
+    }),
+    buildTask({
+      id: "preview-scenarios",
+      phase: "analysis",
+      title: "Draft bull/base/bear earnings scenarios",
+      description: `Define the key debate items, scenario branches, and confirmation signals for ${scope}.`,
+      toolIds: ["zee:invest-market-data", "zee:invest-scratchpad"],
+      dependsOn: ["expectation-map"],
+      deliverable: "Scenario grid with trigger metrics and key questions for the call.",
+    }),
+    buildTask({
+      id: "preview-brief",
+      phase: "synthesis",
+      title: "Publish earnings preview brief",
+      description: `Summarize setup, key questions, and scenario-weighted expectations for ${scope}.`,
+      toolIds: ["zee:invest-scratchpad"],
+      dependsOn: ["preview-scenarios"],
+      deliverable: "Earnings preview brief ready for execution or review.",
+    }),
+  ];
+}
+
+function earningsReviewTasks(symbols: string[]): InvestingResearchTask[] {
+  const scope = symbolLabel(symbols);
+  return [
+    ...baseTasks(symbols),
+    buildTask({
+      id: "event-capture",
+      phase: "analysis",
+      title: "Capture earnings release delta",
+      description: `Document reported results, management commentary, and disclosed surprises for ${scope}.`,
+      toolIds: ["zee:invest-research", "zee:invest-sec-filings"],
+      dependsOn: ["source-refresh"],
+      deliverable: "Event delta log with reported vs expected differences.",
+    }),
+    buildTask({
+      id: "reaction-check",
+      phase: "analysis",
+      title: "Measure market and estimate reaction",
+      description: `Track price response, estimate revisions, and analyst posture after the release for ${scope}.`,
+      toolIds: ["zee:invest-market-data", "zee:invest-estimates"],
+      dependsOn: ["event-capture"],
+      deliverable: "Reaction snapshot with first-order and second-order moves.",
+    }),
+    buildTask({
+      id: "review-brief",
+      phase: "synthesis",
+      title: "Publish post-earnings review",
+      description: `Update the investment view, debate points, and next watch items for ${scope}.`,
+      toolIds: ["zee:invest-scratchpad"],
+      dependsOn: ["reaction-check"],
+      deliverable: "Post-earnings review with thesis implications and next steps.",
+    }),
+  ];
+}
+
+function thesisRefreshTasks(symbols: string[]): InvestingResearchTask[] {
+  const scope = symbolLabel(symbols);
+  return [
+    ...baseTasks(symbols),
+    buildTask({
+      id: "thesis-delta",
+      phase: "analysis",
+      title: "Compare old thesis against new evidence",
+      description: `Identify what changed in fundamentals, narrative, and risk posture for ${scope}.`,
+      toolIds: ["zee:invest-research", "zee:invest-insider-trades"],
+      dependsOn: ["source-refresh"],
+      deliverable: "Thesis delta with confirms, breaks, and unresolved items.",
+    }),
+    buildTask({
+      id: "valuation-check",
+      phase: "analysis",
+      title: "Refresh valuation anchors",
+      description: `Update price context and estimate anchors to test whether the thesis still clears the hurdle for ${scope}.`,
+      toolIds: ["zee:invest-market-data", "zee:invest-estimates"],
+      dependsOn: ["thesis-delta"],
+      deliverable: "Valuation check with current hurdle rate and sensitivity notes.",
+    }),
+    buildTask({
+      id: "thesis-refresh-brief",
+      phase: "synthesis",
+      title: "Write refreshed thesis",
+      description: `Produce an updated thesis statement, conviction view, and monitoring plan for ${scope}.`,
+      toolIds: ["zee:invest-scratchpad"],
+      dependsOn: ["valuation-check"],
+      deliverable: "Refreshed thesis with watchpoints and conviction changes.",
+    }),
+  ];
+}
+
+function valuationRefreshTasks(symbols: string[]): InvestingResearchTask[] {
+  const scope = symbolLabel(symbols);
+  return [
+    ...baseTasks(symbols),
+    buildTask({
+      id: "valuation-inputs",
+      phase: "analysis",
+      title: "Refresh operating and market inputs",
+      description: `Update the valuation baseline with price context, estimates, and the latest primary source data for ${scope}.`,
+      toolIds: ["zee:invest-market-data", "zee:invest-estimates", "zee:invest-sec-filings"],
+      dependsOn: ["source-refresh"],
+      deliverable: "Current valuation input deck with assumptions and source lineage.",
+    }),
+    buildTask({
+      id: "valuation-scenarios",
+      phase: "analysis",
+      title: "Build scenario valuation ranges",
+      description: `Define bull, base, and bear valuation ranges and identify the key assumption sensitivities for ${scope}.`,
+      toolIds: ["zee:invest-scratchpad"],
+      dependsOn: ["valuation-inputs"],
+      deliverable: "Scenario valuation table with upside/downside drivers.",
+    }),
+    buildTask({
+      id: "valuation-brief",
+      phase: "synthesis",
+      title: "Publish valuation refresh",
+      description: `Summarize the revised valuation view, key assumptions, and decision threshold for ${scope}.`,
+      toolIds: ["zee:invest-scratchpad"],
+      dependsOn: ["valuation-scenarios"],
+      deliverable: "Valuation refresh note with action thresholds and caveats.",
+    }),
+  ];
+}
+
+function eventFollowUpTasks(symbols: string[]): InvestingResearchTask[] {
+  const scope = symbolLabel(symbols);
+  return [
+    ...baseTasks(symbols),
+    buildTask({
+      id: "event-intake",
+      phase: "analysis",
+      title: "Capture event facts and primary sources",
+      description: `Identify what happened, who disclosed it, and which primary sources define the event for ${scope}.`,
+      toolIds: ["zee:invest-research", "zee:invest-sec-filings"],
+      dependsOn: ["source-refresh"],
+      deliverable: "Event fact pattern with primary-source citations.",
+    }),
+    buildTask({
+      id: "impact-map",
+      phase: "analysis",
+      title: "Map first-order and second-order impacts",
+      description: `Assess the operational, financial, and sentiment impact channels created by the event for ${scope}.`,
+      toolIds: ["zee:invest-market-data", "zee:invest-research"],
+      dependsOn: ["event-intake"],
+      deliverable: "Impact map with immediate effects and follow-on implications.",
+    }),
+    buildTask({
+      id: "event-brief",
+      phase: "synthesis",
+      title: "Publish event follow-up brief",
+      description: `Write the updated view, thesis impact, and next monitoring actions for ${scope}.`,
+      toolIds: ["zee:invest-scratchpad"],
+      dependsOn: ["impact-map"],
+      deliverable: "Event follow-up brief with monitoring triggers.",
+    }),
+  ];
+}
+
+function peerCompareTasks(symbols: string[]): InvestingResearchTask[] {
+  const scope = symbolLabel(symbols);
+  return [
+    ...baseTasks(symbols),
+    buildTask({
+      id: "peer-matrix",
+      phase: "analysis",
+      title: "Build comparable company matrix",
+      description: `Align the peer set, shared metrics, and source coverage for ${scope}.`,
+      toolIds: ["zee:invest-market-data", "zee:invest-estimates"],
+      dependsOn: ["source-refresh"],
+      deliverable: "Comparable matrix with consistent metrics across the peer set.",
+    }),
+    buildTask({
+      id: "differentiators",
+      phase: "analysis",
+      title: "Identify differentiators and edge cases",
+      description: `Highlight the operating, strategic, and valuation differences that matter across ${scope}.`,
+      toolIds: ["zee:invest-research", "zee:invest-segments"],
+      dependsOn: ["peer-matrix"],
+      deliverable: "Differentiator map with why the peer set diverges.",
+    }),
+    buildTask({
+      id: "comparison-brief",
+      phase: "synthesis",
+      title: "Publish peer comparison brief",
+      description: `Write the ranked comparison, relative valuation view, and follow-up questions for ${scope}.`,
+      toolIds: ["zee:invest-scratchpad"],
+      dependsOn: ["differentiators"],
+      deliverable: "Peer comparison brief with ranking logic and next diligence targets.",
+    }),
+  ];
+}
+
+function buildWorkflowTasks(workflow: InvestingResearchWorkflowKind, symbols: string[]): InvestingResearchTask[] {
+  switch (workflow) {
+    case "earnings-preview":
+      return earningsPreviewTasks(symbols);
+    case "earnings-review":
+      return earningsReviewTasks(symbols);
+    case "thesis-refresh":
+      return thesisRefreshTasks(symbols);
+    case "valuation-refresh":
+      return valuationRefreshTasks(symbols);
+    case "event-follow-up":
+      return eventFollowUpTasks(symbols);
+    case "peer-compare":
+      return peerCompareTasks(symbols);
+    case "company-brief":
+    default:
+      return companyBriefTasks(symbols);
+  }
+}
+
+export function buildInvestingResearchPlan(input: CreateInvestingResearchPlanInput): InvestingResearchPlan {
+  const workflow = inferInvestingResearchWorkflow(input.objective, input.workflow);
+  const symbols = normalizeSymbols(input.symbols?.length ? input.symbols : extractSymbolsFromObjective(input.objective));
+  const timestamp = new Date().toISOString();
+  const tasks = buildWorkflowTasks(workflow, symbols);
+  if (tasks.length > 0) {
+    tasks[0].status = "in_progress";
+  }
+
+  return {
+    id: `research-plan-${randomUUID().slice(0, 12)}`,
+    objective: input.objective.trim(),
+    workflow,
+    symbols,
+    status: "active",
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    tasks,
+  };
+}
+
+function updatePlanStatus(plan: InvestingResearchPlan): void {
+  if (plan.tasks.every((task) => task.status === "completed")) {
+    plan.status = "completed";
+    return;
+  }
+  if (plan.tasks.some((task) => task.status === "blocked")) {
+    plan.status = "blocked";
+    return;
+  }
+  plan.status = "active";
+}
+
+function maybeAdvanceNextTask(plan: InvestingResearchPlan): void {
+  if (plan.tasks.some((task) => task.status === "in_progress")) {
+    return;
+  }
+
+  const completed = new Set(
+    plan.tasks.filter((task) => task.status === "completed").map((task) => task.id),
+  );
+  const nextTask = plan.tasks.find(
+    (task) => task.status === "pending" && task.dependsOn.every((dependency) => completed.has(dependency)),
+  );
+  if (nextTask) {
+    nextTask.status = "in_progress";
+  }
+}
+
+export function createInvestingResearchPlan(input: CreateInvestingResearchPlanInput): InvestingResearchPlan {
+  const plan = buildInvestingResearchPlan(input);
+  const state = readPlannerState();
+  state.plans = [plan, ...state.plans].slice(0, 200);
+  writePlannerState(state);
+
+  FluxRecorder.record({
+    traceID: plan.id,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.research.plan",
+    status: "ok",
+    method: "create",
+    path: plan.workflow,
+    route: plan.id,
+    metadata: {
+      objective: plan.objective,
+      workflow: plan.workflow,
+      symbols: plan.symbols,
+      taskCount: plan.tasks.length,
+      phases: Array.from(new Set(plan.tasks.map((task) => task.phase))),
+    },
+  });
+
+  return plan;
+}
+
+export function getInvestingResearchPlan(planId: string): InvestingResearchPlan | null {
+  const state = readPlannerState();
+  return state.plans.find((plan) => plan.id === planId) ?? null;
+}
+
+export function listInvestingResearchPlans(options?: {
+  status?: InvestingResearchPlanStatus;
+  limit?: number;
+}): InvestingResearchPlan[] {
+  const state = readPlannerState();
+  const filtered = options?.status
+    ? state.plans.filter((plan) => plan.status === options.status)
+    : state.plans;
+
+  return filtered
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+    .slice(0, options?.limit ?? 20);
+}
+
+export function updateInvestingResearchTask(input: UpdateInvestingResearchTaskInput): InvestingResearchPlan {
+  const state = readPlannerState();
+  const plan = state.plans.find((entry) => entry.id === input.planId);
+  if (!plan) {
+    throw new Error(`Research plan not found: ${input.planId}`);
+  }
+
+  const task = plan.tasks.find((entry) => entry.id === input.taskId);
+  if (!task) {
+    throw new Error(`Research task not found: ${input.taskId}`);
+  }
+
+  if (input.status === "in_progress") {
+    for (const candidate of plan.tasks) {
+      if (candidate.id !== input.taskId && candidate.status === "in_progress") {
+        candidate.status = "pending";
+      }
+    }
+  }
+
+  task.status = input.status;
+  if (input.note) {
+    task.note = input.note;
+  }
+
+  if (input.status === "completed") {
+    maybeAdvanceNextTask(plan);
+  }
+  updatePlanStatus(plan);
+  plan.updatedAt = new Date().toISOString();
+  writePlannerState(state);
+
+  FluxRecorder.record({
+    traceID: plan.id,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.research.plan.task",
+    status: input.status === "blocked" ? "error" : "ok",
+    method: "update",
+    path: task.id,
+    route: plan.id,
+    metadata: {
+      workflow: plan.workflow,
+      planStatus: plan.status,
+      taskId: task.id,
+      taskTitle: task.title,
+      taskStatus: task.status,
+      note: input.note,
+      symbols: plan.symbols,
+    },
+  });
+
+  return plan;
+}

--- a/src/domain/investing/tools.ts
+++ b/src/domain/investing/tools.ts
@@ -13,6 +13,15 @@ import type { ToolDefinition, ToolRuntime, ToolExecutionContext, ToolExecutionRe
 import { Investing } from "../../paths";
 import { scratchpadTool } from "./scratchpad";
 import { getResearchContextManager, resetResearchContextManager } from "./research-context";
+import {
+  INVESTING_RESEARCH_PLAN_STATUSES,
+  INVESTING_RESEARCH_TASK_STATUSES,
+  INVESTING_RESEARCH_WORKFLOW_KINDS,
+  createInvestingResearchPlan,
+  getInvestingResearchPlan,
+  listInvestingResearchPlans,
+  updateInvestingResearchTask,
+} from "./planner";
 
 type InvestingResult = {
   ok: boolean;
@@ -471,6 +480,102 @@ export const researchTool: ToolDefinition = {
   }),
 };
 
+const ResearchPlannerParams = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("create"),
+    objective: z.string().describe("Research objective to decompose into a repeatable workflow"),
+    workflow: z.enum(INVESTING_RESEARCH_WORKFLOW_KINDS).optional()
+      .describe("Optional workflow override"),
+    symbols: z.array(z.string()).optional()
+      .describe("Ticker symbols in scope for the workflow"),
+  }),
+  z.object({
+    action: z.literal("read"),
+    planId: z.string().describe("Persisted research plan identifier"),
+  }),
+  z.object({
+    action: z.literal("list"),
+    status: z.enum(INVESTING_RESEARCH_PLAN_STATUSES).optional()
+      .describe("Optional plan status filter"),
+    limit: z.number().min(1).max(100).default(10)
+      .describe("Maximum number of plans to return"),
+  }),
+  z.object({
+    action: z.literal("update"),
+    planId: z.string().describe("Persisted research plan identifier"),
+    taskId: z.string().describe("Task identifier within the plan"),
+    status: z.enum(INVESTING_RESEARCH_TASK_STATUSES)
+      .describe("Next status for the task"),
+    note: z.string().optional()
+      .describe("Optional operator note or execution result"),
+  }),
+]);
+
+export const researchPlannerTool: ToolDefinition = {
+  id: "zee:invest-planner",
+  category: "domain",
+  init: async () => ({
+    description: `Create and manage repeatable multi-step investing research workflows. Use create before a complex Stanley-style analysis, read to reload a plan, list to inspect active work, and update as tasks progress.`,
+    parameters: ResearchPlannerParams,
+    execute: async (args, ctx): Promise<ToolExecutionResult> => {
+      switch (args.action) {
+        case "create": {
+          ctx.metadata({ title: `Planning research workflow: ${args.objective.slice(0, 48)}` });
+          const plan = createInvestingResearchPlan({
+            objective: args.objective,
+            workflow: args.workflow,
+            symbols: args.symbols,
+          });
+          return {
+            title: "Investing Research Planner",
+            metadata: { action: args.action, planId: plan.id, workflow: plan.workflow },
+            output: JSON.stringify(plan, null, 2),
+          };
+        }
+        case "read": {
+          ctx.metadata({ title: `Loading research plan ${args.planId}` });
+          const plan = getInvestingResearchPlan(args.planId);
+          return {
+            title: "Investing Research Planner",
+            metadata: { action: args.action, planId: args.planId, found: Boolean(plan) },
+            output: JSON.stringify(
+              plan ?? { error: `Research plan not found: ${args.planId}` },
+              null,
+              2,
+            ),
+          };
+        }
+        case "list": {
+          ctx.metadata({ title: "Listing investing research plans" });
+          const plans = listInvestingResearchPlans({
+            status: args.status,
+            limit: args.limit,
+          });
+          return {
+            title: "Investing Research Planner",
+            metadata: { action: args.action, count: plans.length, status: args.status },
+            output: JSON.stringify({ plans, count: plans.length }, null, 2),
+          };
+        }
+        case "update": {
+          ctx.metadata({ title: `Updating research task ${args.taskId}` });
+          const plan = updateInvestingResearchTask({
+            planId: args.planId,
+            taskId: args.taskId,
+            status: args.status,
+            note: args.note,
+          });
+          return {
+            title: "Investing Research Planner",
+            metadata: { action: args.action, planId: plan.id, status: plan.status, taskId: args.taskId },
+            output: JSON.stringify(plan, null, 2),
+          };
+        }
+      }
+    },
+  }),
+};
+
 // =============================================================================
 // Nautilus Trading Tool
 // =============================================================================
@@ -642,6 +747,7 @@ export const INVESTING_TOOLS = [
   portfolioTool,
   secFilingsTool,
   researchTool,
+  researchPlannerTool,
   nautilusTool,
   estimatesTool,
   insiderTradesTool,

--- a/src/mcp/domain/index.ts
+++ b/src/mcp/domain/index.ts
@@ -13,8 +13,8 @@ import type { ToolDefinition } from '../types';
 import { getToolRegistry } from '../registry';
 import { Log } from '../../../packages/zee/src/util/log';
 
-// MCP layer stubs (fallback implementations)
-import { InvestingMarketDataTool, InvestingResearchTool, InvestingPortfolioTool, InvestingSecFilingTool, InvestingEstimatesTool, InvestingInsiderTradesTool, InvestingSegmentsTool } from './investing';
+// Full domain implementations
+import { INVESTING_TOOLS as FULL_INVESTING_TOOLS } from '../../domain/investing/tools.js';
 import { ZeeMemoryStoreTool, ZeeMemorySearchTool, ZeeMessagingTool, ZeeNotificationTool } from './zee';
 
 const log = Log.create({ service: 'domain-tools' });
@@ -27,13 +27,7 @@ const log = Log.create({ service: 'domain-tools' });
  * Investing domain tools (zee:invest-* namespace)
  */
 export const investingTools: ToolDefinition[] = [
-  InvestingMarketDataTool,
-  InvestingResearchTool,
-  InvestingPortfolioTool,
-  InvestingSecFilingTool,
-  InvestingEstimatesTool,
-  InvestingInsiderTradesTool,
-  InvestingSegmentsTool,
+  ...(FULL_INVESTING_TOOLS as unknown as ToolDefinition[]),
 ];
 
 /**


### PR DESCRIPTION
## Summary
- add a persisted Stanley research planner with repeatable workflow templates and task-level telemetry
- expose the planner through `zee:invest-planner` and wire the MCP investing registry to the full investing tool surface
- document the operator workflow and validate with focused and full local CI plus binary verification

## Local validation
- `bash scripts/bun-audit-ci.sh`
- `bash scripts/verify-skills.sh`
- `cd packages/zee && bun run typecheck`
- `cd packages/zee && bun test ./test/investing/research-planner.test.ts ./test/investing/ingestion.test.ts`
- `cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov`
- `cd packages/zee && bun run build`
- `cd packages/zee && ./script/verify-binary.sh`

Closes #500