### PR TITLE
[child] valuation packet schema and export interface

### DIFF
--- a/docs/architecture/investing-valuation-packets.md
+++ b/docs/architecture/investing-valuation-packets.md
@@ -1,0 +1,63 @@
+# Investing Valuation Packets
+
+Valuation packets are the export-ready layer on top of the valuation kernel. They standardize the exact contract downstream portfolio operations can consume without understanding the raw kernel internals.
+
+## Packet schema
+
+Each packet includes:
+
+- `schemaVersion`
+- `runId`
+- `valuationCaseId`
+- `symbol`
+- `summary`
+- `verdict`
+- `portfolioContext`
+- `operationsContext`
+- `methods`
+- `assumptionProvenance`
+- `sensitivityTables`
+- `thesisContext`
+- `audit`
+
+## Portfolio-ops context
+
+Packets now carry downstream ops fields by default:
+
+- `portfolioContext`
+  - whether the symbol is already in the configured holdings file
+- `operationsContext`
+  - consumer audience and an audit key suitable for scheduling/logging systems
+- `audit`
+  - generation time plus export counters
+
+This is the minimum packet contract needed for the later portfolio-ops workflows to consume valuation outputs without building a custom adapter per use case.
+
+## Tool surface
+
+Packets are exposed as `zee:invest-valuation-packets`.
+
+Supported actions:
+
+- `create`
+  - inputs: `runId`, optional `overwrite`
+- `read`
+  - inputs: `packetId`
+- `list`
+  - inputs: optional `symbol`, optional `runId`, optional `limit`
+- `export`
+  - inputs: `packetId`, `format`
+
+Exports currently support:
+
+- `json`
+- `markdown`
+
+## Telemetry
+
+This slice emits:
+
+- `investing.valuation.packet`
+  - one event per packet create/update
+- `investing.valuation.packet.export`
+  - one event per packet export

--- a/docs/architecture/openclaw-opencode-financial-roadmap.md
+++ b/docs/architecture/openclaw-opencode-financial-roadmap.md
@@ -72,6 +72,7 @@ Exit criteria:
 - Structured report artifacts and diagnostics runbook: `docs/architecture/investing-report-artifacts.md`.
 - Valuation model kernel runbook: `docs/architecture/investing-valuation-kernel.md`.
 - Valuation assumption provenance and sensitivity runbook: `docs/architecture/investing-valuation-provenance.md`.
+- Valuation packet schema and export runbook: `docs/architecture/investing-valuation-packets.md`.
 
 Exit criteria:
 - End-to-end automated research run produces usable analyst packet.

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -59,6 +59,8 @@ export type FluxKind =
   | "investing.valuation.scenario"
   | "investing.valuation.assumption"
   | "investing.valuation.sensitivity"
+  | "investing.valuation.packet"
+  | "investing.valuation.packet.export"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"
   | "provider.fallback.used"

