### PR TITLE
[child] structured report artifacts and failure diagnostics

### DIFF
--- a/docs/architecture/investing-report-artifacts.md
+++ b/docs/architecture/investing-report-artifacts.md
@@ -1,0 +1,95 @@
+# Investing Report Artifacts
+
+Structured investing report artifacts sit on top of the research planner and synthesis executor. They turn each persisted execution into a stable JSON contract that operators and future evals can score without reparsing freeform notes.
+
+## Implementation plan
+
+This slice adds three things:
+
+1. A local artifact store at `~/.local/state/zee/investing/research-artifacts.json`.
+2. Automatic artifact generation after every research execution.
+3. Actionable diagnostics for degraded or failed runs, plus a read/list tool surface.
+
+## Artifact contract
+
+Each artifact includes:
+
+- `id`
+- `executionId`
+- `planId`
+- `taskId`
+- `workflow`
+- `kind`
+- `status`
+- `title`
+- `objective`
+- `symbols`
+- `summary`
+- `sections[]`
+- `citations[]`
+- `nextActions[]`
+- `diagnostics[]`
+
+Artifact kinds map to workflow phases:
+
+- `scope-note`
+- `source-delta`
+- `analysis-memo`
+- `research-brief`
+- `failure-diagnostic`
+
+Artifact status signals rollout quality:
+
+- `ready`: all evidence sources completed
+- `degraded`: execution completed but one or more evidence sources failed
+- `failed`: no usable evidence was collected
+
+## Diagnostics model
+
+Every degraded or failed run emits structured diagnostics with:
+
+- the affected tool or source
+- the failure detail
+- an operator action
+- an optional command hint
+
+Current remediations focus on:
+
+- missing symbol scope
+- investing runtime or connector failures
+- stale or missing ingestion coverage
+- blocked downstream plan tasks
+
+## Tool surface
+
+Artifacts are exposed as `zee:invest-artifacts`.
+
+Supported actions:
+
+- `create`
+  - inputs: `executionId`, optional `overwrite`
+- `read`
+  - inputs: `artifactId`
+- `list`
+  - inputs: optional `planId`, optional `taskId`, optional `executionId`, optional `status`, optional `limit`
+
+The executor also auto-generates an artifact after each run and stores the resulting `artifactId` on the execution packet.
+
+## Telemetry
+
+This slice emits:
+
+- `investing.research.artifact`
+  - one event per generated or refreshed artifact
+- `investing.research.diagnostic`
+  - one event per diagnostic emitted for degraded or failed runs
+
+These events give operators a stable control-plane signal for future eval gates and reliability review.
+
+## Operating loop
+
+1. Create a plan with `zee:invest-planner`.
+2. Run a task with `zee:invest-executor`.
+3. Read the generated artifact via `zee:invest-artifacts`.
+4. If the artifact is `degraded` or `failed`, follow `diagnostics[]` and `nextActions[]`.
+5. Rerun the execution once coverage is restored.

--- a/docs/architecture/openclaw-opencode-financial-roadmap.md
+++ b/docs/architecture/openclaw-opencode-financial-roadmap.md
@@ -69,6 +69,7 @@ Exit criteria:
 - Add quality evaluation harness (factuality, consistency, timeliness).
 - Research workflow planner and task decomposition runbook: `docs/architecture/investing-research-planner.md`.
 - Multi-source synthesis executor runbook: `docs/architecture/investing-synthesis-executor.md`.
+- Structured report artifacts and diagnostics runbook: `docs/architecture/investing-report-artifacts.md`.
 
 Exit criteria:
 - End-to-end automated research run produces usable analyst packet.

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -52,6 +52,8 @@ export type FluxKind =
   | "investing.research.plan.task"
   | "investing.research.execution"
   | "investing.research.evidence"
+  | "investing.research.artifact"
+  | "investing.research.diagnostic"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"
   | "provider.fallback.used"

--- a/packages/zee/test/investing/research-artifacts.test.ts
+++ b/packages/zee/test/investing/research-artifacts.test.ts
@@ -1,19 +1,15 @@
 import { describe, expect, spyOn, test } from "bun:test"
-import fs from "node:fs/promises"
 import { FluxRecorder } from "../../src/flux"
 import { tmpdir } from "../fixture/fixture"
 import {
   createInvestingResearchPlan,
-  getInvestingResearchPlan,
   updateInvestingResearchTask,
 } from "../../../../src/domain/investing/planner"
+import { runInvestingResearchExecution } from "../../../../src/domain/investing/executor"
 import {
-  getInvestingResearchExecution,
-  getInvestingResearchExecutionStateFile,
-  runInvestingResearchExecution,
-} from "../../../../src/domain/investing/executor"
+  researchArtifactsTool,
+} from "../../../../src/domain/investing/tools"
 import { getInvestingResearchArtifact } from "../../../../src/domain/investing/artifacts"
