### PR TITLE
feat(#487): add runtime parity release gate

### DIFF
--- a/docs/architecture/opencode-runtime-rollout.md
+++ b/docs/architecture/opencode-runtime-rollout.md
@@ -1,6 +1,6 @@
 # OpenCode Runtime Rollout
 
-This document is the operator-facing control surface for issue `#486`: switching Zee's primary execution path to the OpenCode runtime with staged enablement, explicit rollback, and telemetry.
+This document is the operator-facing control surface for issues `#486` and `#487`: switching Zee's primary execution path to the OpenCode runtime with staged enablement, parity telemetry, explicit fallback SLOs, and rollback guidance.
 
 ## Source Of Truth
 
@@ -27,6 +27,18 @@ bun run --conditions=browser ./src/index.ts inspect runtime-rollout --no-json
 - `ZEE_RUNTIME_OPENCODE_ALLOW_LEGACY_FALLBACK`
   Boolean gate recorded in telemetry so operators can distinguish staged fallback mode from a hard cutover.
 
+## Parity Window And SLO
+
+- `zee inspect runtime-rollout` evaluates a trailing `24h` window of runtime route events.
+- Flux route counters are grouped per surface:
+  - `runtime.opencode.route.selected`
+  - `runtime.opencode.route.fallback`
+- Release SLO:
+  - `cli`: `0` fallback events, `0%` fallback rate
+  - `orchestration`: `0` fallback events, `0%` fallback rate
+  - `gateway`: `0` fallback events, `0%` fallback rate
+- Any forced-legacy surface or any fallback traffic inside the trailing window is treated as a parity breach and blocks `zee v3 release --strict`.
+
 ## Surface Mapping
 
 - `zee run` now creates sessions with `surface: "cli"`, so standard CLI prompts report against the CLI runtime surface.
@@ -49,6 +61,30 @@ export ZEE_RUNTIME_OPENCODE_SURFACES=cli
 export ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES=orchestration,gateway
 ```
 
+Recommended rollback runbook when `inspect runtime-rollout` reports a breach:
+
+1. Pin all tracked surfaces to legacy:
+
+```bash
+export ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES=cli,orchestration,gateway
+export ZEE_RUNTIME_OPENCODE_ALLOW_LEGACY_FALLBACK=true
+```
+
+2. Restart Zee server and daemon workers so the updated route controls are active.
+3. Re-run the operator report:
+
+```bash
+cd packages/zee
+bun run --conditions=browser ./src/index.ts inspect runtime-rollout --no-json
+```
+
+4. Fix the parity/control-plane regression, clear the forced-legacy override, and require:
+
+```bash
+cd packages/zee
+bun run --conditions=browser ./src/index.ts v3 release --strict
+```
+
 ## Telemetry
 
 - Bus event: `runtime.opencode-rollout.inspected`
@@ -60,4 +96,9 @@ export ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES=orchestration,gateway
   - `primarySurfaceCount`
   - `legacySurfaceCount`
   - `forcedLegacySurfaceCount`
+  - `routeEventCount`
+  - `fallbackEventCount`
+  - `breachCount`
+  - `releaseReady`
+  - `windowHours`
   - `allowLegacyFallback`

--- a/docs/architecture/v3-release-readiness.md
+++ b/docs/architecture/v3-release-readiness.md
@@ -17,7 +17,7 @@ This document defines the executable v3 gate introduced by `zee v3`.
   - `zee v3 plan <objective> [--execute]`
   - `zee v3 release [--strict]`
 - Release gate:
-  - combines memory, swarm mesh, agentic-flow, and deep security audit checks
+  - combines memory, swarm mesh, agentic-flow, OpenCode runtime parity, and deep security audit checks
 
 ## Operational usage
 - Inspect readiness:
@@ -26,6 +26,14 @@ This document defines the executable v3 gate introduced by `zee v3`.
   - `zee v3 plan "objective text" --steps 6 --execute`
 - Enforce CI-like strict gate:
   - `zee v3 release --strict`
+
+## Runtime parity tie-in
+- `zee v3 status` and `zee v3 release` both embed the `inspect runtime-rollout` parity verdict.
+- The runtime gate is `runtime.opencode-parity`.
+- `zee v3 release` emits the same `runtime.opencode-rollout.inspected` bus telemetry used by the inspect command.
+- The gate blocks release when:
+  - any tracked surface is still pinned to legacy
+  - any `runtime.opencode.route.fallback` traffic appears in the trailing `24h` parity window
 
 ## Security tie-in
 - v3 release gate consumes deep security audit output.

--- a/packages/zee/src/cli/cmd/v3.ts
+++ b/packages/zee/src/cli/cmd/v3.ts
@@ -1,11 +1,17 @@
 import type { Argv } from "yargs"
 import { cmd } from "./cmd"
+import { bootstrap } from "../bootstrap"
 import { Config } from "../../config/config"
 import { auditControlUiSecurityDeep, emitSecurityAuditTelemetry } from "@/security"
 import { getAgentDbMemoryStats } from "@/memory/agentdb-service"
 import { getHierarchicalMeshCoordinator } from "@/coordination/hierarchical-mesh"
 import { AgenticFlowBridge } from "@/orchestration/agentic-flow-bridge"
 import { getNodeClientRegistry, resolveNodeClientPolicy } from "@/gateway/node-client-registry"
+import {
+  buildOpenCodeRuntimeReleaseGate,
+  buildOpenCodeRuntimeRolloutReport,
+  emitOpenCodeRuntimeRolloutTelemetry,
+} from "@/runtime/opencode-rollout"
 
 type V3StatusArgs = {
   json?: boolean
@@ -38,6 +44,11 @@ async function collectV3Status(options: { emitSecurityTelemetry?: boolean } = {}
   const nodeStats = await getNodeClientRegistry().getStats()
   const flowBridge = new AgenticFlowBridge()
   const samplePlan = flowBridge.decomposeObjective("memory sync; swarm routing; release gate", { maxSteps: 3 })
+  const runtimeRollout = buildOpenCodeRuntimeRolloutReport()
+  if (options.emitSecurityTelemetry) {
+    await emitOpenCodeRuntimeRolloutTelemetry(runtimeRollout)
+  }
+  const runtimeGate = buildOpenCodeRuntimeReleaseGate(runtimeRollout)
 
   const gates = [
     { id: "memory.agentdb", ok: true, details: "Unified AgentDB memory service is wired through server routes." },
@@ -56,6 +67,7 @@ async function collectV3Status(options: { emitSecurityTelemetry?: boolean } = {}
       ok: true,
       details: "v3 status/plan/release command surface available for operator workflows.",
     },
+    runtimeGate,
     {
       id: "release.security",
       ok: security.ok,
@@ -78,6 +90,7 @@ async function collectV3Status(options: { emitSecurityTelemetry?: boolean } = {}
       policy: nodePolicy,
       stats: nodeStats,
     },
+    runtimeRollout,
     security,
     gates,
     readyForRelease: gates.every((gate) => gate.ok),
@@ -94,16 +107,18 @@ const V3StatusCommand = cmd({
       describe: "output JSON",
     }),
   handler: async (args: V3StatusArgs) => {
-    const status = await collectV3Status()
-    if (args.json) {
-      console.log(JSON.stringify(status, null, 2))
-      return
-    }
+    await bootstrap(process.cwd(), async () => {
+      const status = await collectV3Status()
+      if (args.json) {
+        console.log(JSON.stringify(status, null, 2))
+        return
+      }
 
-    console.log(`v3 release readiness: ${status.readyForRelease ? "ready" : "blocked"}`)
-    for (const gate of status.gates) {
-      console.log(`- ${gate.ok ? "ok" : "fail"} ${gate.id}: ${gate.details}`)
-    }
+      console.log(`v3 release readiness: ${status.readyForRelease ? "ready" : "blocked"}`)
+      for (const gate of status.gates) {
+        console.log(`- ${gate.ok ? "ok" : "fail"} ${gate.id}: ${gate.details}`)
+      }
+    })
   },
 })
 
@@ -133,22 +148,24 @@ const V3PlanCommand = cmd({
         describe: "output JSON",
       }),
   handler: async (args: V3PlanArgs) => {
-    const bridge = new AgenticFlowBridge()
-    const plan = bridge.decomposeObjective(args.objective, { maxSteps: args.steps })
-    const result = args.execute ? await bridge.runPlan(plan) : undefined
+    await bootstrap(process.cwd(), async () => {
+      const bridge = new AgenticFlowBridge()
+      const plan = bridge.decomposeObjective(args.objective, { maxSteps: args.steps })
+      const result = args.execute ? await bridge.runPlan(plan) : undefined
 
-    if (args.json) {
-      console.log(JSON.stringify({ plan, result }, null, 2))
-      return
-    }
+      if (args.json) {
+        console.log(JSON.stringify({ plan, result }, null, 2))
+        return
+      }
 
-    console.log(`flow: ${plan.id}`)
-    for (const step of plan.steps) {
-      console.log(`- ${step.id}: ${step.prompt}`)
-    }
-    if (result) {
-      console.log(`submitted: ${result.submitted.length} step(s)`)
-    }
+      console.log(`flow: ${plan.id}`)
+      for (const step of plan.steps) {
+        console.log(`- ${step.id}: ${step.prompt}`)
+      }
+      if (result) {
+        console.log(`submitted: ${result.submitted.length} step(s)`)
+      }
+    })
   },
 })
 
@@ -168,19 +185,21 @@ const V3ReleaseCommand = cmd({
         describe: "exit 1 when release is blocked",
       }),
   handler: async (args: V3ReleaseArgs) => {
-    const status = await collectV3Status({ emitSecurityTelemetry: true })
-    if (args.json) {
-      console.log(JSON.stringify(status, null, 2))
-    } else {
-      console.log(`v3 release gate: ${status.readyForRelease ? "PASS" : "FAIL"}`)
-      for (const gate of status.gates) {
-        console.log(`- ${gate.ok ? "ok" : "fail"} ${gate.id}: ${gate.details}`)
+    await bootstrap(process.cwd(), async () => {
+      const status = await collectV3Status({ emitSecurityTelemetry: true })
+      if (args.json) {
+        console.log(JSON.stringify(status, null, 2))
+      } else {
+        console.log(`v3 release gate: ${status.readyForRelease ? "PASS" : "FAIL"}`)
+        for (const gate of status.gates) {
+          console.log(`- ${gate.ok ? "ok" : "fail"} ${gate.id}: ${gate.details}`)
+        }
       }
-    }
 
-    if (args.strict && !status.readyForRelease) {
-      process.exit(1)
-    }
+      if (args.strict && !status.readyForRelease) {
+        process.exit(1)
+      }
+    })
   },
 })
 

--- a/packages/zee/src/runtime/opencode-rollout.ts
+++ b/packages/zee/src/runtime/opencode-rollout.ts
@@ -1,6 +1,6 @@
 import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
-import { FluxRecorder } from "@/flux"
+import { FluxRecorder, type FluxEvent } from "@/flux"
 import { Flag } from "@/flag/flag"
 import { Log } from "@/util/log"
 import type { RuntimeContractSurface } from "./opencode-contract"
@@ -9,6 +9,8 @@ import z from "zod"
 const log = Log.create({ service: "runtime:opencode-rollout" })
 
 const DEFAULT_PRIMARY_SURFACES: RuntimeContractSurface[] = ["cli", "orchestration", "gateway"]
+const ROUTE_FLUX_KINDS = ["runtime.opencode.route.selected", "runtime.opencode.route.fallback"] as const
+const ROLLOUT_WINDOW_HOURS = 24
 const ENABLE_FLAG = "ZEE_RUNTIME_OPENCODE_SURFACES"
 const FORCE_LEGACY_FLAG = "ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES"
 const ALLOW_LEGACY_FALLBACK_FLAG = "ZEE_RUNTIME_OPENCODE_ALLOW_LEGACY_FALLBACK"
@@ -31,11 +33,50 @@ export type OpenCodeRuntimeRolloutSurface = {
   reason: OpenCodeRuntimeRouteReason
 }
 
+export type OpenCodeRuntimeFallbackSlo = {
+  maxFallbackRate: number
+  maxFallbackEvents: number
+}
+
+export type OpenCodeRuntimeFallbackBreach = {
+  surface: RuntimeContractSurface
+  route: OpenCodeRuntimeRoute
+  reason: OpenCodeRuntimeRouteReason
+  fallbackEvents: number
+  fallbackRate: number
+  maxFallbackRate: number
+  maxFallbackEvents: number
+  breachReasons: string[]
+}
+
+export type OpenCodeRuntimeParitySurface = OpenCodeRuntimeRolloutSurface & {
+  selectedEvents: number
+  fallbackEvents: number
+  routeEvents: number
+  fallbackRate: number
+  lastSelectedAt?: string
+  lastFallbackAt?: string
+  reasons: Record<OpenCodeRuntimeRouteReason, number>
+  slo: OpenCodeRuntimeFallbackSlo & {
+    status: "ok" | "breach" | "no_traffic"
+  }
+}
+
+export type OpenCodeRuntimeReleaseGate = {
+  id: "runtime.opencode-parity"
+  ok: boolean
+  details: string
+  breachCount: number
+  fallbackEvents: number
+  routeEvents: number
+  windowHours: number
+}
+
 export type OpenCodeRuntimeRolloutReport = {
   reportId: "opencode-runtime-rollout"
   reportVersion: 1
   generatedAt: string
-  roadmapIssue: number
+  roadmapIssue: 487
   upstreamTarget: "sst/opencode"
   defaultRoute: OpenCodeRuntimeRoute
   controlFlags: {
@@ -47,14 +88,39 @@ export type OpenCodeRuntimeRolloutReport = {
     allowLegacyFallback: boolean
   }
   surfaces: OpenCodeRuntimeRolloutSurface[]
+  parityWindow: {
+    hours: number
+    startedAt: string
+    endedAt: string
+  }
+  parity: {
+    routeEvents: number
+    selectedEvents: number
+    fallbackEvents: number
+    fallbackRate: number
+    releaseReady: boolean
+    breaches: OpenCodeRuntimeFallbackBreach[]
+    surfaces: OpenCodeRuntimeParitySurface[]
+  }
+  rollback: {
+    recommended: boolean
+    command: string
+    reason: string
+    runbook: string[]
+  }
   telemetry: {
     eventType: string
-    fluxKinds: ["runtime.opencode.route.selected", "runtime.opencode.route.fallback"]
+    fluxKinds: typeof ROUTE_FLUX_KINDS
     metrics: {
       surfaceCount: number
       primarySurfaceCount: number
       legacySurfaceCount: number
       forcedLegacySurfaceCount: number
+      routeEventCount: number
+      fallbackEventCount: number
+      breachCount: number
+      releaseReady: boolean
+      windowHours: number
       allowLegacyFallback: boolean
     }
   }
@@ -69,9 +135,185 @@ export const OpenCodeRuntimeRolloutInspected = BusEvent.define(
     primarySurfaceCount: z.number().int().nonnegative(),
     legacySurfaceCount: z.number().int().nonnegative(),
     forcedLegacySurfaceCount: z.number().int().nonnegative(),
+    routeEventCount: z.number().int().nonnegative(),
+    fallbackEventCount: z.number().int().nonnegative(),
+    breachCount: z.number().int().nonnegative(),
+    releaseReady: z.boolean(),
+    windowHours: z.number().int().positive(),
     allowLegacyFallback: z.boolean(),
   }),
 )
+
+const FALLBACK_SLO_THRESHOLDS: Record<RuntimeContractSurface, OpenCodeRuntimeFallbackSlo> = {
+  cli: { maxFallbackRate: 0, maxFallbackEvents: 0 },
+  orchestration: { maxFallbackRate: 0, maxFallbackEvents: 0 },
+  gateway: { maxFallbackRate: 0, maxFallbackEvents: 0 },
+}
+
+function createReasonCounts(): Record<OpenCodeRuntimeRouteReason, number> {
+  return {
+    default_primary: 0,
+    surface_disabled: 0,
+    forced_legacy: 0,
+  }
+}
+
+function isRuntimeContractSurface(value: unknown): value is RuntimeContractSurface {
+  return value === "cli" || value === "orchestration" || value === "gateway"
+}
+
+function isOpenCodeRuntimeRouteReason(value: unknown): value is OpenCodeRuntimeRouteReason {
+  return value === "default_primary" || value === "surface_disabled" || value === "forced_legacy"
+}
+
+function toIsoTimestamp(timestamp: number | undefined): string | undefined {
+  return typeof timestamp === "number" ? new Date(timestamp).toISOString() : undefined
+}
+
+function listFluxEventsPaginated(query: {
+  kind: (typeof ROUTE_FLUX_KINDS)[number]
+  from: number
+  to: number
+}): FluxEvent[] {
+  const events: FluxEvent[] = []
+  let offset = 0
+
+  while (true) {
+    const page = FluxRecorder.list({
+      domain: "runtime",
+      kind: query.kind,
+      from: query.from,
+      to: query.to,
+      limit: 1000,
+      offset,
+    })
+
+    events.push(...page.events)
+    if (page.events.length < 1000) break
+    offset += page.events.length
+  }
+
+  return events
+}
+
+function collectOpenCodeRuntimeRouteEvents(windowStart: number, windowEnd: number): FluxEvent[] {
+  return ROUTE_FLUX_KINDS.flatMap((kind) =>
+    listFluxEventsPaginated({
+      kind,
+      from: windowStart,
+      to: windowEnd,
+    }),
+  )
+}
+
+function buildSurfaceParity(input: {
+  surfaces: OpenCodeRuntimeRolloutSurface[]
+  routeEvents: FluxEvent[]
+}): {
+  surfaces: OpenCodeRuntimeParitySurface[]
+  breaches: OpenCodeRuntimeFallbackBreach[]
+  routeEvents: number
+  selectedEvents: number
+  fallbackEvents: number
+  fallbackRate: number
+  releaseReady: boolean
+} {
+  const eventsBySurface = new Map<RuntimeContractSurface, FluxEvent[]>()
+  for (const surface of DEFAULT_PRIMARY_SURFACES) {
+    eventsBySurface.set(surface, [])
+  }
+
+  let selectedEvents = 0
+  let fallbackEvents = 0
+
+  for (const event of input.routeEvents) {
+    if (event.kind === "runtime.opencode.route.selected") selectedEvents++
+    if (event.kind === "runtime.opencode.route.fallback") fallbackEvents++
+
+    const surface = event.metadata?.surface
+    if (!isRuntimeContractSurface(surface)) continue
+    eventsBySurface.get(surface)?.push(event)
+  }
+
+  const paritySurfaces = input.surfaces.map((surface) => {
+    const events = eventsBySurface.get(surface.surface) ?? []
+    const selectedForSurface = events.filter((event) => event.kind === "runtime.opencode.route.selected")
+    const fallbackForSurface = events.filter((event) => event.kind === "runtime.opencode.route.fallback")
+    const reasons = createReasonCounts()
+
+    for (const event of events) {
+      const reason = event.metadata?.reason
+      if (isOpenCodeRuntimeRouteReason(reason)) {
+        reasons[reason]++
+      }
+    }
+
+    const routeEvents = events.length
+    const fallbackRate = routeEvents > 0 ? fallbackForSurface.length / routeEvents : 0
+    const threshold = FALLBACK_SLO_THRESHOLDS[surface.surface]
+    const forcedLegacyBreach = surface.route === "legacy_fallback"
+    const countBreach = fallbackForSurface.length > threshold.maxFallbackEvents
+    const rateBreach = fallbackRate > threshold.maxFallbackRate
+    const breached = forcedLegacyBreach || countBreach || rateBreach
+    const status: OpenCodeRuntimeParitySurface["slo"]["status"] =
+      routeEvents === 0 && !breached ? "no_traffic" : breached ? "breach" : "ok"
+
+    return {
+      surface: surface.surface,
+      route: surface.route,
+      reason: surface.reason,
+      selectedEvents: selectedForSurface.length,
+      fallbackEvents: fallbackForSurface.length,
+      routeEvents,
+      fallbackRate,
+      lastSelectedAt: toIsoTimestamp(selectedForSurface.at(-1)?.timestamp),
+      lastFallbackAt: toIsoTimestamp(fallbackForSurface.at(-1)?.timestamp),
+      reasons,
+      slo: {
+        ...threshold,
+        status,
+      },
+    }
+  })
+
+  const breaches = paritySurfaces
+    .filter((surface) => surface.slo.status === "breach")
+    .map((surface) => {
+      const breachReasons: string[] = []
+      if (surface.route === "legacy_fallback") {
+        breachReasons.push("surface is not routed to the OpenCode primary path")
+      }
+      if (surface.fallbackEvents > surface.slo.maxFallbackEvents) {
+        breachReasons.push(`fallback events ${surface.fallbackEvents} exceed limit ${surface.slo.maxFallbackEvents}`)
+      }
+      if (surface.fallbackRate > surface.slo.maxFallbackRate) {
+        breachReasons.push(`fallback rate ${(surface.fallbackRate * 100).toFixed(1)}% exceeds ${(surface.slo.maxFallbackRate * 100).toFixed(1)}%`)
+      }
+
+      return {
+        surface: surface.surface,
+        route: surface.route,
+        reason: surface.reason,
+        fallbackEvents: surface.fallbackEvents,
+        fallbackRate: surface.fallbackRate,
+        maxFallbackRate: surface.slo.maxFallbackRate,
+        maxFallbackEvents: surface.slo.maxFallbackEvents,
+        breachReasons,
+      }
+    })
+
+  const routeEventCount = input.routeEvents.length
+
+  return {
+    surfaces: paritySurfaces,
+    breaches,
+    routeEvents: routeEventCount,
+    selectedEvents,
+    fallbackEvents,
+    fallbackRate: routeEventCount > 0 ? fallbackEvents / routeEventCount : 0,
+    releaseReady: breaches.length === 0,
+  }
+}
 
 function parseBoolean(value: string | undefined, fallback: boolean): boolean {
   if (!value) return fallback
@@ -204,7 +446,12 @@ export function recordOpenCodeRuntimeRoute(input: {
   return selection
 }
 
-export function buildOpenCodeRuntimeRolloutReport(now: Date = new Date()): OpenCodeRuntimeRolloutReport {
+export function buildOpenCodeRuntimeRolloutReport(
+  now: Date = new Date(),
+  options: {
+    routeEvents?: FluxEvent[]
+  } = {},
+): OpenCodeRuntimeRolloutReport {
   const surfaces = DEFAULT_PRIMARY_SURFACES.map((surface) => {
     const selection = resolveOpenCodeRuntimeRoute(surface)
     return {
@@ -217,12 +464,24 @@ export function buildOpenCodeRuntimeRolloutReport(now: Date = new Date()): OpenC
   const legacySurfaceCount = surfaces.length - primarySurfaceCount
   const forcedLegacySurfaceCount = surfaces.filter((surface) => surface.reason === "forced_legacy").length
   const sample = resolveOpenCodeRuntimeRoute("cli")
+  const windowEnd = now.getTime()
+  const windowStart = windowEnd - ROLLOUT_WINDOW_HOURS * 60 * 60 * 1000
+  const routeEvents = options.routeEvents ?? collectOpenCodeRuntimeRouteEvents(windowStart, windowEnd)
+  const parity = buildSurfaceParity({
+    surfaces,
+    routeEvents,
+  })
+  const rollbackCommand = `export ${FORCE_LEGACY_FLAG}=cli,orchestration,gateway`
+  const rollbackReason =
+    parity.breaches.length > 0
+      ? `fallback SLO breach on ${parity.breaches.map((breach) => breach.surface).join(", ")}`
+      : "OpenCode primary parity is within the fallback SLO for all tracked surfaces."
 
   return {
     reportId: "opencode-runtime-rollout",
     reportVersion: 1,
     generatedAt: now.toISOString(),
-    roadmapIssue: 486,
+    roadmapIssue: 487,
     upstreamTarget: "sst/opencode",
     defaultRoute: "opencode_primary",
     controlFlags: {
@@ -234,14 +493,37 @@ export function buildOpenCodeRuntimeRolloutReport(now: Date = new Date()): OpenC
       allowLegacyFallback: sample.allowLegacyFallback,
     },
     surfaces,
+    parityWindow: {
+      hours: ROLLOUT_WINDOW_HOURS,
+      startedAt: new Date(windowStart).toISOString(),
+      endedAt: now.toISOString(),
+    },
+    parity,
+    rollback: {
+      recommended: parity.breaches.length > 0,
+      command: rollbackCommand,
+      reason: rollbackReason,
+      runbook: [
+        `1. Execute \`${rollbackCommand}\` to pin all tracked surfaces to the legacy fallback path.`,
+        `2. Keep ${ALLOW_LEGACY_FALLBACK_FLAG}=true while parity or control-plane regressions are investigated.`,
+        "3. Restart Zee server and daemon workers so the updated route controls take effect everywhere.",
+        "4. Re-run `zee inspect runtime-rollout --no-json` and confirm the breach surfaces are now explicitly forced to legacy.",
+        "5. Fix the parity gap, clear the forced-legacy override, and require `zee v3 release --strict` to pass before resuming rollout.",
+      ],
+    },
     telemetry: {
       eventType: OpenCodeRuntimeRolloutInspected.type,
-      fluxKinds: ["runtime.opencode.route.selected", "runtime.opencode.route.fallback"],
+      fluxKinds: ROUTE_FLUX_KINDS,
       metrics: {
         surfaceCount: surfaces.length,
         primarySurfaceCount,
         legacySurfaceCount,
         forcedLegacySurfaceCount,
+        routeEventCount: parity.routeEvents,
+        fallbackEventCount: parity.fallbackEvents,
+        breachCount: parity.breaches.length,
+        releaseReady: parity.releaseReady,
+        windowHours: ROLLOUT_WINDOW_HOURS,
         allowLegacyFallback: sample.allowLegacyFallback,
       },
     },