--- a/packages/zee/test/investing/research-planner.test.ts
+++ b/packages/zee/test/investing/research-planner.test.ts
@@ -142,6 +142,7 @@ describe("investing research planner", () => {
       expect(registry.has("zee:invest-market-data")).toBe(true)
       expect(registry.has("zee:invest-scratchpad")).toBe(true)
       expect(registry.has("zee:invest-valuation")).toBe(true)
+      expect(registry.has("zee:invest-valuation-packets")).toBe(true)
       expect(registry.has("zee:invest-planner")).toBe(true)
       expect(registry.has("zee:invest-executor")).toBe(true)
       expect(registry.has("zee:invest-artifacts")).toBe(true)

--- a/packages/zee/test/investing/valuation-packet.test.ts
+++ b/packages/zee/test/investing/valuation-packet.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, spyOn, test } from "bun:test"
 import { FluxRecorder } from "../../src/flux"
 import { tmpdir } from "../fixture/fixture"
+import { runInvestingValuationKernel } from "../../../../src/domain/investing/valuation"
 import {
-  getInvestingValuationKernel,
-  getInvestingValuationKernelStateFile,
-  runInvestingValuationKernel,
-} from "../../../../src/domain/investing/valuation"
-import { getInvestingValuationPacket } from "../../../../src/domain/investing/valuation-packet"
-import { valuationKernelTool } from "../../../../src/domain/investing/tools"
+  getInvestingValuationPacket,
+  getInvestingValuationPacketStateFile,
+} from "../../../../src/domain/investing/valuation-packet"
+import { valuationPacketTool } from "../../../../src/domain/investing/tools"
 
 function makeToolContext() {
   return {
@@ -19,11 +18,20 @@ function makeToolContext() {
   }
 }
 
-async function withValuationState<T>(fn: () => Promise<T>): Promise<T> {
+async function withPacketState<T>(fn: () => Promise<T>): Promise<T> {
   await using dir = await tmpdir()
   const originalStateHome = process.env.XDG_STATE_HOME
+  const originalPortfolioFile = process.env.ZEE_INVESTING_PORTFOLIO_FILE
   const originalFetch = globalThis.fetch
   process.env.XDG_STATE_HOME = dir.path
+  process.env.ZEE_INVESTING_PORTFOLIO_FILE = `${dir.path}/portfolio.json`
+  await Bun.write(
+    process.env.ZEE_INVESTING_PORTFOLIO_FILE,
+    JSON.stringify({
+      positions: [{ symbol: "NVDA", shares: 10, average_cost: 95 }],
+    }),
+  )
+
   try {
     return await fn()
   } finally {
@@ -33,12 +41,17 @@ async function withValuationState<T>(fn: () => Promise<T>): Promise<T> {
     } else {
       process.env.XDG_STATE_HOME = originalStateHome
     }
+    if (originalPortfolioFile === undefined) {
+      delete process.env.ZEE_INVESTING_PORTFOLIO_FILE
+    } else {
+      process.env.ZEE_INVESTING_PORTFOLIO_FILE = originalPortfolioFile
+    }
   }
 }
 
-describe("investing valuation kernel", () => {
-  test("runs DCF, comps, and scenario analysis into a persisted kernel", async () => {
-    await withValuationState(async () => {
+describe("investing valuation packets", () => {
+  test("auto-generates a standardized valuation packet from a kernel run", async () => {
+    await withPacketState(async () => {
       const recordSpy = spyOn(FluxRecorder, "record")
       globalThis.fetch = (async (input: RequestInfo | URL) => {
         const url = String(input)
@@ -46,13 +59,7 @@ describe("investing valuation kernel", () => {
           return new Response(
             JSON.stringify({
               success: true,
-              data: {
-                symbol: "NVDA",
-                fairValue: 140,
-                currentPrice: 100,
-                upsidePercent: 40,
-                assumptions: { revenueGrowth: 0.18 },
-              },
+              data: { symbol: "NVDA", fairValue: 140, currentPrice: 100, upsidePercent: 40 },
             }),
             { status: 200, headers: { "content-type": "application/json" } },
           )
@@ -63,11 +70,7 @@ describe("investing valuation kernel", () => {
               success: true,
               data: {
                 symbol: "NVDA",
-                dcf: {
-                  intrinsicValue: 150,
-                  currentPrice: 100,
-                  upsidePercentage: 50,
-                },
+                dcf: { intrinsicValue: 150, currentPrice: 100, upsidePercentage: 50 },
                 assumptions: { discountRate: 0.1, terminalGrowth: 0.03 },
               },
             }),
@@ -89,35 +92,24 @@ describe("investing valuation kernel", () => {
         throw new Error(`Unexpected URL ${url}`)
       }) as typeof fetch
 
-      const run = await runInvestingValuationKernel({
-        symbol: "NVDA",
-        peers: ["AMD", "AVGO"],
-      })
+      const run = await runInvestingValuationKernel({ symbol: "NVDA" })
+      const packet = getInvestingValuationPacket(run.packetId!)
 
-      expect(run.symbol).toBe("NVDA")
-      expect(run.status).toBe("ok")
-      expect(run.valuationCaseId).toContain("valuation_case:equity:nvda:")
-      expect(run.packetId).toBeDefined()
-      expect(run.methods).toHaveLength(3)
-      expect(run.blendedFairValue).toBeCloseTo((140 + 150 + 110) / 3, 5)
-      expect(run.scenarios.map((scenario) => scenario.name)).toEqual(["bear", "base", "bull"])
-      expect(run.scenarios[1]?.fairValue).toBeCloseTo(run.blendedFairValue!, 5)
-      expect(run.assumptionProvenance.some((item) => item.name === "discountRate")).toBe(true)
-      expect(run.sensitivityTables.map((table) => table.method)).toEqual(["dcf", "comparables", "blended"])
-      expect(run.thesisContext.thesisKey).toBe("thesis:nvda")
-      expect(getInvestingValuationKernel(run.id)?.id).toBe(run.id)
-      expect(getInvestingValuationPacket(run.packetId!)?.runId).toBe(run.id)
-      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.valuation.kernel")).toBe(true)
-      expect(recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.valuation.method")).toHaveLength(3)
-      expect(recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.valuation.scenario")).toHaveLength(3)
-      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.valuation.assumption")).toBe(true)
-      expect(recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.valuation.sensitivity")).toHaveLength(3)
-      expect(await Bun.file(getInvestingValuationKernelStateFile()).exists()).toBe(true)
+      expect(packet).toBeDefined()
+      if (!packet) throw new Error("packet should be defined")
+
+      expect(packet.schemaVersion).toBe("valuation-packet.v1")
+      expect(packet.portfolioContext.positionStatus).toBe("holding")
+      expect(packet.operationsContext.consumer).toBe("portfolio-ops")
+      expect(packet.audit.exportCount).toBe(0)
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.valuation.packet")).toBe(true)
+      expect(await Bun.file(getInvestingValuationPacketStateFile()).exists()).toBe(true)
     })
   })
 
-  test("tool surface can run, read, and list valuation kernels", async () => {
-    await withValuationState(async () => {
+  test("tool surface can read, list, and export valuation packets", async () => {
+    await withPacketState(async () => {
+      const recordSpy = spyOn(FluxRecorder, "record")
       globalThis.fetch = (async (input: RequestInfo | URL) => {
         const url = String(input)
         if (url.endsWith("/api/valuation/NVDA?include_dcf=true")) {
@@ -136,7 +128,7 @@ describe("investing valuation kernel", () => {
               data: {
                 symbol: "NVDA",
                 dcf: { intrinsicValue: 145, currentPrice: 100, upsidePercentage: 45 },
-                assumptions: {},
+                assumptions: { discountRate: 0.1, terminalGrowth: 0.03 },
               },
             }),
             { status: 200, headers: { "content-type": "application/json" } },
@@ -157,27 +149,19 @@ describe("investing valuation kernel", () => {
         throw new Error(`Unexpected URL ${url}`)
       }) as typeof fetch
 
-      const runtime = await valuationKernelTool.init()
+      const run = await runInvestingValuationKernel({ symbol: "NVDA" })
+      const runtime = await valuationPacketTool.init()
       const ctx = makeToolContext()
-      const runResult = await runtime.execute(
-        {
-          action: "run",
-          symbol: "NVDA",
-        },
-        ctx,
-      )
-      const run = JSON.parse(runResult.output) as { id: string; symbol: string }
-      expect(run.symbol).toBe("NVDA")
 
       const readResult = await runtime.execute(
         {
           action: "read",
-          runId: run.id,
+          packetId: run.packetId!,
         },
         ctx,
       )
       expect(JSON.parse(readResult.output)).toMatchObject({
-        id: run.id,
+        id: run.packetId,
       })
 
       const listResult = await runtime.execute(
@@ -190,10 +174,25 @@ describe("investing valuation kernel", () => {
       )
       const listed = JSON.parse(listResult.output) as {
         count: number
-        runs: Array<{ id: string }>
+        packets: Array<{ id: string }>
       }
       expect(listed.count).toBeGreaterThan(0)
-      expect(listed.runs.some((entry) => entry.id === run.id)).toBe(true)
+      expect(listed.packets.some((entry) => entry.id === run.packetId)).toBe(true)
+
+      const exportResult = await runtime.execute(
+        {
+          action: "export",
+          packetId: run.packetId!,
+          format: "markdown",
+        },
+        ctx,
+      )
+      expect(exportResult.output).toContain("# Valuation Packet: NVDA")
+      expect(exportResult.output).toContain("Audit key:")
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.valuation.packet.export")).toBe(true)
+
+      const packet = getInvestingValuationPacket(run.packetId!)
+      expect(packet?.audit.exportCount).toBe(1)
     })
   })
 })

--- a/src/agent/assistants.ts
+++ b/src/agent/assistants.ts
@@ -99,6 +99,7 @@ export const ZEE_AGENT_CONFIG: AgentConfig = {
     "zee:invest-portfolio": true,
     "zee:invest-research": true,
     "zee:invest-valuation": true,
+    "zee:invest-valuation-packets": true,
     "zee:invest-planner": true,
     "zee:invest-executor": true,
     "zee:invest-artifacts": true,

--- a/src/awareness/tool-catalog.ts
+++ b/src/awareness/tool-catalog.ts
@@ -47,6 +47,7 @@ const AGENT_PRIMARY_TOOLS: Record<string, string[]> = {
     "zee:invest-sec-filings",
     "zee:invest-research",
     "zee:invest-valuation",
+    "zee:invest-valuation-packets",
     "zee:invest-planner",
     "zee:invest-executor",
     "zee:invest-artifacts",

--- a/src/domain/investing/tools.ts
+++ b/src/domain/investing/tools.ts
@@ -38,6 +38,12 @@ import {
   listInvestingValuationKernels,
   runInvestingValuationKernel,
 } from "./valuation";
+import {
+  createInvestingValuationPacket,
+  exportInvestingValuationPacket,
+  getInvestingValuationPacket,
+  listInvestingValuationPackets,
+} from "./valuation-packet";
 
 type InvestingResult = {
   ok: boolean;
@@ -838,6 +844,102 @@ export const valuationKernelTool: ToolDefinition = {
   }),
 };
 
+const ValuationPacketParams = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("create"),
+    runId: z.string().describe("Persisted valuation kernel run identifier"),
+    overwrite: z.boolean().optional().default(false).describe("Regenerate the packet even if one already exists"),
+  }),
+  z.object({
+    action: z.literal("read"),
+    packetId: z.string().describe("Persisted valuation packet identifier"),
+  }),
+  z.object({
+    action: z.literal("list"),
+    symbol: z.string().optional().describe("Optional symbol filter"),
+    runId: z.string().optional().describe("Optional valuation run filter"),
+    limit: z.number().min(1).max(100).default(10).describe("Maximum number of packets to return"),
+  }),
+  z.object({
+    action: z.literal("export"),
+    packetId: z.string().describe("Persisted valuation packet identifier"),
+    format: z.enum(["json", "markdown"]).default("json").describe("Export format"),
+  }),
+]);
+
+export const valuationPacketTool: ToolDefinition = {
+  id: "zee:invest-valuation-packets",
+  category: "domain",
+  init: async () => ({
+    description: `Create, inspect, list, and export standardized valuation packets for downstream portfolio operations.`,
+    parameters: ValuationPacketParams,
+    execute: async (args, ctx): Promise<ToolExecutionResult> => {
+      switch (args.action) {
+        case "create": {
+          ctx.metadata({ title: `Creating valuation packet for ${args.runId}` });
+          const run = getInvestingValuationKernel(args.runId);
+          if (!run) {
+            return {
+              title: "Investing Valuation Packets",
+              metadata: { action: args.action, runId: args.runId, found: false },
+              output: JSON.stringify({ error: `Valuation run not found: ${args.runId}` }, null, 2),
+            };
+          }
+
+          const packet = createInvestingValuationPacket({
+            run,
+            overwrite: args.overwrite,
+          });
+          return {
+            title: "Investing Valuation Packets",
+            metadata: { action: args.action, packetId: packet.id, runId: packet.runId },
+            output: JSON.stringify(packet, null, 2),
+          };
+        }
+        case "read": {
+          ctx.metadata({ title: `Loading valuation packet ${args.packetId}` });
+          const packet = getInvestingValuationPacket(args.packetId);
+          return {
+            title: "Investing Valuation Packets",
+            metadata: { action: args.action, packetId: args.packetId, found: Boolean(packet) },
+            output: JSON.stringify(packet ?? { error: `Valuation packet not found: ${args.packetId}` }, null, 2),
+          };
+        }
+        case "list": {
+          ctx.metadata({ title: "Listing valuation packets" });
+          const packets = listInvestingValuationPackets({
+            symbol: args.symbol,
+            runId: args.runId,
+            limit: args.limit,
+          });
+          return {
+            title: "Investing Valuation Packets",
+            metadata: { action: args.action, count: packets.length, symbol: args.symbol, runId: args.runId },
+            output: JSON.stringify({ packets, count: packets.length }, null, 2),
+          };
+        }
+        case "export": {
+          ctx.metadata({ title: `Exporting valuation packet ${args.packetId}` });
+          const exported = exportInvestingValuationPacket({
+            packetId: args.packetId,
+            format: args.format,
+          });
+          return {
+            title: "Investing Valuation Packets",
+            metadata: {
+              action: args.action,
+              packetId: args.packetId,
+              format: args.format,
+              exportCount: exported.packet.audit.exportCount,
+            },
+            output: exported.content,
+          };
+        }
+      }
+    },
+  }),
+};
+
 // =============================================================================
 // Nautilus Trading Tool
 // =============================================================================
@@ -1010,6 +1112,7 @@ export const INVESTING_TOOLS = [
   secFilingsTool,
   researchTool,
   valuationKernelTool,
+  valuationPacketTool,
   researchPlannerTool,
   researchExecutorTool,
   researchArtifactsTool,

--- a/src/domain/investing/valuation-packet.ts
+++ b/src/domain/investing/valuation-packet.ts
@@ -1,0 +1,333 @@
+/**
+ * Investing Valuation Packets
+ *
+ * Standardizes export-ready valuation packets for downstream portfolio and
+ * research operations consumers.
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { FluxRecorder } from "../../../packages/zee/src/flux";
+import { Log } from "../../../packages/zee/src/util/log";
+import { Investing } from "../../paths";
+import type {
+  InvestingValuationKernelRun,
+  InvestingValuationMethodResult,
+  InvestingValuationAssumption,
+  InvestingValuationSensitivityTable,
+  InvestingValuationThesisContext,
+} from "./valuation";
+
+const log = Log.create({ service: "investing:valuation-packets" });
+
+type PortfolioPosition = {
+  symbol: string;
+  shares: number;
+  averageCost: number;
+};
+
+export interface InvestingValuationPacket {
+  id: string;
+  schemaVersion: "valuation-packet.v1";
+  runId: string;
+  valuationCaseId: string;
+  symbol: string;
+  createdAt: string;
+  summary: string;
+  verdict: {
+    fairValue: number | null;
+    currentPrice: number | null;
+    upsidePercent: number | null;
+    signal: InvestingValuationThesisContext["signal"];
+  };
+  portfolioContext: {
+    positionStatus: "holding" | "unclassified";
+    shares?: number;
+    averageCost?: number;
+  };
+  operationsContext: {
+    consumer: "portfolio-ops";
+    audience: "holdings" | "general";
+    auditKey: string;
+  };
+  methods: InvestingValuationMethodResult[];
+  assumptionProvenance: InvestingValuationAssumption[];
+  sensitivityTables: InvestingValuationSensitivityTable[];
+  thesisContext: InvestingValuationThesisContext;
+  audit: {
+    generatedAt: string;
+    lastExportedAt?: string;
+    exportCount: number;
+  };
+}
+
+type PacketState = {
+  version: 1;
+  packets: InvestingValuationPacket[];
+};
+
+type CreateInvestingValuationPacketInput = {
+  run: InvestingValuationKernelRun;
+  overwrite?: boolean;
+};
+
+type ExportFormat = "json" | "markdown";
+
+function getPacketStateDir(): string {
+  const stateDir = process.env.XDG_STATE_HOME
+    ? path.join(process.env.XDG_STATE_HOME, "zee")
+    : path.join(os.homedir(), ".local", "state", "zee");
+  return path.join(stateDir, "investing");
+}
+
+export function getInvestingValuationPacketStateFile(): string {
+  return path.join(getPacketStateDir(), "valuation-packets.json");
+}
+
+function ensurePacketStateDir(): void {
+  mkdirSync(getPacketStateDir(), { recursive: true });
+}
+
+function readPacketState(): PacketState {
+  const filePath = getInvestingValuationPacketStateFile();
+  if (!existsSync(filePath)) {
+    return { version: 1, packets: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as PacketState;
+    return {
+      version: 1,
+      packets: Array.isArray(parsed.packets) ? parsed.packets : [],
+    };
+  } catch (error) {
+    log.warn("failed to read valuation packet state", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { version: 1, packets: [] };
+  }
+}
+
+function writePacketState(state: PacketState): void {
+  ensurePacketStateDir();
+  writeFileSync(getInvestingValuationPacketStateFile(), JSON.stringify(state, null, 2) + "\n", "utf-8");
+}
+
+function normalizeSymbol(symbol: string): string {
+  return symbol.trim().toUpperCase();
+}
+
+function loadPortfolioHoldings(): PortfolioPosition[] {
+  const portfolioFile = Investing.portfolioFile();
+  if (!existsSync(portfolioFile)) return [];
+
+  try {
+    const parsed = JSON.parse(readFileSync(portfolioFile, "utf8")) as any;
+    const positions = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(parsed?.positions)
+        ? parsed.positions
+        : [];
+
+    return positions
+      .map((position: any): PortfolioPosition | null => {
+        const symbol = typeof position?.symbol === "string" ? normalizeSymbol(position.symbol) : "";
+        const shares = Number(position?.shares ?? 0);
+        const averageCost = Number(
+          position?.averageCost ??
+            position?.average_cost ??
+            position?.avg_cost ??
+            position?.entryPrice ??
+            position?.entry_price ??
+            position?.price ??
+            0,
+        );
+        if (!symbol || !Number.isFinite(shares) || shares <= 0) return null;
+        return { symbol, shares, averageCost };
+      })
+      .filter((position: PortfolioPosition | null): position is PortfolioPosition => Boolean(position));
+  } catch {
+    return [];
+  }
+}
+
+function buildPortfolioContext(symbol: string): InvestingValuationPacket["portfolioContext"] {
+  const position = loadPortfolioHoldings().find((entry) => entry.symbol === normalizeSymbol(symbol));
+  if (!position) {
+    return { positionStatus: "unclassified" };
+  }
+
+  return {
+    positionStatus: "holding",
+    shares: position.shares,
+    averageCost: position.averageCost,
+  };
+}
+
+function buildOperationsContext(packet: {
+  symbol: string;
+  portfolioContext: InvestingValuationPacket["portfolioContext"];
+  createdAt: string;
+}): InvestingValuationPacket["operationsContext"] {
+  return {
+    consumer: "portfolio-ops",
+    audience: packet.portfolioContext.positionStatus === "holding" ? "holdings" : "general",
+    auditKey: `portfolio-ops:${packet.symbol}:${packet.createdAt}`,
+  };
+}
+
+function renderPacketMarkdown(packet: InvestingValuationPacket): string {
+  const methodLines = packet.methods
+    .map((method) => `- ${method.method}: ${method.summary}`)
+    .join("\n");
+  const sensitivityLines = packet.sensitivityTables
+    .map((table) => `- ${table.title}: ${table.rows.length} row(s)`)
+    .join("\n");
+
+  return [
+    `# Valuation Packet: ${packet.symbol}`,
+    "",
+    `- Case: ${packet.valuationCaseId}`,
+    `- Summary: ${packet.summary}`,
+    `- Signal: ${packet.verdict.signal}`,
+    `- Current price: ${packet.verdict.currentPrice ?? "n/a"}`,
+    `- Fair value: ${packet.verdict.fairValue ?? "n/a"}`,
+    `- Upside: ${packet.verdict.upsidePercent ?? "n/a"}`,
+    "",
+    "## Methods",
+    methodLines || "- none",
+    "",
+    "## Sensitivity",
+    sensitivityLines || "- none",
+    "",
+    "## Ops Context",
+    `- Audience: ${packet.operationsContext.audience}`,
+    `- Audit key: ${packet.operationsContext.auditKey}`,
+  ].join("\n");
+}
+
+export function findInvestingValuationPacketByRun(runId: string): InvestingValuationPacket | null {
+  const state = readPacketState();
+  return state.packets.find((packet) => packet.runId === runId) ?? null;
+}
+
+export function createInvestingValuationPacket(
+  input: CreateInvestingValuationPacketInput,
+): InvestingValuationPacket {
+  const state = readPacketState();
+  const existing = state.packets.find((packet) => packet.runId === input.run.id);
+  if (existing && !input.overwrite) {
+    return existing;
+  }
+
+  const createdAt = new Date().toISOString();
+  const portfolioContext = buildPortfolioContext(input.run.symbol);
+  const packet: InvestingValuationPacket = {
+    id: existing?.id ?? `valuation-packet-${randomUUID().slice(0, 12)}`,
+    schemaVersion: "valuation-packet.v1",
+    runId: input.run.id,
+    valuationCaseId: input.run.valuationCaseId,
+    symbol: input.run.symbol,
+    createdAt: existing?.createdAt ?? createdAt,
+    summary: input.run.summary,
+    verdict: {
+      fairValue: input.run.blendedFairValue,
+      currentPrice: input.run.currentPrice,
+      upsidePercent: input.run.upsidePercent,
+      signal: input.run.thesisContext.signal,
+    },
+    portfolioContext,
+    operationsContext: buildOperationsContext({
+      symbol: input.run.symbol,
+      portfolioContext,
+      createdAt,
+    }),
+    methods: input.run.methods,
+    assumptionProvenance: input.run.assumptionProvenance,
+    sensitivityTables: input.run.sensitivityTables,
+    thesisContext: input.run.thesisContext,
+    audit: {
+      generatedAt: existing?.audit.generatedAt ?? createdAt,
+      lastExportedAt: existing?.audit.lastExportedAt,
+      exportCount: existing?.audit.exportCount ?? 0,
+    },
+  };
+
+  state.packets = [packet, ...state.packets.filter((entry) => entry.id !== packet.id)].slice(0, 300);
+  writePacketState(state);
+
+  FluxRecorder.record({
+    traceID: packet.id,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.valuation.packet",
+    status: "ok",
+    method: existing ? "update" : "create",
+    path: packet.symbol,
+    route: packet.id,
+    metadata: {
+      runId: packet.runId,
+      valuationCaseId: packet.valuationCaseId,
+      audience: packet.operationsContext.audience,
+      schemaVersion: packet.schemaVersion,
+    },
+  });
+
+  return packet;
+}
+
+export function getInvestingValuationPacket(packetId: string): InvestingValuationPacket | null {
+  const state = readPacketState();
+  return state.packets.find((packet) => packet.id === packetId) ?? null;
+}
+
+export function listInvestingValuationPackets(options?: {
+  symbol?: string;
+  runId?: string;
+  limit?: number;
+}): InvestingValuationPacket[] {
+  const normalizedSymbol = options?.symbol ? normalizeSymbol(options.symbol) : undefined;
+  const state = readPacketState();
+  return state.packets
+    .filter((packet) => (normalizedSymbol ? packet.symbol === normalizedSymbol : true))
+    .filter((packet) => (options?.runId ? packet.runId === options.runId : true))
+    .slice(0, options?.limit ?? 20);
+}
+
+export function exportInvestingValuationPacket(input: {
+  packetId: string;
+  format: ExportFormat;
+}): { packet: InvestingValuationPacket; content: string } {
+  const state = readPacketState();
+  const packet = state.packets.find((entry) => entry.id === input.packetId);
+  if (!packet) {
+    throw new Error(`Valuation packet not found: ${input.packetId}`);
+  }
+
+  packet.audit.exportCount += 1;
+  packet.audit.lastExportedAt = new Date().toISOString();
+  writePacketState(state);
+
+  FluxRecorder.record({
+    traceID: packet.id,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.valuation.packet.export",
+    status: "ok",
+    method: "export",
+    path: input.format,
+    route: packet.id,
+    metadata: {
+      runId: packet.runId,
+      valuationCaseId: packet.valuationCaseId,
+      exportCount: packet.audit.exportCount,
+    },
+  });
+
+  return {
+    packet,
+    content: input.format === "markdown" ? renderPacketMarkdown(packet) : JSON.stringify(packet, null, 2),
+  };
+}

--- a/src/domain/investing/valuation.ts
+++ b/src/domain/investing/valuation.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import { FluxRecorder } from "../../../packages/zee/src/flux";
 import { Log } from "../../../packages/zee/src/util/log";
 import { Investing } from "../../paths";
+import { createInvestingValuationPacket } from "./valuation-packet";
 
 const log = Log.create({ service: "investing:valuation-kernel" });
 
@@ -73,6 +74,7 @@ export interface InvestingValuationKernelRun {
   id: string;
   symbol: string;
   valuationCaseId: string;
+  packetId?: string;
   status: InvestingValuationKernelStatus;
   createdAt: string;
   peerSymbols: string[];
@@ -792,6 +794,18 @@ export async function runInvestingValuationKernel(
         rowCount: table.rows.length,
         title: table.title,
       },
+    });
+  }
+
+  try {
+    const packet = createInvestingValuationPacket({ run });
+    run.packetId = packet.id;
+    state.runs = state.runs.map((entry) => (entry.id === run.id ? run : entry));
+    writeValuationState(state);
+  } catch (error) {
+    log.warn("failed to create valuation packet", {
+      runId: run.id,
+      error: error instanceof Error ? error.message : String(error),
     });
   }
 


### PR DESCRIPTION
## Summary
- add a standardized valuation packet store with auto-generated packets layered on top of valuation kernel runs
- expose the `zee:invest-valuation-packets` tool with read/list/export actions and audit/export counters for downstream ops
- document the packet contract and validate portfolio-context handling plus markdown/json export with tests

## Local verification
- `bash scripts/bun-audit-ci.sh`
- `bash scripts/verify-skills.sh`
- `cd packages/zee && bun run typecheck`
- `cd packages/zee && bun test ./test/investing/valuation-kernel.test.ts ./test/investing/valuation-packet.test.ts ./test/investing/research-planner.test.ts`
- `cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov`
- `cd packages/zee && bun run build`
- `cd packages/zee && ./script/verify-binary.sh`

Closes #505