-import { researchExecutorTool } from "../../../../src/domain/investing/tools"
 
 function makeToolContext() {
   return {
@@ -25,7 +21,7 @@ function makeToolContext() {
   }
 }
 
-async function withExecutorState<T>(fn: () => Promise<T>): Promise<T> {
+async function withArtifactState<T>(fn: () => Promise<T>): Promise<T> {
   await using dir = await tmpdir()
   const originalStateHome = process.env.XDG_STATE_HOME
   const originalFetch = globalThis.fetch
@@ -42,9 +38,10 @@ async function withExecutorState<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
-describe("investing research executor", () => {
-  test("runs a multi-source task, persists evidence links, and advances the planner", async () => {
-    await withExecutorState(async () => {
+describe("investing research artifacts", () => {
+  test("creates a structured artifact for a successful execution", async () => {
+    await withArtifactState(async () => {
+      const recordSpy = spyOn(FluxRecorder, "record")
       globalThis.fetch = (async (input: RequestInfo | URL) => {
         const url = String(input)
         if (url.endsWith("/api/accounting/NVDA/filings")) {
@@ -60,7 +57,7 @@ describe("investing research executor", () => {
           return new Response(
             JSON.stringify({
               success: true,
-              data: { symbol: "NVDA", summary: "Demand for AI infrastructure remains strong." },
+              data: { symbol: "NVDA", summary: "Demand remains strong." },
             }),
             { status: 200, headers: { "content-type": "application/json" } },
           )
@@ -68,7 +65,6 @@ describe("investing research executor", () => {
         throw new Error(`Unexpected URL ${url}`)
       }) as typeof fetch
 
-      const recordSpy = spyOn(FluxRecorder, "record")
       const plan = createInvestingResearchPlan({
         objective: "Prepare a pre-earnings preview for NVDA",
       })
@@ -79,36 +75,55 @@ describe("investing research executor", () => {
       })
 
       const execution = await runInvestingResearchExecution({ planId: plan.id })
-
-      expect(execution.taskId).toBe("source-refresh")
-      expect(execution.status).toBe("ok")
-      expect(execution.evidence).toHaveLength(2)
-      expect(execution.evidence[0]?.citation).toBe("E1")
-      expect(execution.evidence[1]?.citation).toBe("E2")
-      expect(execution.synthesis).toContain("[E1]")
-      expect(execution.synthesis).toContain("[E2]")
-      expect(execution.synthesis).toContain("Source Used:")
-      expect(execution.synthesis).toContain("Primary source: zee:invest-research")
       expect(execution.artifactId).toBeDefined()
-      expect(getInvestingResearchArtifact(execution.artifactId!)?.executionId).toBe(execution.id)
-      expect(getInvestingResearchExecution(execution.id)?.id).toBe(execution.id)
 
-      const persisted = JSON.parse(await fs.readFile(getInvestingResearchExecutionStateFile(), "utf8")) as {
-        executions: Array<{ id: string }>
-      }
-      expect(persisted.executions[0]?.id).toBe(execution.id)
+      const artifact = getInvestingResearchArtifact(execution.artifactId!)
+      expect(artifact).toBeDefined()
+      if (!artifact) throw new Error("artifact should be defined")
 
-      const updatedPlan = getInvestingResearchPlan(plan.id)
-      expect(updatedPlan?.tasks.find((task) => task.id === "source-refresh")?.status).toBe("completed")
-      expect(updatedPlan?.tasks.find((task) => task.id === "expectation-map")?.status).toBe("in_progress")
-
-      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.research.execution")).toBe(true)
-      expect(recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.research.evidence").length).toBeGreaterThanOrEqual(2)
+      expect(artifact.kind).toBe("source-delta")
+      expect(artifact.status).toBe("ready")
+      expect(artifact.sections.map((section) => section.title)).toEqual(["Overview", "Synthesis", "Evidence"])
+      expect(artifact.citations.map((item) => item.citation)).toEqual(["E1", "E2"])
+      expect(artifact.nextActions).toContain("Run the next task: Map consensus and management setup.")
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.research.artifact")).toBe(true)
     })
   })
 
-  test("tool surface can run, read, and list executions", async () => {
-    await withExecutorState(async () => {
+  test("captures actionable diagnostics for failed runs", async () => {
+    await withArtifactState(async () => {
+      const recordSpy = spyOn(FluxRecorder, "record")
+      globalThis.fetch = (async () => {
+        throw new Error("connection refused")
+      }) as typeof fetch
+
+      const plan = createInvestingResearchPlan({
+        objective: "Prepare a pre-earnings preview for NVDA",
+      })
+      updateInvestingResearchTask({
+        planId: plan.id,
+        taskId: "coverage-check",
+        status: "completed",
+      })
+
+      const execution = await runInvestingResearchExecution({ planId: plan.id })
+      const artifact = getInvestingResearchArtifact(execution.artifactId!)
+
+      expect(execution.status).toBe("error")
+      expect(artifact).toBeDefined()
+      if (!artifact) throw new Error("artifact should be defined")
+
+      expect(artifact.kind).toBe("failure-diagnostic")
+      expect(artifact.status).toBe("failed")
+      expect(artifact.diagnostics.length).toBeGreaterThanOrEqual(2)
+      expect(artifact.sections.some((section) => section.title === "Diagnostics")).toBe(true)
+      expect(artifact.diagnostics.some((diagnostic) => diagnostic.command === "zee investing ingest status")).toBe(true)
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.research.diagnostic")).toBe(true)
+    })
+  })
+
+  test("tool surface can create, read, and list artifacts", async () => {
+    await withArtifactState(async () => {
       globalThis.fetch = (async (input: RequestInfo | URL) => {
         const url = String(input)
         if (url.endsWith("/api/accounting/NVDA/filings")) {
@@ -124,7 +139,7 @@ describe("investing research executor", () => {
           return new Response(
             JSON.stringify({
               success: true,
-              data: { symbol: "NVDA", headline: "Consensus nudging higher" },
+              data: { symbol: "NVDA", headline: "Consensus moving higher" },
             }),
             { status: 200, headers: { "content-type": "application/json" } },
           )
@@ -141,28 +156,29 @@ describe("investing research executor", () => {
         status: "completed",
       })
 
-      const runtime = await researchExecutorTool.init()
+      const execution = await runInvestingResearchExecution({ planId: plan.id })
+      const runtime = await researchArtifactsTool.init()
       const ctx = makeToolContext()
-      const runResult = await runtime.execute(
-        {
-          action: "run",
-          planId: plan.id,
-          taskId: "source-refresh",
-        },
-        ctx,
-      )
-      const execution = JSON.parse(runResult.output) as { id: string; taskId: string }
-      expect(execution.taskId).toBe("source-refresh")
 
-      const readResult = await runtime.execute(
+      const createResult = await runtime.execute(
         {
-          action: "read",
+          action: "create",
           executionId: execution.id,
         },
         ctx,
       )
+      const artifact = JSON.parse(createResult.output) as { id: string; executionId: string }
+      expect(artifact.executionId).toBe(execution.id)
+
+      const readResult = await runtime.execute(
+        {
+          action: "read",
+          artifactId: artifact.id,
+        },
+        ctx,
+      )
       expect(JSON.parse(readResult.output)).toMatchObject({
-        id: execution.id,
+        id: artifact.id,
       })
 
       const listResult = await runtime.execute(
@@ -175,10 +191,10 @@ describe("investing research executor", () => {
       )
       const listed = JSON.parse(listResult.output) as {
         count: number
-        executions: Array<{ id: string }>
+        artifacts: Array<{ id: string }>
       }
       expect(listed.count).toBeGreaterThan(0)
-      expect(listed.executions.some((entry) => entry.id === execution.id)).toBe(true)
+      expect(listed.artifacts.some((entry) => entry.id === artifact.id)).toBe(true)
     })
   })
 })

--- a/packages/zee/test/investing/research-planner.test.ts
+++ b/packages/zee/test/investing/research-planner.test.ts
@@ -142,6 +142,8 @@ describe("investing research planner", () => {
       expect(registry.has("zee:invest-market-data")).toBe(true)
       expect(registry.has("zee:invest-scratchpad")).toBe(true)
       expect(registry.has("zee:invest-planner")).toBe(true)
+      expect(registry.has("zee:invest-executor")).toBe(true)
+      expect(registry.has("zee:invest-artifacts")).toBe(true)
     })
   })
 })

--- a/src/agent/assistants.ts
+++ b/src/agent/assistants.ts
@@ -100,6 +100,7 @@ export const ZEE_AGENT_CONFIG: AgentConfig = {
     "zee:invest-research": true,
     "zee:invest-planner": true,
     "zee:invest-executor": true,
+    "zee:invest-artifacts": true,
     "zee:invest-sec-filings": true,
     "zee:invest-nautilus": true,
     "zee:invest-estimates": true,

--- a/src/awareness/tool-catalog.ts
+++ b/src/awareness/tool-catalog.ts
@@ -48,6 +48,7 @@ const AGENT_PRIMARY_TOOLS: Record<string, string[]> = {
     "zee:invest-research",
     "zee:invest-planner",
     "zee:invest-executor",
+    "zee:invest-artifacts",
     "zee:invest-estimates",
     "zee:invest-insider-trades",
     "zee:invest-segments",

--- a/src/domain/investing/artifacts.ts
+++ b/src/domain/investing/artifacts.ts
@@ -1,0 +1,499 @@
+/**
+ * Investing Research Report Artifacts
+ *
+ * Turns research executions into stable, structured artifacts that future
+ * review and evaluation flows can score without reparsing freeform text.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { FluxRecorder } from "../../../packages/zee/src/flux";
+import { Log } from "../../../packages/zee/src/util/log";
+import type { InvestingResearchExecution, InvestingResearchEvidence } from "./executor";
+import type { InvestingResearchPlan, InvestingResearchTask } from "./planner";
+
+const log = Log.create({ service: "investing:research-artifacts" });
+
+export const INVESTING_RESEARCH_ARTIFACT_KINDS = [
+  "scope-note",
+  "source-delta",
+  "analysis-memo",
+  "research-brief",
+  "failure-diagnostic",
+] as const;
+
+export type InvestingResearchArtifactKind = (typeof INVESTING_RESEARCH_ARTIFACT_KINDS)[number];
+
+export const INVESTING_RESEARCH_ARTIFACT_STATUSES = ["ready", "degraded", "failed"] as const;
+
+export type InvestingResearchArtifactStatus = (typeof INVESTING_RESEARCH_ARTIFACT_STATUSES)[number];
+
+export interface InvestingResearchArtifactCitation {
+  citation: string;
+  link: string;
+  toolId: string;
+  sourceLabel: string;
+  status: InvestingResearchEvidence["status"];
+}
+
+export interface InvestingResearchArtifactSection {
+  id: string;
+  title: string;
+  body: string;
+  citations: string[];
+}
+
+export interface InvestingResearchArtifactDiagnostic {
+  id: string;
+  severity: "warning" | "error";
+  toolId?: string;
+  summary: string;
+  detail: string;
+  operatorAction: string;
+  command?: string;
+}
+
+export interface InvestingResearchArtifact {
+  id: string;
+  executionId: string;
+  planId: string;
+  taskId: string;
+  workflow: InvestingResearchPlan["workflow"];
+  kind: InvestingResearchArtifactKind;
+  status: InvestingResearchArtifactStatus;
+  title: string;
+  objective: string;
+  symbols: string[];
+  createdAt: string;
+  updatedAt: string;
+  summary: string;
+  sections: InvestingResearchArtifactSection[];
+  citations: InvestingResearchArtifactCitation[];
+  nextActions: string[];
+  diagnostics: InvestingResearchArtifactDiagnostic[];
+}
+
+type ArtifactState = {
+  version: 1;
+  artifacts: InvestingResearchArtifact[];
+};
+
+type CreateInvestingResearchArtifactInput = {
+  execution: InvestingResearchExecution;
+  plan: InvestingResearchPlan;
+  task: InvestingResearchTask;
+  overwrite?: boolean;
+};
+
+function getArtifactStateDir(): string {
+  const stateDir = process.env.XDG_STATE_HOME
+    ? path.join(process.env.XDG_STATE_HOME, "zee")
+    : path.join(os.homedir(), ".local", "state", "zee");
+  return path.join(stateDir, "investing");
+}
+
+export function getInvestingResearchArtifactStateFile(): string {
+  return path.join(getArtifactStateDir(), "research-artifacts.json");
+}
+
+function ensureArtifactStateDir(): void {
+  mkdirSync(getArtifactStateDir(), { recursive: true });
+}
+
+function readArtifactState(): ArtifactState {
+  const filePath = getInvestingResearchArtifactStateFile();
+  if (!existsSync(filePath)) {
+    return { version: 1, artifacts: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as ArtifactState;
+    return {
+      version: 1,
+      artifacts: Array.isArray(parsed.artifacts) ? parsed.artifacts : [],
+    };
+  } catch (error) {
+    log.warn("failed to read research artifact state", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { version: 1, artifacts: [] };
+  }
+}
+
+function writeArtifactState(state: ArtifactState): void {
+  ensureArtifactStateDir();
+  writeFileSync(getInvestingResearchArtifactStateFile(), JSON.stringify(state, null, 2) + "\n", "utf-8");
+}
+
+function artifactKindForExecution(
+  execution: InvestingResearchExecution,
+  task: InvestingResearchTask,
+): InvestingResearchArtifactKind {
+  if (execution.status === "error") return "failure-diagnostic";
+
+  switch (task.phase) {
+    case "intake":
+      return "scope-note";
+    case "data":
+      return "source-delta";
+    case "analysis":
+      return "analysis-memo";
+    case "synthesis":
+    default:
+      return "research-brief";
+  }
+}
+
+function artifactStatusForExecution(execution: InvestingResearchExecution): InvestingResearchArtifactStatus {
+  if (execution.status === "error") return "failed";
+  return execution.evidence.some((item) => item.status === "error") ? "degraded" : "ready";
+}
+
+function firstSymbol(plan: InvestingResearchPlan): string | undefined {
+  return plan.symbols[0];
+}
+
+function remediationForFailure(input: {
+  toolId?: string;
+  error?: string;
+  plan: InvestingResearchPlan;
+}): Pick<InvestingResearchArtifactDiagnostic, "operatorAction" | "command"> {
+  const normalizedError = input.error?.toLowerCase() ?? "";
+  const symbol = firstSymbol(input.plan);
+
+  if (normalizedError.includes("symbol is required")) {
+    return {
+      operatorAction: "Recreate or update the research plan with an explicit ticker scope before rerunning this task.",
+    };
+  }
+
+  if (
+    normalizedError.includes("connection") ||
+    normalizedError.includes("fetch") ||
+    normalizedError.includes("timed out") ||
+    normalizedError.includes("status 5")
+  ) {
+    return {
+      operatorAction: "Validate investing runtime health, then rerun the execution once the service is stable.",
+      command: "zee investing ingest status",
+    };
+  }
+
+  switch (input.toolId) {
+    case "zee:invest-sec-filings":
+      return {
+        operatorAction: `Confirm filing coverage${symbol ? ` for ${symbol}` : ""} and backfill stale primary-source data before retrying.`,
+        command: "zee investing ingest status",
+      };
+    case "zee:invest-market-data":
+    case "zee:invest-estimates":
+    case "zee:invest-insider-trades":
+      return {
+        operatorAction: "Check the affected data connector health and refresh stale coverage before rerunning.",
+        command: "zee investing ingest status",
+      };
+    case "zee:invest-research":
+      return {
+        operatorAction: "Inspect the research endpoint response and restore source coverage before rerunning the workflow step.",
+        command: "zee investing ingest status",
+      };
+    default:
+      return {
+        operatorAction: "Inspect the failing source, restore coverage, and rerun the execution when the dependency is healthy.",
+      };
+  }
+}
+
+function buildDiagnostics(input: {
+  execution: InvestingResearchExecution;
+  plan: InvestingResearchPlan;
+  task: InvestingResearchTask;
+}): InvestingResearchArtifactDiagnostic[] {
+  const diagnostics: InvestingResearchArtifactDiagnostic[] = [];
+
+  const failedEvidence = input.execution.evidence.filter((item) => item.status === "error");
+  for (const item of failedEvidence) {
+    const remediation = remediationForFailure({
+      toolId: item.toolId,
+      error: item.error,
+      plan: input.plan,
+    });
+
+    diagnostics.push({
+      id: `diagnostic-${randomUUID().slice(0, 12)}`,
+      severity: input.execution.status === "error" ? "error" : "warning",
+      toolId: item.toolId,
+      summary: `${item.sourceLabel} failed during ${input.task.id}.`,
+      detail: item.error || "The source returned an unspecified error.",
+      operatorAction: remediation.operatorAction,
+      command: remediation.command,
+    });
+  }
+
+  if (input.execution.status === "error" && failedEvidence.length === 0) {
+    diagnostics.push({
+      id: `diagnostic-${randomUUID().slice(0, 12)}`,
+      severity: "error",
+      summary: "The execution finished without any usable evidence.",
+      detail: "No completed evidence items were persisted for this workflow step.",
+      operatorAction: "Review the plan scope and source mappings, then rerun the task once a usable source path is available.",
+    });
+  }
+
+  if (input.plan.status === "blocked") {
+    diagnostics.push({
+      id: `diagnostic-${randomUUID().slice(0, 12)}`,
+      severity: "error",
+      summary: "The plan is blocked after this execution.",
+      detail: `Task ${input.task.id} is blocking downstream work until this failure is resolved.`,
+      operatorAction: "Resolve the failed source diagnostics, then rerun the blocked task to unblock the research plan.",
+    });
+  }
+
+  return diagnostics;
+}
+
+function buildSections(input: {
+  execution: InvestingResearchExecution;
+  plan: InvestingResearchPlan;
+  task: InvestingResearchTask;
+  diagnostics: InvestingResearchArtifactDiagnostic[];
+}): InvestingResearchArtifactSection[] {
+  const evidenceCitations = input.execution.evidence.map((item) => item.citation);
+  const sections: InvestingResearchArtifactSection[] = [
+    {
+      id: "overview",
+      title: "Overview",
+      body: [
+        `Objective: ${input.plan.objective}`,
+        `Workflow: ${input.plan.workflow}`,
+        `Task: ${input.task.title}`,
+        `Deliverable: ${input.task.deliverable}`,
+        `Symbols: ${input.plan.symbols.length > 0 ? input.plan.symbols.join(", ") : "scope not pinned"}`,
+      ].join("\n"),
+      citations: [],
+    },
+    {
+      id: "synthesis",
+      title: "Synthesis",
+      body: input.execution.synthesis,
+      citations: evidenceCitations,
+    },
+    {
+      id: "evidence",
+      title: "Evidence",
+      body:
+        input.execution.evidence.length > 0
+          ? input.execution.evidence
+              .map(
+                (item) =>
+                  `- [${item.citation}] ${item.sourceLabel} (${item.status}): ${item.summary}`,
+              )
+              .join("\n")
+          : "- No evidence items were persisted.",
+      citations: evidenceCitations,
+    },
+  ];
+
+  if (input.diagnostics.length > 0) {
+    sections.push({
+      id: "diagnostics",
+      title: "Diagnostics",
+      body: input.diagnostics
+        .map((diagnostic) =>
+          [
+            `- ${diagnostic.summary}`,
+            `  Detail: ${diagnostic.detail}`,
+            `  Action: ${diagnostic.operatorAction}`,
+            diagnostic.command ? `  Command: ${diagnostic.command}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        )
+        .join("\n"),
+      citations: [],
+    });
+  }
+
+  return sections;
+}
+
+function buildSummary(input: {
+  execution: InvestingResearchExecution;
+  plan: InvestingResearchPlan;
+  task: InvestingResearchTask;
+  diagnostics: InvestingResearchArtifactDiagnostic[];
+  status: InvestingResearchArtifactStatus;
+}): string {
+  const completedEvidence = input.execution.evidence.filter((item) => item.status === "completed").length;
+
+  if (input.status === "failed") {
+    return `${input.task.title} failed for ${input.plan.objective}; ${input.diagnostics.length} actionable diagnostic(s) were captured.`;
+  }
+  if (input.status === "degraded") {
+    return `${input.task.title} completed with gaps: ${completedEvidence}/${input.execution.evidence.length} evidence item(s) succeeded.`;
+  }
+  return `${input.task.title} produced a structured artifact with ${completedEvidence} evidence item(s).`;
+}
+
+function buildNextActions(input: {
+  plan: InvestingResearchPlan;
+  task: InvestingResearchTask;
+  status: InvestingResearchArtifactStatus;
+  diagnostics: InvestingResearchArtifactDiagnostic[];
+}): string[] {
+  const actions: string[] = [];
+
+  if (input.status === "failed") {
+    actions.push(...input.diagnostics.map((diagnostic) => diagnostic.operatorAction));
+    return Array.from(new Set(actions));
+  }
+
+  if (input.status === "degraded") {
+    actions.push("Review the warning diagnostics before using this artifact as a final research deliverable.");
+  }
+
+  const nextTask = input.plan.tasks.find((candidate) => candidate.status === "in_progress");
+  if (nextTask && nextTask.id !== input.task.id) {
+    actions.push(`Run the next task: ${nextTask.title}.`);
+  } else if (input.plan.status === "completed") {
+    actions.push("Review the completed artifact set and promote the final brief into the next portfolio or thesis workflow.");
+  } else if (input.plan.status === "blocked") {
+    actions.push("Resolve the blocked task diagnostics before continuing the plan.");
+  }
+
+  return Array.from(new Set(actions));
+}
+
+export function findInvestingResearchArtifactByExecution(
+  executionId: string,
+): InvestingResearchArtifact | null {
+  const state = readArtifactState();
+  return state.artifacts.find((artifact) => artifact.executionId === executionId) ?? null;
+}
+
+export function createInvestingResearchArtifact(
+  input: CreateInvestingResearchArtifactInput,
+): InvestingResearchArtifact {
+  const state = readArtifactState();
+  const existing = state.artifacts.find((artifact) => artifact.executionId === input.execution.id);
+  if (existing && !input.overwrite) {
+    return existing;
+  }
+
+  const diagnostics = buildDiagnostics(input);
+  const status = artifactStatusForExecution(input.execution);
+  const timestamp = new Date().toISOString();
+  const artifact: InvestingResearchArtifact = {
+    id: existing?.id ?? `research-artifact-${randomUUID().slice(0, 12)}`,
+    executionId: input.execution.id,
+    planId: input.plan.id,
+    taskId: input.task.id,
+    workflow: input.plan.workflow,
+    kind: artifactKindForExecution(input.execution, input.task),
+    status,
+    title: `${input.task.title} artifact`,
+    objective: input.plan.objective,
+    symbols: input.plan.symbols,
+    createdAt: existing?.createdAt ?? timestamp,
+    updatedAt: timestamp,
+    summary: buildSummary({
+      execution: input.execution,
+      plan: input.plan,
+      task: input.task,
+      diagnostics,
+      status,
+    }),
+    sections: buildSections({
+      execution: input.execution,
+      plan: input.plan,
+      task: input.task,
+      diagnostics,
+    }),
+    citations: input.execution.evidence.map((item) => ({
+      citation: item.citation,
+      link: item.link,
+      toolId: item.toolId,
+      sourceLabel: item.sourceLabel,
+      status: item.status,
+    })),
+    nextActions: buildNextActions({
+      plan: input.plan,
+      task: input.task,
+      status,
+      diagnostics,
+    }),
+    diagnostics,
+  };
+
+  state.artifacts = [artifact, ...state.artifacts.filter((entry) => entry.id !== artifact.id)].slice(0, 500);
+  writeArtifactState(state);
+
+  FluxRecorder.record({
+    traceID: artifact.id,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.research.artifact",
+    status: artifact.status === "failed" ? "error" : "ok",
+    method: existing ? "update" : "create",
+    path: artifact.kind,
+    route: artifact.id,
+    metadata: {
+      executionId: artifact.executionId,
+      planId: artifact.planId,
+      taskId: artifact.taskId,
+      workflow: artifact.workflow,
+      status: artifact.status,
+      diagnosticCount: artifact.diagnostics.length,
+      citationCount: artifact.citations.length,
+    },
+  });
+
+  for (const diagnostic of artifact.diagnostics) {
+    FluxRecorder.record({
+      traceID: artifact.id,
+      direction: "internal",
+      domain: "investing",
+      kind: "investing.research.diagnostic",
+      status: diagnostic.severity === "error" ? "error" : "ok",
+      method: "emit",
+      path: diagnostic.toolId ?? artifact.taskId,
+      route: diagnostic.id,
+      metadata: {
+        artifactId: artifact.id,
+        executionId: artifact.executionId,
+        planId: artifact.planId,
+        taskId: artifact.taskId,
+        summary: diagnostic.summary,
+        operatorAction: diagnostic.operatorAction,
+        command: diagnostic.command,
+      },
+    });
+  }
+
+  return artifact;
+}
+
+export function getInvestingResearchArtifact(artifactId: string): InvestingResearchArtifact | null {
+  const state = readArtifactState();
+  return state.artifacts.find((artifact) => artifact.id === artifactId) ?? null;
+}
+
+export function listInvestingResearchArtifacts(options?: {
+  planId?: string;
+  taskId?: string;
+  executionId?: string;
+  status?: InvestingResearchArtifactStatus;
+  limit?: number;
+}): InvestingResearchArtifact[] {
+  const state = readArtifactState();
+  return state.artifacts
+    .filter((artifact) => (options?.planId ? artifact.planId === options.planId : true))
+    .filter((artifact) => (options?.taskId ? artifact.taskId === options.taskId : true))
+    .filter((artifact) => (options?.executionId ? artifact.executionId === options.executionId : true))
+    .filter((artifact) => (options?.status ? artifact.status === options.status : true))
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+    .slice(0, options?.limit ?? 20);
+}

--- a/src/domain/investing/executor.ts
+++ b/src/domain/investing/executor.ts
@@ -18,6 +18,7 @@ import {
 } from "../../../packages/zee/src/session/investing-provenance";
 import { Log } from "../../../packages/zee/src/util/log";
 import { Investing } from "../../paths";
+import { createInvestingResearchArtifact } from "./artifacts";
 import {
   getInvestingResearchPlan,
   updateInvestingResearchTask,
@@ -55,6 +56,7 @@ export interface InvestingResearchExecution {
   synthesis: string;
   evidence: InvestingResearchEvidence[];
   provenance: InvestingProvenanceSummary | null;
+  artifactId?: string;
 }
 
 type ExecutionState = {
@@ -491,6 +493,25 @@ export async function runInvestingResearchExecution(
         ? `Execution ${execution.id} collected ${evidence.length} evidence item(s).`
         : `Execution ${execution.id} failed to collect usable evidence.`,
   });
+
+  const updatedPlan = getInvestingResearchPlan(plan.id) ?? plan;
+  const updatedTask = updatedPlan.tasks.find((entry) => entry.id === task.id) ?? task;
+
+  try {
+    const artifact = createInvestingResearchArtifact({
+      execution,
+      plan: updatedPlan,
+      task: updatedTask,
+    });
+    execution.artifactId = artifact.id;
+    state.executions = state.executions.map((entry) => (entry.id === execution.id ? execution : entry));
+    writeExecutionState(state);
+  } catch (error) {
+    log.warn("failed to create research artifact", {
+      executionId: execution.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   return execution;
 }

--- a/src/domain/investing/tools.ts
+++ b/src/domain/investing/tools.ts
@@ -27,6 +27,12 @@ import {
   listInvestingResearchExecutions,
   runInvestingResearchExecution,
 } from "./executor";
+import {
+  INVESTING_RESEARCH_ARTIFACT_STATUSES,
+  createInvestingResearchArtifact,
+  getInvestingResearchArtifact,
+  listInvestingResearchArtifacts,
+} from "./artifacts";
 
 type InvestingResult = {
   ok: boolean;
@@ -650,6 +656,116 @@ export const researchExecutorTool: ToolDefinition = {
   }),
 };
 
+const ResearchArtifactsParams = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("create"),
+    executionId: z.string().describe("Persisted execution identifier"),
+    overwrite: z.boolean().optional().default(false).describe("Regenerate the artifact even if one already exists"),
+  }),
+  z.object({
+    action: z.literal("read"),
+    artifactId: z.string().describe("Persisted artifact identifier"),
+  }),
+  z.object({
+    action: z.literal("list"),
+    planId: z.string().optional().describe("Optional plan filter"),
+    taskId: z.string().optional().describe("Optional task filter"),
+    executionId: z.string().optional().describe("Optional execution filter"),
+    status: z.enum(INVESTING_RESEARCH_ARTIFACT_STATUSES).optional().describe("Optional artifact status filter"),
+    limit: z.number().min(1).max(100).default(10).describe("Maximum number of artifacts to return"),
+  }),
+]);
+
+export const researchArtifactsTool: ToolDefinition = {
+  id: "zee:invest-artifacts",
+  category: "domain",
+  init: async () => ({
+    description: `Create, read, and list structured investing research artifacts with failure diagnostics for operator review and future evals.`,
+    parameters: ResearchArtifactsParams,
+    execute: async (args, ctx): Promise<ToolExecutionResult> => {
+      switch (args.action) {
+        case "create": {
+          ctx.metadata({ title: `Creating research artifact for ${args.executionId}` });
+          const execution = getInvestingResearchExecution(args.executionId);
+          if (!execution) {
+            return {
+              title: "Investing Research Artifacts",
+              metadata: { action: args.action, executionId: args.executionId, found: false },
+              output: JSON.stringify({ error: `Research execution not found: ${args.executionId}` }, null, 2),
+            };
+          }
+
+          const plan = getInvestingResearchPlan(execution.planId);
+          const task = plan?.tasks.find((entry) => entry.id === execution.taskId);
+          if (!plan || !task) {
+            return {
+              title: "Investing Research Artifacts",
+              metadata: { action: args.action, executionId: args.executionId, found: false },
+              output: JSON.stringify(
+                { error: `Research plan context not found for execution: ${args.executionId}` },
+                null,
+                2,
+              ),
+            };
+          }
+
+          const artifact = createInvestingResearchArtifact({
+            execution,
+            plan,
+            task,
+            overwrite: args.overwrite,
+          });
+          return {
+            title: "Investing Research Artifacts",
+            metadata: {
+              action: args.action,
+              artifactId: artifact.id,
+              executionId: artifact.executionId,
+              status: artifact.status,
+            },
+            output: JSON.stringify(artifact, null, 2),
+          };
+        }
+        case "read": {
+          ctx.metadata({ title: `Loading research artifact ${args.artifactId}` });
+          const artifact = getInvestingResearchArtifact(args.artifactId);
+          return {
+            title: "Investing Research Artifacts",
+            metadata: { action: args.action, artifactId: args.artifactId, found: Boolean(artifact) },
+            output: JSON.stringify(
+              artifact ?? { error: `Research artifact not found: ${args.artifactId}` },
+              null,
+              2,
+            ),
+          };
+        }
+        case "list": {
+          ctx.metadata({ title: "Listing research artifacts" });
+          const artifacts = listInvestingResearchArtifacts({
+            planId: args.planId,
+            taskId: args.taskId,
+            executionId: args.executionId,
+            status: args.status,
+            limit: args.limit,
+          });
+          return {
+            title: "Investing Research Artifacts",
+            metadata: {
+              action: args.action,
+              count: artifacts.length,
+              planId: args.planId,
+              taskId: args.taskId,
+              executionId: args.executionId,
+              status: args.status,
+            },
+            output: JSON.stringify({ artifacts, count: artifacts.length }, null, 2),
+          };
+        }
+      }
+    },
+  }),
+};
+
 // =============================================================================
 // Nautilus Trading Tool
 // =============================================================================
@@ -823,6 +939,7 @@ export const INVESTING_TOOLS = [
   researchTool,
   researchPlannerTool,
   researchExecutorTool,
+  researchArtifactsTool,
   nautilusTool,
   estimatesTool,
   insiderTradesTool,


### PR DESCRIPTION
## Summary
- add a persisted investing research artifact store that auto-generates structured reports from research executions
- capture actionable failure diagnostics and emit new artifact/diagnostic telemetry for operator review and future evals
- expose the `zee:invest-artifacts` tool and document the artifact contract and operating loop

## Local verification
- `bash scripts/bun-audit-ci.sh`
- `bash scripts/verify-skills.sh`
- `cd packages/zee && bun run typecheck`
- `cd packages/zee && bun test ./test/investing/research-artifacts.test.ts ./test/investing/research-executor.test.ts ./test/investing/research-planner.test.ts ./test/session/investing-provenance.test.ts`
- `cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov`
- `cd packages/zee && bun run build`
- `cd packages/zee && ./script/verify-binary.sh`

Closes #502