@@ -262,22 +544,48 @@ export async function emitOpenCodeRuntimeRolloutTelemetry(report: OpenCodeRuntim
     primarySurfaceCount: report.telemetry.metrics.primarySurfaceCount,
     legacySurfaceCount: report.telemetry.metrics.legacySurfaceCount,
     forcedLegacySurfaceCount: report.telemetry.metrics.forcedLegacySurfaceCount,
+    routeEventCount: report.telemetry.metrics.routeEventCount,
+    fallbackEventCount: report.telemetry.metrics.fallbackEventCount,
+    breachCount: report.telemetry.metrics.breachCount,
+    releaseReady: report.telemetry.metrics.releaseReady,
+    windowHours: report.telemetry.metrics.windowHours,
     allowLegacyFallback: report.telemetry.metrics.allowLegacyFallback,
   })
 }
 
+export function buildOpenCodeRuntimeReleaseGate(report: OpenCodeRuntimeRolloutReport): OpenCodeRuntimeReleaseGate {
+  const forcedLegacyCount = report.surfaces.filter((surface) => surface.route === "legacy_fallback").length
+
+  return {
+    id: "runtime.opencode-parity",
+    ok: report.parity.releaseReady,
+    details:
+      `window=${report.parityWindow.hours}h route-events=${report.parity.routeEvents} ` +
+      `fallback=${report.parity.fallbackEvents} breaches=${report.parity.breaches.length} forced-legacy=${forcedLegacyCount}`,
+    breachCount: report.parity.breaches.length,
+    fallbackEvents: report.parity.fallbackEvents,
+    routeEvents: report.parity.routeEvents,
+    windowHours: report.parityWindow.hours,
+  }
+}
+
 export function summarizeOpenCodeRuntimeRollout(report: OpenCodeRuntimeRolloutReport): string {
+  const fallbackRate = `${(report.parity.fallbackRate * 100).toFixed(1)}%`
   const lines = [
     `OpenCode runtime rollout v${report.reportVersion}`,
     `- default=${report.defaultRoute} primary=${report.telemetry.metrics.primarySurfaceCount} legacy=${report.telemetry.metrics.legacySurfaceCount}`,
     `- flags: ${report.controlFlags.enableFlag}=${report.controlFlags.configuredPrimarySurfaces.join(",")} ${report.controlFlags.forceLegacyFlag}=${report.controlFlags.forcedLegacySurfaces.join(",") || "none"}`,
     `- fallback: ${report.controlFlags.allowLegacyFallbackFlag}=${String(report.controlFlags.allowLegacyFallback)}`,
+    `- parity: window=${report.parityWindow.hours}h route-events=${report.parity.routeEvents} fallback=${report.parity.fallbackEvents} rate=${fallbackRate} breaches=${report.parity.breaches.length} release=${report.parity.releaseReady ? "ready" : "blocked"}`,
   ]
 
-  for (const surface of report.surfaces) {
-    lines.push(`- ${surface.surface}: ${surface.route} (${surface.reason})`)
+  for (const surface of report.parity.surfaces) {
+    lines.push(
+      `- ${surface.surface}: ${surface.route} (${surface.reason}) selected=${surface.selectedEvents} fallback=${surface.fallbackEvents} rate=${(surface.fallbackRate * 100).toFixed(1)}% slo<=${surface.slo.maxFallbackEvents}/${(surface.slo.maxFallbackRate * 100).toFixed(1)}% status=${surface.slo.status}`,
+    )
   }
 
+  lines.push(`- rollback: ${report.rollback.recommended ? "recommended" : "not-required"} :: ${report.rollback.reason}`)
   lines.push(`- telemetry: ${report.telemetry.eventType}`)
   lines.push(`- flux: ${report.telemetry.fluxKinds.join(", ")}`)
   return lines.join("\n")

--- a/packages/zee/test/cli/inspect-command.test.ts
+++ b/packages/zee/test/cli/inspect-command.test.ts
@@ -6,10 +6,12 @@ import {
 } from "../../src/runtime/opencode-contract"
 import {
   buildOpenCodeRuntimeRolloutReport,
+  buildOpenCodeRuntimeReleaseGate,
   summarizeOpenCodeRuntimeRollout,
 } from "../../src/runtime/opencode-rollout"
 import { buildPiMonoCompatReport, summarizePiMonoCompatReport } from "../../src/runtime/pimono-compat"
 import { reloadFlags } from "../../src/flag/flag"
+import type { FluxEvent } from "../../src/flux"
 import type { UsageStats, UsageSummary } from "../../src/usage/types"
 
 function setEnv(name: string, value: string | undefined) {
@@ -73,6 +75,28 @@ function makeSummary(): UsageSummary {
     errorCount: 0,
     errorRate: 0,
     cacheHitRate: 0.3,
+  }
+}
+
+function makeRouteEvent(params: {
+  timestamp: string
+  surface: "cli" | "orchestration" | "gateway"
+  kind: "runtime.opencode.route.selected" | "runtime.opencode.route.fallback"
+  reason?: "default_primary" | "surface_disabled" | "forced_legacy"
+}): FluxEvent {
+  return {
+    id: `${params.surface}-${params.kind}-${params.timestamp}`,
+    timestamp: new Date(params.timestamp).getTime(),
+    traceID: `trace-${params.surface}-${params.kind}-${params.timestamp}`,
+    direction: "internal",
+    domain: "runtime",
+    kind: params.kind,
+    status: "ok",
+    metadata: {
+      surface: params.surface,
+      route: params.kind === "runtime.opencode.route.selected" ? "opencode_primary" : "legacy_fallback",
+      reason: params.reason ?? (params.kind === "runtime.opencode.route.selected" ? "default_primary" : "forced_legacy"),
+    },
   }
 }
 
@@ -177,37 +201,86 @@ describe("inspect command helpers", () => {
         ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES: undefined,
       },
       () => {
-        const report = buildOpenCodeRuntimeRolloutReport(new Date("2026-03-14T12:15:00.000Z"))
+        const report = buildOpenCodeRuntimeRolloutReport(new Date("2026-03-14T12:15:00.000Z"), {
+          routeEvents: [],
+        })
 
         expect(report.reportId).toBe("opencode-runtime-rollout")
+        expect(report.roadmapIssue).toBe(487)
         expect(report.defaultRoute).toBe("opencode_primary")
         expect(report.surfaces.map((surface) => surface.route)).toEqual([
           "opencode_primary",
           "opencode_primary",
           "opencode_primary",
         ])
+        expect(report.parityWindow.hours).toBe(24)
+        expect(report.parity.routeEvents).toBe(0)
+        expect(report.parity.breaches).toHaveLength(0)
+        expect(report.parity.releaseReady).toBe(true)
         expect(report.telemetry.metrics.primarySurfaceCount).toBe(3)
         expect(report.telemetry.metrics.legacySurfaceCount).toBe(0)
+        expect(report.telemetry.metrics.routeEventCount).toBe(0)
+        expect(report.telemetry.metrics.breachCount).toBe(0)
       },
     )
   })
 
