### PR TITLE
[child] multi-source synthesis executor with evidence linking

### DIFF
--- a/docs/architecture/investing-synthesis-executor.md
+++ b/docs/architecture/investing-synthesis-executor.md
@@ -1,0 +1,98 @@
+# Investing Synthesis Executor
+
+The investing synthesis executor turns a planned research task into a persisted execution packet with evidence links, source provenance, and a task-level synthesis note.
+
+## Scope
+
+This slice sits directly after the research planner:
+
+- planner: decide what should be done
+- executor: run the current task across relevant sources
+- later slices: richer analyst packets, event deltas, and thesis artifacts
+
+Persisted execution packets live at `~/.local/state/zee/investing/research-executions.json`.
+
+## Tool surface
+
+The executor is exposed as `zee:invest-executor`.
+
+Supported actions:
+
+- `run`
+  - inputs: `planId`, optional `taskId`
+- `read`
+  - inputs: `executionId`
+- `list`
+  - inputs: optional `planId`, optional `taskId`, optional `limit`
+
+## Execution model
+
+When `run` is called, Zee:
+
+1. Loads the research plan and resolves the active task.
+2. Maps the task's source tools into concrete source fetches.
+3. Collects evidence items from each source.
+4. Assigns stable evidence citations such as `E1`, `E2`, and stable links such as `evidence:<executionId>:E1`.
+5. Produces a synthesis note that embeds those evidence links.
+6. Appends the standard investing provenance block.
+7. Persists the execution packet and advances the task in the planner.
+
+If a task has no directly executable source tools, the executor reuses the latest evidence from dependency tasks so synthesis steps can still cite prior evidence.
+
+## Current source coverage
+
+The executor currently synthesizes across:
+
+- investing runtime health
+- SEC filings
+- research endpoint output
+- market data
+- analyst estimates
+- insider trade flow
+- segment coverage gap markers
+
+That matches the currently available investing tool surface and avoids fake citations to sources Zee did not actually call.
+
+## Output contract
+
+Each execution packet contains:
+
+- `id`
+- `planId`
+- `taskId`
+- `workflow`
+- `status`
+- `startedAt`
+- `finishedAt`
+- `synthesis`
+- `evidence[]`
+- `provenance`
+
+Each evidence item contains:
+
+- `citation`
+- `link`
+- `toolId`
+- `sourceLabel`
+- `args`
+- `status`
+- `summary`
+
+## Telemetry
+
+The executor emits Flux events under `domain=investing`:
+
+- `investing.research.execution`
+  - one event per execution run with workflow, task, and evidence counts
+- `investing.research.evidence`
+  - one event per evidence item with citation, source label, and summary
+
+The executor also relies on the planner's `investing.research.plan.task` telemetry when it marks a task `completed` or `blocked` after execution.
+
+## Operating loop
+
+1. Create a plan with `zee:invest-planner`.
+2. Run the active task with `zee:invest-executor`.
+3. Inspect the resulting `synthesis` and `evidence` links.
+4. Re-run on the next active task or override `taskId` for targeted execution.
+5. Use `read` and `list` to resume or audit research sessions.

--- a/docs/architecture/openclaw-opencode-financial-roadmap.md
+++ b/docs/architecture/openclaw-opencode-financial-roadmap.md
@@ -68,6 +68,7 @@ Exit criteria:
 - Add portfolio-linked daily and earnings briefing pipelines.
 - Add quality evaluation harness (factuality, consistency, timeliness).
 - Research workflow planner and task decomposition runbook: `docs/architecture/investing-research-planner.md`.
+- Multi-source synthesis executor runbook: `docs/architecture/investing-synthesis-executor.md`.
 
 Exit criteria:
 - End-to-end automated research run produces usable analyst packet.

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -50,6 +50,8 @@ export type FluxKind =
   | "investing.ingestion.schedule"
   | "investing.research.plan"
   | "investing.research.plan.task"
+  | "investing.research.execution"
+  | "investing.research.evidence"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"
   | "provider.fallback.used"