-  test("OpenCode runtime rollout summary reflects forced legacy surfaces and flux kinds", async () => {
+  test("OpenCode runtime rollout summary reflects parity breaches and rollback guidance", async () => {
     await withRolloutEnv(
       {
-        ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES: "gateway",
+        ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES: undefined,
       },
       () => {
         const summary = summarizeOpenCodeRuntimeRollout(
-          buildOpenCodeRuntimeRolloutReport(new Date("2026-03-14T12:20:00.000Z")),
+          buildOpenCodeRuntimeRolloutReport(new Date("2026-03-14T12:20:00.000Z"), {
+            routeEvents: [
+              makeRouteEvent({
+                timestamp: "2026-03-14T11:45:00.000Z",
+                surface: "cli",
+                kind: "runtime.opencode.route.selected",
+              }),
+              makeRouteEvent({
+                timestamp: "2026-03-14T11:50:00.000Z",
+                surface: "gateway",
+                kind: "runtime.opencode.route.fallback",
+              }),
+            ],
+          }),
         )
 
         expect(summary).toContain("OpenCode runtime rollout v1")
-        expect(summary).toContain("gateway: legacy_fallback (forced_legacy)")
+        expect(summary).toContain("parity: window=24h route-events=2 fallback=1")
+        expect(summary).toContain("gateway: opencode_primary (default_primary) selected=0 fallback=1")
+        expect(summary).toContain("status=breach")
+        expect(summary).toContain("rollback: recommended")
         expect(summary).toContain("runtime.opencode.route.selected")
         expect(summary).toContain("runtime.opencode.route.fallback")
       },
     )
+  })
+
+  test("OpenCode runtime release gate blocks when parity breaches are present", () => {
+    const report = buildOpenCodeRuntimeRolloutReport(new Date("2026-03-14T12:20:00.000Z"), {
+      routeEvents: [
+        makeRouteEvent({
+          timestamp: "2026-03-14T11:45:00.000Z",
+          surface: "cli",
+          kind: "runtime.opencode.route.selected",
+        }),
+        makeRouteEvent({
+          timestamp: "2026-03-14T11:50:00.000Z",
+          surface: "gateway",
+          kind: "runtime.opencode.route.fallback",
+        }),
+      ],
+    })
+    const gate = buildOpenCodeRuntimeReleaseGate(report)
+
+    expect(gate.id).toBe("runtime.opencode-parity")
+    expect(gate.ok).toBe(false)
+    expect(gate.breachCount).toBe(1)
+    expect(gate.details).toContain("breaches=1")
+    expect(gate.details).toContain("forced-legacy=0")
   })
 
   test("pi-mono compatibility report inventories explicit shim boundaries and statuses", () => {

--- a/packages/zee/test/runtime/opencode-rollout.test.ts
+++ b/packages/zee/test/runtime/opencode-rollout.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test"
 import { reloadFlags } from "../../src/flag/flag"
-import { FluxRecorder } from "../../src/flux"
+import { FluxRecorder, type FluxEvent } from "../../src/flux"
 import {
+  buildOpenCodeRuntimeReleaseGate,
+  buildOpenCodeRuntimeRolloutReport,
   recordOpenCodeRuntimeRoute,
   resolveOpenCodeRuntimeRoute,
   resolveOpenCodeRuntimeSurface,
@@ -46,6 +48,28 @@ async function withRolloutEnv<T>(
     setEnv("ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES", originalLegacy)
     setEnv("ZEE_RUNTIME_OPENCODE_ALLOW_LEGACY_FALLBACK", originalFallback)
     reloadFlags()
+  }
+}
+
+function makeRouteEvent(params: {
+  timestamp: string
+  surface: "cli" | "orchestration" | "gateway"
+  kind: "runtime.opencode.route.selected" | "runtime.opencode.route.fallback"
+  reason?: "default_primary" | "surface_disabled" | "forced_legacy"
+}): FluxEvent {
+  return {
+    id: `${params.surface}-${params.kind}-${params.timestamp}`,
+    timestamp: new Date(params.timestamp).getTime(),
+    traceID: `trace-${params.surface}-${params.kind}-${params.timestamp}`,
+    direction: "internal",
+    domain: "runtime",
+    kind: params.kind,
+    status: "ok",
+    metadata: {
+      surface: params.surface,
+      route: params.kind === "runtime.opencode.route.selected" ? "opencode_primary" : "legacy_fallback",
+      reason: params.reason ?? (params.kind === "runtime.opencode.route.selected" ? "default_primary" : "forced_legacy"),
+    },
   }
 }
 
@@ -110,5 +134,81 @@ describe("OpenCode runtime rollout", () => {
         expect(FluxRecorder.list({ kind: "runtime.opencode.route.fallback" }).total).toBe(fallbackBefore + 1)
       },
     )
+  })
+
+  test("buildOpenCodeRuntimeRolloutReport computes parity counters and breach details from route events", async () => {
+    await withRolloutEnv(
+      {
+        ZEE_RUNTIME_OPENCODE_SURFACES: undefined,
+        ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES: undefined,
+      },
+      () => {
+        const report = buildOpenCodeRuntimeRolloutReport(new Date("2026-03-15T12:00:00.000Z"), {
+          routeEvents: [
+            makeRouteEvent({
+              timestamp: "2026-03-15T11:00:00.000Z",
+              surface: "cli",
+              kind: "runtime.opencode.route.selected",
+            }),
+            makeRouteEvent({
+              timestamp: "2026-03-15T11:05:00.000Z",
+              surface: "gateway",
+              kind: "runtime.opencode.route.fallback",
+            }),
+          ],
+        })
+
+        expect(report.parity.routeEvents).toBe(2)
+        expect(report.parity.selectedEvents).toBe(1)
+        expect(report.parity.fallbackEvents).toBe(1)
+        expect(report.parity.breaches).toHaveLength(1)
+        expect(report.parity.breaches[0]).toMatchObject({
+          surface: "gateway",
+          fallbackEvents: 1,
+          maxFallbackEvents: 0,
+        })
+        expect(report.rollback.recommended).toBe(true)
+        expect(report.telemetry.metrics.breachCount).toBe(1)
+      },
+    )
+  })
+
+  test("buildOpenCodeRuntimeReleaseGate passes only when parity is clean", () => {
+    const cleanReport = buildOpenCodeRuntimeRolloutReport(new Date("2026-03-15T12:00:00.000Z"), {
+      routeEvents: [
+        makeRouteEvent({
+          timestamp: "2026-03-15T11:00:00.000Z",
+          surface: "cli",
+          kind: "runtime.opencode.route.selected",
+        }),
+        makeRouteEvent({
+          timestamp: "2026-03-15T11:01:00.000Z",
+          surface: "orchestration",
+          kind: "runtime.opencode.route.selected",
+        }),
+        makeRouteEvent({
+          timestamp: "2026-03-15T11:02:00.000Z",
+          surface: "gateway",
+          kind: "runtime.opencode.route.selected",
+        }),
+      ],
+    })
+    const cleanGate = buildOpenCodeRuntimeReleaseGate(cleanReport)
+    expect(cleanGate.ok).toBe(true)
+    expect(cleanGate.breachCount).toBe(0)
+
+    const breachReport = buildOpenCodeRuntimeRolloutReport(new Date("2026-03-15T12:00:00.000Z"), {
+      routeEvents: [
+        makeRouteEvent({
+          timestamp: "2026-03-15T11:05:00.000Z",
+          surface: "gateway",
+          kind: "runtime.opencode.route.fallback",
+        }),
+      ],
+    })
+    const breachGate = buildOpenCodeRuntimeReleaseGate(breachReport)
+    expect(breachGate.ok).toBe(false)
+    expect(breachGate.details).toContain("fallback=1")
+    expect(breachGate.details).toContain("breaches=1")
   })
 })


### PR DESCRIPTION
## Summary
- add per-surface runtime parity counters, explicit zero-fallback SLOs, breach reporting, and rollback guidance to `inspect runtime-rollout`
- wire the same runtime parity verdict into `zee v3 status` and `zee v3 release`, and bootstrap the `v3` command handlers so the operator path resolves instance context correctly
- document the rollout runbook and cover the new report and release-gate behavior with focused tests

## Validation
- `bash scripts/bun-audit-ci.sh`
- `bash scripts/verify-skills.sh`
- `bun run --cwd packages/zee typecheck`
- `cd packages/zee && bun test test/runtime/opencode-rollout.test.ts test/cli/inspect-command.test.ts`
- `cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov`
- `cd packages/zee && bun run build`
- `cd packages/zee && ./script/verify-binary.sh`
- `cd packages/zee && bun run script/reliability/run.ts --profile alpha --long-soak-minutes 1`
- `cd packages/zee && bun run --conditions=browser ./src/index.ts inspect runtime-rollout --no-json`
- `zee v3 release --json`

Closes #487