--- a/packages/zee/src/session/investing-provenance.ts
+++ b/packages/zee/src/session/investing-provenance.ts
@@ -33,7 +33,13 @@ function normalizeToolName(name: string): string {
 }
 
 function isInvestingTool(name: string): boolean {
-  return normalizeToolName(name).startsWith("zee_invest_")
+  const normalized = normalizeToolName(name)
+  return normalized.startsWith("zee_invest_") || normalized.startsWith("zee:invest-")
+}
+
+function isResearchTool(name: string): boolean {
+  const normalized = normalizeToolName(name)
+  return normalized === "zee_invest_research" || normalized === "zee:invest-research"
 }
 
 function isWebTool(name: string): boolean {
@@ -81,9 +87,7 @@ export function summarizeInvestingProvenance(toolTraces: ToolTrace[]): Investing
   const errorInvesting = toolTraces.filter((trace) => isInvestingTool(trace.tool) && trace.status === "error")
   const completedWeb = toolTraces.filter((trace) => isWebTool(trace.tool) && trace.status === "completed")
 
-  const primaryInvesting =
-    completedInvesting.find((trace) => normalizeToolName(trace.tool) === "zee_invest_research")?.tool ??
-    completedInvesting[0]?.tool
+  const primaryInvesting = completedInvesting.find((trace) => isResearchTool(trace.tool))?.tool ?? completedInvesting[0]?.tool
   const primaryWeb = completedWeb[0]?.tool
   const primarySource = primaryInvesting ?? primaryWeb ?? orderedToolCalls[0]
   if (!primarySource) return null

--- a/packages/zee/test/investing/research-executor.test.ts
+++ b/packages/zee/test/investing/research-executor.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import fs from "node:fs/promises"
+import { FluxRecorder } from "../../src/flux"
+import { tmpdir } from "../fixture/fixture"
+import {
+  createInvestingResearchPlan,
+  getInvestingResearchPlan,
+  updateInvestingResearchTask,
+} from "../../../../src/domain/investing/planner"
+import {
+  getInvestingResearchExecution,
+  getInvestingResearchExecutionStateFile,
+  runInvestingResearchExecution,
+} from "../../../../src/domain/investing/executor"
+import { researchExecutorTool } from "../../../../src/domain/investing/tools"
+
+function makeToolContext() {
+  return {
+    sessionId: "session-1",
+    messageId: "message-1",
+    agent: "zee",
+    abort: new AbortController().signal,
+    metadata: () => {},
+  }
+}
+
+async function withExecutorState<T>(fn: () => Promise<T>): Promise<T> {
+  await using dir = await tmpdir()
+  const originalStateHome = process.env.XDG_STATE_HOME
+  const originalFetch = globalThis.fetch
+  process.env.XDG_STATE_HOME = dir.path
+  try {
+    return await fn()
+  } finally {
+    globalThis.fetch = originalFetch
+    if (originalStateHome === undefined) {
+      delete process.env.XDG_STATE_HOME
+    } else {
+      process.env.XDG_STATE_HOME = originalStateHome
+    }
+  }
+}
+
+describe("investing research executor", () => {
+  test("runs a multi-source task, persists evidence links, and advances the planner", async () => {
+    await withExecutorState(async () => {
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.endsWith("/api/accounting/NVDA/filings")) {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              data: [{ form: "10-K", filedAt: "2026-02-20" }],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        if (url.endsWith("/api/research/NVDA")) {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              data: { symbol: "NVDA", summary: "Demand for AI infrastructure remains strong." },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        throw new Error(`Unexpected URL ${url}`)
+      }) as typeof fetch
+
+      const recordSpy = spyOn(FluxRecorder, "record")
+      const plan = createInvestingResearchPlan({
+        objective: "Prepare a pre-earnings preview for NVDA",
+      })
+      updateInvestingResearchTask({
+        planId: plan.id,
+        taskId: "coverage-check",
+        status: "completed",
+      })
+
+      const execution = await runInvestingResearchExecution({ planId: plan.id })
+
+      expect(execution.taskId).toBe("source-refresh")
+      expect(execution.status).toBe("ok")
+      expect(execution.evidence).toHaveLength(2)
+      expect(execution.evidence[0]?.citation).toBe("E1")
+      expect(execution.evidence[1]?.citation).toBe("E2")
+      expect(execution.synthesis).toContain("[E1]")
+      expect(execution.synthesis).toContain("[E2]")
+      expect(execution.synthesis).toContain("Source Used:")
+      expect(execution.synthesis).toContain("Primary source: zee:invest-research")
+      expect(getInvestingResearchExecution(execution.id)?.id).toBe(execution.id)
+
+      const persisted = JSON.parse(await fs.readFile(getInvestingResearchExecutionStateFile(), "utf8")) as {
+        executions: Array<{ id: string }>
+      }
+      expect(persisted.executions[0]?.id).toBe(execution.id)
+
+      const updatedPlan = getInvestingResearchPlan(plan.id)
+      expect(updatedPlan?.tasks.find((task) => task.id === "source-refresh")?.status).toBe("completed")
+      expect(updatedPlan?.tasks.find((task) => task.id === "expectation-map")?.status).toBe("in_progress")
+
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.research.execution")).toBe(true)
+      expect(recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.research.evidence")).toHaveLength(2)
+    })
+  })
+
+  test("tool surface can run, read, and list executions", async () => {
+    await withExecutorState(async () => {
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.endsWith("/api/accounting/NVDA/filings")) {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              data: [{ form: "10-Q", filedAt: "2026-03-01" }],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        if (url.endsWith("/api/research/NVDA")) {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              data: { symbol: "NVDA", headline: "Consensus nudging higher" },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        throw new Error(`Unexpected URL ${url}`)
+      }) as typeof fetch
+
+      const plan = createInvestingResearchPlan({
+        objective: "Prepare a pre-earnings preview for NVDA",
+      })
+      updateInvestingResearchTask({
+        planId: plan.id,
+        taskId: "coverage-check",
+        status: "completed",
+      })
+
+      const runtime = await researchExecutorTool.init()
+      const ctx = makeToolContext()
+      const runResult = await runtime.execute(
+        {
+          action: "run",
+          planId: plan.id,
+          taskId: "source-refresh",
+        },
+        ctx,
+      )
+      const execution = JSON.parse(runResult.output) as { id: string; taskId: string }
+      expect(execution.taskId).toBe("source-refresh")
+
+      const readResult = await runtime.execute(
+        {
+          action: "read",
+          executionId: execution.id,
+        },
+        ctx,
+      )
+      expect(JSON.parse(readResult.output)).toMatchObject({
+        id: execution.id,
+      })
+
+      const listResult = await runtime.execute(
+        {
+          action: "list",
+          planId: plan.id,
+          limit: 5,
+        },
+        ctx,
+      )
+      const listed = JSON.parse(listResult.output) as {
+        count: number
+        executions: Array<{ id: string }>
+      }
+      expect(listed.count).toBeGreaterThan(0)
+      expect(listed.executions.some((entry) => entry.id === execution.id)).toBe(true)
+    })
+  })
+})

--- a/packages/zee/test/session/investing-provenance.test.ts
+++ b/packages/zee/test/session/investing-provenance.test.ts
@@ -40,6 +40,21 @@ describe("session.investing-provenance", () => {
     expect(summary.toolCalls).toEqual(["zee_invest_market", "zee_invest_research", "websearch", "webfetch"])
   })
 
+  test("supports colon-namespaced investing tools", () => {
+    const summary = summarizeInvestingProvenance([
+      { tool: "zee:invest-market-data", status: "completed" },
+      { tool: "zee:invest-research", status: "completed" },
+      { tool: "websearch", status: "completed" },
+    ])
+
+    expect(summary).toBeDefined()
+    if (!summary) throw new Error("summary should be defined")
+
+    expect(summary.primarySource).toBe("zee:invest-research")
+    expect(summary.fallbackUsed).toBe(true)
+    expect(summary.toolCalls).toEqual(["zee:invest-market-data", "zee:invest-research", "websearch"])
+  })
+
   test("summarizes web fallback when investing fails", () => {
     const summary = summarizeInvestingProvenance([
       { tool: "zee_invest_research", status: "error", error: "connection refused" },

--- a/src/agent/assistants.ts
+++ b/src/agent/assistants.ts
@@ -99,6 +99,7 @@ export const ZEE_AGENT_CONFIG: AgentConfig = {
     "zee:invest-portfolio": true,
     "zee:invest-research": true,
     "zee:invest-planner": true,
+    "zee:invest-executor": true,
     "zee:invest-sec-filings": true,
     "zee:invest-nautilus": true,
     "zee:invest-estimates": true,

--- a/src/awareness/tool-catalog.ts
+++ b/src/awareness/tool-catalog.ts
@@ -47,6 +47,7 @@ const AGENT_PRIMARY_TOOLS: Record<string, string[]> = {
     "zee:invest-sec-filings",
     "zee:invest-research",
     "zee:invest-planner",
+    "zee:invest-executor",
     "zee:invest-estimates",
     "zee:invest-insider-trades",
     "zee:invest-segments",

--- a/src/domain/investing/executor.ts
+++ b/src/domain/investing/executor.ts
@@ -1,0 +1,513 @@
+/**
+ * Investing Research Synthesis Executor
+ *
+ * Executes planner steps across multiple investing sources, persists
+ * evidence-linked synthesis packets, and advances the underlying workflow.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { FluxRecorder } from "../../../packages/zee/src/flux";
+import {
+  appendInvestingProvenance,
+  summarizeInvestingProvenance,
+  type InvestingProvenanceSummary,
+  type ToolTrace,
+} from "../../../packages/zee/src/session/investing-provenance";
+import { Log } from "../../../packages/zee/src/util/log";
+import { Investing } from "../../paths";
+import {
+  getInvestingResearchPlan,
+  updateInvestingResearchTask,
+  type InvestingResearchPlan,
+  type InvestingResearchTask,
+} from "./planner";
+
+const log = Log.create({ service: "investing:research-executor" });
+
+export type InvestingResearchExecutionStatus = "ok" | "error";
+export type InvestingResearchEvidenceStatus = "completed" | "error";
+
+export interface InvestingResearchEvidence {
+  id: string;
+  citation: string;
+  link: string;
+  toolId: string;
+  sourceLabel: string;
+  args: Record<string, unknown>;
+  collectedAt: string;
+  status: InvestingResearchEvidenceStatus;
+  summary: string;
+  data?: unknown;
+  error?: string;
+}
+
+export interface InvestingResearchExecution {
+  id: string;
+  planId: string;
+  taskId: string;
+  workflow: string;
+  status: InvestingResearchExecutionStatus;
+  startedAt: string;
+  finishedAt: string;
+  synthesis: string;
+  evidence: InvestingResearchEvidence[];
+  provenance: InvestingProvenanceSummary | null;
+}
+
+type ExecutionState = {
+  version: 1;
+  executions: InvestingResearchExecution[];
+};
+
+type InvestingRequestResult = {
+  ok: boolean;
+  data?: unknown;
+  error?: string;
+};
+
+export type RunInvestingResearchExecutionInput = {
+  planId: string;
+  taskId?: string;
+};
+
+function getExecutorStateDir(): string {
+  const stateDir = process.env.XDG_STATE_HOME
+    ? path.join(process.env.XDG_STATE_HOME, "zee")
+    : path.join(os.homedir(), ".local", "state", "zee");
+  return path.join(stateDir, "investing");
+}
+
+export function getInvestingResearchExecutionStateFile(): string {
+  return path.join(getExecutorStateDir(), "research-executions.json");
+}
+
+function ensureExecutorStateDir(): void {
+  mkdirSync(getExecutorStateDir(), { recursive: true });
+}
+
+function readExecutionState(): ExecutionState {
+  const filePath = getInvestingResearchExecutionStateFile();
+  if (!existsSync(filePath)) {
+    return { version: 1, executions: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as ExecutionState;
+    return {
+      version: 1,
+      executions: Array.isArray(parsed.executions) ? parsed.executions : [],
+    };
+  } catch (error) {
+    log.warn("failed to read research execution state", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { version: 1, executions: [] };
+  }
+}
+
+function writeExecutionState(state: ExecutionState): void {
+  ensureExecutorStateDir();
+  writeFileSync(getInvestingResearchExecutionStateFile(), JSON.stringify(state, null, 2) + "\n", "utf-8");
+}
+
+function normalizeSymbol(symbol?: string): string | undefined {
+  const trimmed = symbol?.trim().toUpperCase();
+  if (!trimmed) return undefined;
+  return trimmed;
+}
+
+async function requestInvesting(pathname: string, init?: RequestInit): Promise<InvestingRequestResult> {
+  try {
+    const baseUrl = Investing.apiUrl().replace(/\/+$/, "");
+    const response = await fetch(`${baseUrl}${pathname}`, {
+      ...init,
+      headers: {
+        "content-type": "application/json",
+        ...(init?.headers ?? {}),
+      },
+    });
+    const text = await response.text();
+    const payload = text ? (JSON.parse(text) as { success?: boolean; data?: unknown; error?: string } | unknown) : null;
+
+    if (payload && typeof payload === "object" && "success" in payload && "data" in payload) {
+      const envelope = payload as { success: boolean; data: unknown; error?: string };
+      if (!response.ok || !envelope.success) {
+        return {
+          ok: false,
+          error: envelope.error || `Investing request failed with status ${response.status}`,
+        };
+      }
+      return { ok: true, data: envelope.data };
+    }
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: text || `Investing request failed with status ${response.status}`,
+      };
+    }
+
+    return { ok: true, data: payload };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function summarizeEvidenceData(data: unknown): string {
+  if (data == null) return "No data returned.";
+  if (typeof data === "string") {
+    return data.length <= 180 ? data : `${data.slice(0, 180)}...`;
+  }
+  if (Array.isArray(data)) {
+    return `${data.length} record(s) collected.`;
+  }
+  if (typeof data === "object") {
+    const record = data as Record<string, unknown>;
+    if (typeof record.symbol === "string") {
+      return `Symbol ${record.symbol} with fields: ${Object.keys(record).slice(0, 4).join(", ")}.`;
+    }
+    if (typeof record.note === "string") {
+      return record.note;
+    }
+    const keys = Object.keys(record);
+    return keys.length > 0
+      ? `Object fields: ${keys.slice(0, 5).join(", ")}.`
+      : "Structured object with no top-level fields.";
+  }
+  return String(data);
+}
+
+function latestDependencyEvidence(
+  state: ExecutionState,
+  plan: InvestingResearchPlan,
+  task: InvestingResearchTask,
+): InvestingResearchEvidence[] {
+  return task.dependsOn.flatMap((dependency) => {
+    const latest = state.executions.find((execution) => execution.planId === plan.id && execution.taskId === dependency);
+    return latest?.evidence ?? [];
+  });
+}
+
+function createEvidenceLink(executionId: string, index: number): { id: string; citation: string; link: string } {
+  const citation = `E${index + 1}`;
+  return {
+    id: `${executionId}:${citation}`,
+    citation,
+    link: `evidence:${executionId}:${citation}`,
+  };
+}
+
+function sourceLabelForTool(toolId: string): string {
+  switch (toolId) {
+    case "zee:invest-status":
+      return "Investing runtime health";
+    case "zee:invest-sec-filings":
+      return "SEC filings";
+    case "zee:invest-research":
+      return "Research endpoint";
+    case "zee:invest-market-data":
+      return "Market data";
+    case "zee:invest-estimates":
+      return "Analyst estimates";
+    case "zee:invest-insider-trades":
+      return "Insider trades";
+    case "zee:invest-segments":
+      return "Business segments";
+    default:
+      return toolId;
+  }
+}
+
+async function collectToolEvidence(input: {
+  plan: InvestingResearchPlan;
+  task: InvestingResearchTask;
+  toolId: string;
+}): Promise<{ args: Record<string, unknown>; result: InvestingRequestResult }> {
+  const primarySymbol = normalizeSymbol(input.plan.symbols[0]);
+
+  switch (input.toolId) {
+    case "zee:invest-status":
+      return {
+        args: {},
+        result: await requestInvesting("/api/health"),
+      };
+    case "zee:invest-sec-filings":
+      if (!primarySymbol) {
+        return {
+          args: {},
+          result: { ok: false, error: "A symbol is required for SEC filings execution." },
+        };
+      }
+      return {
+        args: { ticker: primarySymbol, formType: "all" },
+        result: await requestInvesting(`/api/accounting/${primarySymbol}/filings`),
+      };
+    case "zee:invest-research":
+      if (primarySymbol) {
+        return {
+          args: { query: primarySymbol },
+          result: await requestInvesting(`/api/research/${primarySymbol}`),
+        };
+      }
+      return {
+        args: { query: input.plan.objective },
+        result: {
+          ok: true,
+          data: {
+            objective: input.plan.objective,
+            note: "No explicit symbol in plan scope; research query remains objective-scoped.",
+          },
+        },
+      };
+    case "zee:invest-market-data":
+      if (!primarySymbol) {
+        return {
+          args: {},
+          result: { ok: false, error: "A symbol is required for market data execution." },
+        };
+      }
+      return {
+        args: { symbol: primarySymbol, dataType: "fundamentals" },
+        result: await requestInvesting(`/api/market/${primarySymbol}`),
+      };
+    case "zee:invest-estimates":
+      if (!primarySymbol) {
+        return {
+          args: {},
+          result: { ok: false, error: "A symbol is required for estimates execution." },
+        };
+      }
+      return {
+        args: { symbol: primarySymbol, estimateType: "consensus" },
+        result: await requestInvesting(`/api/valuation/${primarySymbol}`),
+      };
+    case "zee:invest-insider-trades":
+      if (!primarySymbol) {
+        return {
+          args: {},
+          result: { ok: false, error: "A symbol is required for insider trade execution." },
+        };
+      }
+      return {
+        args: { symbol: primarySymbol, limit: 10 },
+        result: await requestInvesting(`/api/institutional/${primarySymbol}/smart-money-flow`),
+      };
+    case "zee:invest-segments":
+      return {
+        args: { symbol: primarySymbol, segmentType: "business" },
+        result: {
+          ok: true,
+          data: {
+            symbol: primarySymbol,
+            note: "Segment detail is not yet exposed on the investing HTTP surface; preserve as a planner-linked gap.",
+          },
+        },
+      };
+    default:
+      return {
+        args: {},
+        result: {
+          ok: true,
+          data: {
+            note: `Execution for ${input.toolId} is operator-managed or not directly automatable in this slice.`,
+          },
+        },
+      };
+  }
+}
+
+function buildSynthesis(input: {
+  plan: InvestingResearchPlan;
+  task: InvestingResearchTask;
+  evidence: InvestingResearchEvidence[];
+  provenance: InvestingProvenanceSummary | null;
+}): string {
+  const evidenceLines =
+    input.evidence.length > 0
+      ? input.evidence
+          .map((item) => `- [${item.citation}] ${item.sourceLabel} (${item.link}): ${item.summary}`)
+          .join("\n")
+      : "- No evidence items were collected."
+
+  const synthesis = [
+    `${input.task.title}`,
+    `Objective: ${input.plan.objective}`,
+    `Workflow: ${input.plan.workflow}`,
+    `Deliverable: ${input.task.deliverable}`,
+    "",
+    "Evidence Links:",
+    evidenceLines,
+  ].join("\n");
+
+  return input.provenance ? appendInvestingProvenance(synthesis, input.provenance) : synthesis;
+}
+
+function resolveTask(plan: InvestingResearchPlan, taskId?: string): InvestingResearchTask {
+  if (taskId) {
+    const explicit = plan.tasks.find((task) => task.id === taskId);
+    if (!explicit) {
+      throw new Error(`Research task not found: ${taskId}`);
+    }
+    return explicit;
+  }
+
+  return (
+    plan.tasks.find((task) => task.status === "in_progress") ??
+    plan.tasks.find((task) => task.status === "pending") ??
+    plan.tasks[0]
+  );
+}
+
+export async function runInvestingResearchExecution(
+  input: RunInvestingResearchExecutionInput,
+): Promise<InvestingResearchExecution> {
+  const plan = getInvestingResearchPlan(input.planId);
+  if (!plan) {
+    throw new Error(`Research plan not found: ${input.planId}`);
+  }
+
+  const task = resolveTask(plan, input.taskId);
+  const executionId = `research-execution-${randomUUID().slice(0, 12)}`;
+  const startedAt = new Date().toISOString();
+  const state = readExecutionState();
+  const evidence: InvestingResearchEvidence[] = [];
+  const toolTraces: ToolTrace[] = [];
+
+  const executableToolIds = task.toolIds.filter((toolId) => toolId !== "zee:invest-scratchpad");
+  for (const toolId of executableToolIds) {
+    const { args, result } = await collectToolEvidence({ plan, task, toolId });
+    const ref = createEvidenceLink(executionId, evidence.length);
+    const item: InvestingResearchEvidence = {
+      ...ref,
+      toolId,
+      sourceLabel: sourceLabelForTool(toolId),
+      args,
+      collectedAt: new Date().toISOString(),
+      status: result.ok ? "completed" : "error",
+      summary: result.ok ? summarizeEvidenceData(result.data) : result.error || "Execution failed.",
+      data: result.data,
+      error: result.error,
+    };
+    evidence.push(item);
+    toolTraces.push({
+      tool: toolId,
+      status: result.ok ? "completed" : "error",
+      error: result.error,
+    });
+
+  }
+
+  if (evidence.length === 0) {
+    const dependencyEvidence = latestDependencyEvidence(state, plan, task);
+    for (const [index, source] of dependencyEvidence.entries()) {
+      evidence.push({
+        ...source,
+        ...createEvidenceLink(executionId, index),
+      });
+      toolTraces.push({
+        tool: source.toolId,
+        status: source.status === "completed" ? "completed" : "error",
+        error: source.error,
+      });
+    }
+  }
+
+  for (const item of evidence) {
+    FluxRecorder.record({
+      traceID: executionId,
+      direction: "internal",
+      domain: "investing",
+      kind: "investing.research.evidence",
+      status: item.status === "completed" ? "ok" : "error",
+      method: "collect",
+      path: item.toolId,
+      route: item.link,
+      metadata: {
+        planId: plan.id,
+        taskId: task.id,
+        citation: item.citation,
+        sourceLabel: item.sourceLabel,
+        summary: item.summary,
+      },
+      error: item.error ? { message: item.error } : undefined,
+    });
+  }
+
+  const finishedAt = new Date().toISOString();
+  const provenance = summarizeInvestingProvenance(toolTraces);
+  const status: InvestingResearchExecutionStatus = evidence.some((item) => item.status === "completed")
+    ? "ok"
+    : "error";
+  const execution: InvestingResearchExecution = {
+    id: executionId,
+    planId: plan.id,
+    taskId: task.id,
+    workflow: plan.workflow,
+    status,
+    startedAt,
+    finishedAt,
+    synthesis: buildSynthesis({
+      plan,
+      task,
+      evidence,
+      provenance,
+    }),
+    evidence,
+    provenance,
+  };
+
+  state.executions = [execution, ...state.executions].slice(0, 500);
+  writeExecutionState(state);
+
+  FluxRecorder.record({
+    traceID: execution.id,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.research.execution",
+    status: execution.status === "ok" ? "ok" : "error",
+    method: "run",
+    path: task.id,
+    route: execution.id,
+    metadata: {
+      planId: plan.id,
+      workflow: plan.workflow,
+      evidenceCount: evidence.length,
+      taskTitle: task.title,
+    },
+  });
+
+  updateInvestingResearchTask({
+    planId: plan.id,
+    taskId: task.id,
+    status: execution.status === "ok" ? "completed" : "blocked",
+    note:
+      execution.status === "ok"
+        ? `Execution ${execution.id} collected ${evidence.length} evidence item(s).`
+        : `Execution ${execution.id} failed to collect usable evidence.`,
+  });
+
+  return execution;
+}
+
+export function getInvestingResearchExecution(executionId: string): InvestingResearchExecution | null {
+  const state = readExecutionState();
+  return state.executions.find((execution) => execution.id === executionId) ?? null;
+}
+
+export function listInvestingResearchExecutions(options?: {
+  planId?: string;
+  taskId?: string;
+  limit?: number;
+}): InvestingResearchExecution[] {
+  const state = readExecutionState();
+  return state.executions
+    .filter((execution) => (options?.planId ? execution.planId === options.planId : true))
+    .filter((execution) => (options?.taskId ? execution.taskId === options.taskId : true))
+    .slice(0, options?.limit ?? 20);
+}

--- a/src/domain/investing/tools.ts
+++ b/src/domain/investing/tools.ts
@@ -22,6 +22,11 @@ import {
   listInvestingResearchPlans,
   updateInvestingResearchTask,
 } from "./planner";
+import {
+  getInvestingResearchExecution,
+  listInvestingResearchExecutions,
+  runInvestingResearchExecution,
+} from "./executor";
 
 type InvestingResult = {
   ok: boolean;
@@ -576,6 +581,75 @@ export const researchPlannerTool: ToolDefinition = {
   }),
 };
 
+const ResearchExecutorParams = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("run"),
+    planId: z.string().describe("Persisted research plan identifier"),
+    taskId: z.string().optional().describe("Optional task override; defaults to the active task"),
+  }),
+  z.object({
+    action: z.literal("read"),
+    executionId: z.string().describe("Persisted execution identifier"),
+  }),
+  z.object({
+    action: z.literal("list"),
+    planId: z.string().optional().describe("Optional plan filter"),
+    taskId: z.string().optional().describe("Optional task filter"),
+    limit: z.number().min(1).max(100).default(10).describe("Maximum number of executions to return"),
+  }),
+]);
+
+export const researchExecutorTool: ToolDefinition = {
+  id: "zee:invest-executor",
+  category: "domain",
+  init: async () => ({
+    description: `Execute investing research workflow steps across multiple sources, persist evidence-linked synthesis packets, and advance the underlying planner state.`,
+    parameters: ResearchExecutorParams,
+    execute: async (args, ctx): Promise<ToolExecutionResult> => {
+      switch (args.action) {
+        case "run": {
+          ctx.metadata({ title: `Running research execution for ${args.planId}` });
+          const execution = await runInvestingResearchExecution({
+            planId: args.planId,
+            taskId: args.taskId,
+          });
+          return {
+            title: "Investing Research Executor",
+            metadata: { action: args.action, executionId: execution.id, planId: execution.planId, status: execution.status },
+            output: JSON.stringify(execution, null, 2),
+          };
+        }
+        case "read": {
+          ctx.metadata({ title: `Loading research execution ${args.executionId}` });
+          const execution = getInvestingResearchExecution(args.executionId);
+          return {
+            title: "Investing Research Executor",
+            metadata: { action: args.action, executionId: args.executionId, found: Boolean(execution) },
+            output: JSON.stringify(
+              execution ?? { error: `Research execution not found: ${args.executionId}` },
+              null,
+              2,
+            ),
+          };
+        }
+        case "list": {
+          ctx.metadata({ title: "Listing research executions" });
+          const executions = listInvestingResearchExecutions({
+            planId: args.planId,
+            taskId: args.taskId,
+            limit: args.limit,
+          });
+          return {
+            title: "Investing Research Executor",
+            metadata: { action: args.action, count: executions.length, planId: args.planId, taskId: args.taskId },
+            output: JSON.stringify({ executions, count: executions.length }, null, 2),
+          };
+        }
+      }
+    },
+  }),
+};
+
 // =============================================================================
 // Nautilus Trading Tool
 // =============================================================================
@@ -748,6 +822,7 @@ export const INVESTING_TOOLS = [
   secFilingsTool,
   researchTool,
   researchPlannerTool,
+  researchExecutorTool,
   nautilusTool,
   estimatesTool,
   insiderTradesTool,


### PR DESCRIPTION
## Summary
- add a persisted investing research executor that runs planner tasks against the investing HTTP surface and stores evidence-linked synthesis packets
- expose the new `zee:invest-executor` tool, extend investing provenance for colon-namespaced tools, and emit execution/evidence telemetry
- document the executor operating model and cover it with fixture-backed tests

## Local verification
- `bash scripts/bun-audit-ci.sh`
- `bash scripts/verify-skills.sh`
- `cd packages/zee && bun run typecheck`
- `cd packages/zee && bun test ./test/investing/research-executor.test.ts ./test/investing/research-planner.test.ts ./test/session/investing-provenance.test.ts`
- `cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov`
- `cd packages/zee && bun run build`
- `cd packages/zee && ./script/verify-binary.sh`

Closes #501
