### PR TITLE
feat(#506): add investing event intelligence ingestion

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -188,10 +188,18 @@ rg "export class Memory|getMemory|getMemoryAsync" src/memory/unified.ts  # Unifi
 **Purpose:** Provide user-facing capabilities across life admin, investing, and learning.
 - **Zee tools collection:** `src/domain/zee/tools.ts:1884`
 - **Zee tool registration:** `src/domain/zee/tools.ts:1909`
-- **Stanley tools collection:** `src/domain/investing/tools.ts:456`
-- **Stanley registration:** `src/domain/investing/tools.ts:469`
+- **Stanley tools collection:** `src/domain/investing/tools.ts:1187`
+- **Stanley registration:** `src/domain/investing/tools.ts:1206`
 - **Johny tools collection:** `src/domain/learning/tools.ts:502`
 - **Johny registration:** `src/domain/learning/tools.ts:504`
+
+### Feature: Investing Event Intelligence
+**Purpose:** Classify normalized earnings and news entities into a persistent event ledger for downstream research automation.
+- **Event catalog + classifier:** `packages/zee/src/investing/events.ts:1`
+- **Ingestion hook + telemetry:** `packages/zee/src/investing/ingestion.ts:473`
+- **CLI surface (`zee investing event ...`):** `packages/zee/src/cli/cmd/investing.ts:162`
+- **Stanley tool (`zee:invest-events`):** `src/domain/investing/tools.ts:806`
+- **Operator doc:** `docs/architecture/investing-event-intelligence.md:1`
 
 ### Feature: Memory (Qdrant + Hybrid Search + Markdown Sync)
 **Purpose:** Store and retrieve semantic/keyword/hybrid memories with local Qdrant.

--- a/docs/architecture/investing-event-intelligence.md
+++ b/docs/architecture/investing-event-intelligence.md
@@ -1,0 +1,78 @@
+# Investing Event Intelligence
+
+Zee's event-intelligence layer classifies normalized `earnings` and `news` entities into a persistent event ledger for downstream research automation.
+
+This slice implements issue `#506`: ingestion and classification.
+It does not yet assign materiality scores or briefing deltas; those remain the follow-on work for `#507` and `#508`.
+
+## Source Of Truth
+
+- Event ledger: `~/.local/state/zee/investing-event-intelligence.json`
+- Entity catalog dependency: `~/.local/state/zee/investing-entity-catalog.json`
+
+## Classification Scope
+
+Supported connectors:
+
+- `earnings`
+- `news`
+
+Current classifications:
+
+- `earnings_result`
+- `guidance_update`
+- `mna`
+- `management_change`
+- `legal_regulatory`
+- `product_and_partnership`
+- `capital_allocation`
+- `general_news`
+
+Each record also carries:
+
+- connector (`earnings` or `news`)
+- direction (`positive`, `negative`, `neutral`, `mixed`, `unknown`)
+- classifier confidence (`0.0` to `1.0`)
+- canonical entity linkage (`entityId`, `companyId`, `instrumentId`, `relatedIds`)
+- source provenance (`sourceId`, `sourceType`, optional `sourceUrl`)
+
+## Operator Surfaces
+
+CLI:
+
+```bash
+zee investing event status
+zee investing event list --limit 20
+zee investing event list --connector news --classification guidance_update --symbol MSFT
+zee investing event read classified:event:news:msft:story-1
+```
+
+Domain tool:
+
+- `zee:invest-events`
+  - `status`
+  - `list`
+  - `read`
+
+## Ingestion Flow
+
+1. Connector payloads are normalized into canonical entities.
+2. `earnings` and `news` event entities are classified into the event ledger.
+3. Each classified record is upserted by stable ID (`classified:<entity-id>`).
+4. Connector run telemetry includes classified-event counts and unique event types for that batch.
+
+## Telemetry
+
+Flux events emitted for this slice:
+
+- `investing.event.classified`
+  - one event per inserted or updated classified record
+  - metadata includes `eventId`, `entityId`, `connector`, `classification`, `direction`, `confidence`, `symbol`, and `mode`
+- `investing.ingestion.run`
+  - now includes `classifiedEventCount`, `classifiedEventTypes`, `eventInserted`, and `eventUpdated` when the connector produces classified events
+
+## Notes
+
+- News classification is heuristic and keyword-driven in this slice.
+- Earnings classification is deterministic from the normalized earnings connector event shape.
+- Materiality scoring, precision tuning, and briefing/thesis integration remain follow-on work.

--- a/packages/zee/src/cli/cmd/investing.ts
+++ b/packages/zee/src/cli/cmd/investing.ts
@@ -2,6 +2,17 @@ import type { Argv } from "yargs"
 import { cmd } from "./cmd"
 import { getInvestingEntityCatalogStatus } from "@/investing/entities"
 import {
+  INVESTING_EVENT_CLASSIFICATIONS,
+  INVESTING_EVENT_CONNECTORS,
+  INVESTING_EVENT_DIRECTIONS,
+  getInvestingEvent,
+  getInvestingEventCatalogStatus,
+  listInvestingEvents,
+  type InvestingEventClassification,
+  type InvestingEventConnector,
+  type InvestingEventDirection,
+} from "@/investing/events"
+import {
   INVESTING_CONNECTOR_KINDS,
   getInvestingIngestionStatus,
   registerInvestingIngestionScheduler,
@@ -148,6 +159,134 @@ const InvestingEntityCommand = cmd({
   async handler() {},
 })
 
+const InvestingEventStatusCommand = cmd({
+  command: "status",
+  describe: "show classified investing event intelligence status",
+  builder: (yargs: Argv) =>
+    yargs.option("json", {
+      type: "boolean",
+      default: false,
+      describe: "output as JSON",
+    }),
+  handler: async (args: { json?: boolean }) => {
+    const status = await getInvestingEventCatalogStatus()
+    if (args.json) {
+      console.log(JSON.stringify(status, null, 2))
+      return
+    }
+
+    const updatedAt = status.updatedAt > 0 ? new Date(status.updatedAt).toISOString() : "never"
+    console.log(`events: total=${status.totalEvents} updatedAt=${updatedAt}`)
+    console.log(`- by connector: ${JSON.stringify(status.countsByConnector)}`)
+    console.log(`- by classification: ${JSON.stringify(status.countsByClassification)}`)
+    console.log(`- by direction: ${JSON.stringify(status.countsByDirection)}`)
+  },
+})
+
+const InvestingEventListCommand = cmd({
+  command: "list",
+  describe: "list classified earnings and news events",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("connector", {
+        type: "string",
+        choices: [...INVESTING_EVENT_CONNECTORS],
+        describe: "optional connector filter",
+      })
+      .option("classification", {
+        type: "string",
+        choices: [...INVESTING_EVENT_CLASSIFICATIONS],
+        describe: "optional classification filter",
+      })
+      .option("direction", {
+        type: "string",
+        choices: [...INVESTING_EVENT_DIRECTIONS],
+        describe: "optional direction filter",
+      })
+      .option("symbol", {
+        type: "string",
+        describe: "optional symbol filter",
+      })
+      .option("limit", {
+        type: "number",
+        default: 10,
+        describe: "maximum number of events to return",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: {
+    connector?: InvestingEventConnector
+    classification?: InvestingEventClassification
+    direction?: InvestingEventDirection
+    symbol?: string
+    limit?: number
+    json?: boolean
+  }) => {
+    const events = await listInvestingEvents({
+      connector: args.connector,
+      classification: args.classification,
+      direction: args.direction,
+      symbol: args.symbol,
+      limit: args.limit,
+    })
+    if (args.json) {
+      console.log(JSON.stringify({ events, count: events.length }, null, 2))
+      return
+    }
+    for (const event of events) {
+      console.log(
+        `- ${event.id}: ${event.classification} connector=${event.connector} direction=${event.direction} confidence=${event.confidence.toFixed(2)} symbol=${event.symbol ?? "n/a"} asOf=${event.asOf} title=${event.title}`,
+      )
+    }
+  },
+})
+
+const InvestingEventReadCommand = cmd({
+  command: "read <eventId>",
+  describe: "read one classified event record",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("eventId", {
+        type: "string",
+        demandOption: true,
+        describe: "classified event identifier",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: { eventId?: string; json?: boolean }) => {
+    if (!args.eventId) {
+      throw new Error("eventId is required")
+    }
+    const event = await getInvestingEvent(args.eventId)
+    const payload = event ?? { error: `Event not found: ${args.eventId}` }
+    if (args.json || !event) {
+      console.log(JSON.stringify(payload, null, 2))
+      return
+    }
+
+    console.log(`${event.id}`)
+    console.log(`- classification=${event.classification} connector=${event.connector} direction=${event.direction}`)
+    console.log(`- confidence=${event.confidence.toFixed(2)} symbol=${event.symbol ?? "n/a"} asOf=${event.asOf}`)
+    console.log(`- title=${event.title}`)
+    console.log(`- summary=${event.summary}`)
+    console.log(`- reasons=${event.reasons.join("; ") || "n/a"}`)
+  },
+})
+
+const InvestingEventCommand = cmd({
+  command: "event",
+  describe: "classified news and earnings event intelligence",
+  builder: (yargs: Argv) =>
+    yargs.command(InvestingEventStatusCommand).command(InvestingEventListCommand).command(InvestingEventReadCommand).demandCommand(),
+  async handler() {},
+})
+
 const InvestingIngestScheduleCommand = cmd({
   command: "schedule",
   describe: "register connector schedules in the current always-on process",
@@ -189,6 +328,7 @@ const InvestingIngestCommand = cmd({
 export const InvestingCommand = cmd({
   command: "investing",
   describe: "investing platform operations",
-  builder: (yargs: Argv) => yargs.command(InvestingIngestCommand).command(InvestingEntityCommand).demandCommand(),
+  builder: (yargs: Argv) =>
+    yargs.command(InvestingIngestCommand).command(InvestingEntityCommand).command(InvestingEventCommand).demandCommand(),
   async handler() {},
 })

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -50,6 +50,7 @@ export type FluxKind =
   | "investing.ingestion.backfill"
   | "investing.ingestion.run"
   | "investing.ingestion.schedule"
+  | "investing.event.classified"
   | "investing.research.plan"
   | "investing.research.plan.task"
   | "investing.research.execution"

--- a/packages/zee/src/investing/events.ts
+++ b/packages/zee/src/investing/events.ts
@@ -1,0 +1,502 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import z from "zod"
+import { FluxRecorder } from "@/flux"
+import { Global } from "@/global"
+import type { NormalizedInvestingEntity } from "./entities"
+
+const EVENT_SCHEMA_VERSION = 1 as const
+const EVENT_STATE_FILE = path.join(Global.Path.state, "investing-event-intelligence.json")
+
+export const INVESTING_EVENT_CONNECTORS = ["earnings", "news"] as const
+export const INVESTING_EVENT_CLASSIFICATIONS = [
+  "earnings_result",
+  "guidance_update",
+  "mna",
+  "management_change",
+  "legal_regulatory",
+  "product_and_partnership",
+  "capital_allocation",
+  "general_news",
+] as const
+export const INVESTING_EVENT_DIRECTIONS = ["positive", "negative", "neutral", "mixed", "unknown"] as const
+
+export type InvestingEventConnector = (typeof INVESTING_EVENT_CONNECTORS)[number]
+export type InvestingEventClassification = (typeof INVESTING_EVENT_CLASSIFICATIONS)[number]
+export type InvestingEventDirection = (typeof INVESTING_EVENT_DIRECTIONS)[number]
+
+const InvestingEventConnectorSchema = z.enum(INVESTING_EVENT_CONNECTORS)
+const InvestingEventClassificationSchema = z.enum(INVESTING_EVENT_CLASSIFICATIONS)
+const InvestingEventDirectionSchema = z.enum(INVESTING_EVENT_DIRECTIONS)
+
+export const InvestingEventRecordSchema = z.object({
+  id: z.string(),
+  version: z.literal(EVENT_SCHEMA_VERSION),
+  connector: InvestingEventConnectorSchema,
+  classification: InvestingEventClassificationSchema,
+  direction: InvestingEventDirectionSchema,
+  confidence: z.number().min(0).max(1),
+  title: z.string(),
+  summary: z.string(),
+  asOf: z.string(),
+  capturedAt: z.string(),
+  symbol: z.string().optional(),
+  entityId: z.string(),
+  companyId: z.string().optional(),
+  instrumentId: z.string().optional(),
+  relatedIds: z.array(z.string()).default([]),
+  sourceId: z.string(),
+  sourceType: z.string(),
+  sourceUrl: z.string().optional(),
+  tags: z.array(z.string()).default([]),
+  reasons: z.array(z.string()).default([]),
+})
+
+export const InvestingEventCatalogSchema = z.object({
+  version: z.literal(EVENT_SCHEMA_VERSION),
+  updatedAt: z.number().int().nonnegative(),
+  events: z.record(z.string(), InvestingEventRecordSchema),
+})
+
+export type InvestingEventRecord = z.infer<typeof InvestingEventRecordSchema>
+type InvestingEventCatalog = z.infer<typeof InvestingEventCatalogSchema>
+
+export type InvestingEventCatalogStatus = {
+  version: 1
+  updatedAt: number
+  totalEvents: number
+  countsByConnector: Record<InvestingEventConnector, number>
+  countsByClassification: Record<InvestingEventClassification, number>
+  countsByDirection: Record<InvestingEventDirection, number>
+}
+
+export type InvestingEventCatalogUpdate = InvestingEventCatalogStatus & {
+  batchCount: number
+  inserted: number
+  updated: number
+}
+
+type GenericRecord = Record<string, unknown>
+
+const POSITIVE_KEYWORDS = [
+  "beat",
+  "beats",
+  "raise",
+  "raises",
+  "raised",
+  "strong",
+  "surge",
+  "surges",
+  "approval",
+  "approved",
+  "win",
+  "wins",
+  "record",
+  "growth",
+  "buyback",
+  "partnership",
+  "launch",
+]
+
+const NEGATIVE_KEYWORDS = [
+  "miss",
+  "misses",
+  "cut",
+  "cuts",
+  "warning",
+  "warns",
+  "warned",
+  "probe",
+  "investigation",
+  "lawsuit",
+  "litigation",
+  "recall",
+  "delay",
+  "delays",
+  "layoffs",
+  "downgrade",
+  "weak",
+  "slump",
+  "drop",
+  "antitrust",
+]
+
+const NEWS_CLASSIFICATION_RULES: Array<{
+  classification: InvestingEventClassification
+  keywords: string[]
+}> = [
+  {
+    classification: "guidance_update",
+    keywords: ["guidance", "outlook", "forecast", "reiterates", "raises outlook", "cuts outlook"],
+  },
+  {
+    classification: "mna",
+    keywords: ["acquire", "acquires", "acquisition", "merger", "buyout", "takeover", "deal", "divest"],
+  },
+  {
+    classification: "management_change",
+    keywords: ["ceo", "cfo", "chair", "board", "executive", "appoints", "appointment", "resigns", "steps down"],
+  },
+  {
+    classification: "legal_regulatory",
+    keywords: ["lawsuit", "litigation", "settlement", "investigation", "probe", "sec", "doj", "ftc", "antitrust", "fine", "penalty"],
+  },
+  {
+    classification: "capital_allocation",
+    keywords: ["dividend", "buyback", "repurchase", "offering", "share sale", "debt", "bond", "capital return"],
+  },
+  {
+    classification: "product_and_partnership",
+    keywords: ["launch", "release", "partnership", "contract", "customer", "order", "approval", "deal win"],
+  },
+  {
+    classification: "earnings_result",
+    keywords: ["earnings", "eps", "revenue", "quarter", "q1", "q2", "q3", "q4"],
+  },
+]
+
+function asRecord(value: unknown): GenericRecord | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  return value as GenericRecord
+}
+
+function normalizeText(value: string | undefined): string {
+  return (value ?? "").trim().toLowerCase()
+}
+
+function trimSentence(value: string, maxLength = 280): string {
+  const normalized = value.replace(/\s+/g, " ").trim()
+  if (normalized.length <= maxLength) return normalized
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`
+}
+
+function withDefaultCounts<const T extends readonly string[]>(items: T): Record<T[number], number> {
+  return Object.fromEntries(items.map((item) => [item, 0])) as Record<T[number], number>
+}
+
+function clampConfidence(value: number): number {
+  return Math.max(0, Math.min(1, Number.parseFloat(value.toFixed(2))))
+}
+
+function dedupeEvents(events: InvestingEventRecord[]): InvestingEventRecord[] {
+  const byId = new Map<string, InvestingEventRecord>()
+  for (const event of events) {
+    byId.set(event.id, event)
+  }
+  return [...byId.values()]
+}
+
+function extractSourceUrl(entity: NormalizedInvestingEntity): string | undefined {
+  const fromIdentifiers = entity.identifiers.external.url
+  if (fromIdentifiers) return fromIdentifiers
+  for (const evidence of entity.lineage.evidence) {
+    if (evidence.url) return evidence.url
+  }
+  return undefined
+}
+
+function entityText(entity: NormalizedInvestingEntity): string {
+  const attributes = asRecord(entity.attributes) ?? {}
+  const parts = [
+    entity.title,
+    typeof attributes.summary === "string" ? attributes.summary : undefined,
+    typeof attributes.description === "string" ? attributes.description : undefined,
+    typeof attributes.body === "string" ? attributes.body : undefined,
+    typeof attributes.snippet === "string" ? attributes.snippet : undefined,
+    typeof attributes.headline === "string" ? attributes.headline : undefined,
+  ]
+  return normalizeText(parts.filter((part): part is string => Boolean(part)).join(" "))
+}
+
+function classifyDirection(text: string, fallback: InvestingEventDirection = "neutral"): InvestingEventDirection {
+  const positiveHits = POSITIVE_KEYWORDS.filter((keyword) => text.includes(keyword)).length
+  const negativeHits = NEGATIVE_KEYWORDS.filter((keyword) => text.includes(keyword)).length
+  if (positiveHits > 0 && negativeHits > 0) return "mixed"
+  if (positiveHits > 0) return "positive"
+  if (negativeHits > 0) return "negative"
+  return fallback
+}
+
+function classifyNewsEntity(entity: NormalizedInvestingEntity): {
+  classification: InvestingEventClassification
+  direction: InvestingEventDirection
+  confidence: number
+  reasons: string[]
+} {
+  const text = entityText(entity)
+  const reasons: string[] = []
+
+  for (const rule of NEWS_CLASSIFICATION_RULES) {
+    const hits = rule.keywords.filter((keyword) => text.includes(keyword))
+    if (hits.length === 0) continue
+    reasons.push(`matched ${rule.classification} keywords: ${hits.join(", ")}`)
+    return {
+      classification: rule.classification,
+      direction: classifyDirection(text, "neutral"),
+      confidence: clampConfidence(0.7 + Math.min(0.2, hits.length * 0.08) + (entity.identifiers.symbol ? 0.05 : 0)),
+      reasons,
+    }
+  }
+
+  reasons.push("no high-signal keyword match; falling back to general_news")
+  return {
+    classification: "general_news",
+    direction: classifyDirection(text, "unknown"),
+    confidence: clampConfidence(0.55 + (entity.identifiers.symbol ? 0.05 : 0)),
+    reasons,
+  }
+}
+
+function summarizeEarningsEntity(entity: NormalizedInvestingEntity, classification: InvestingEventClassification): string {
+  const attributes = asRecord(entity.attributes) ?? {}
+  const summary = asRecord(attributes.summary) ?? {}
+  const quarter = typeof attributes.quarter === "string" ? attributes.quarter : undefined
+  const symbol = entity.identifiers.symbol ?? entity.title
+  const parts = [`${symbol}${quarter ? ` ${quarter}` : ""} classified as ${classification.replace(/_/g, " ")}`]
+
+  if (typeof summary.avgEpsSurprisePercent === "number") {
+    parts.push(`avg EPS surprise ${summary.avgEpsSurprisePercent.toFixed(1)}%`)
+  }
+  if (typeof summary.epsGrowthYoy === "number") {
+    parts.push(`EPS growth YoY ${summary.epsGrowthYoy.toFixed(1)}%`)
+  }
+
+  return trimSentence(parts.join("; "))
+}
+
+function summarizeNewsEntity(entity: NormalizedInvestingEntity, classification: InvestingEventClassification): string {
+  const attributes = asRecord(entity.attributes) ?? {}
+  const summary =
+    typeof attributes.summary === "string"
+      ? attributes.summary
+      : typeof attributes.description === "string"
+        ? attributes.description
+        : entity.title
+
+  return trimSentence(`${classification.replace(/_/g, " ")} :: ${summary}`)
+}
+
+function createEventRecord(input: {
+  connector: InvestingEventConnector
+  entity: NormalizedInvestingEntity
+  capturedAt: string
+}): InvestingEventRecord | undefined {
+  if (input.entity.kind !== "event") return undefined
+
+  const entity = input.entity
+  const sourceUrl = extractSourceUrl(entity)
+  const symbol = entity.identifiers.symbol
+
+  if (input.connector === "earnings") {
+    const text = entityText(entity)
+    const classification = text.includes("guidance") || text.includes("outlook") ? "guidance_update" : "earnings_result"
+    const attributes = asRecord(entity.attributes) ?? {}
+    const summary = asRecord(attributes.summary) ?? {}
+    const surprise = typeof summary.avgEpsSurprisePercent === "number" ? summary.avgEpsSurprisePercent : undefined
+    const direction =
+      typeof surprise === "number"
+        ? surprise > 0
+          ? "positive"
+          : surprise < 0
+            ? "negative"
+            : classifyDirection(text, "neutral")
+        : classifyDirection(text, "neutral")
+
+    return InvestingEventRecordSchema.parse({
+      id: `classified:${entity.id}`,
+      version: EVENT_SCHEMA_VERSION,
+      connector: input.connector,
+      classification,
+      direction,
+      confidence: 0.95,
+      title: entity.title,
+      summary: summarizeEarningsEntity(entity, classification),
+      asOf: entity.asOf,
+      capturedAt: input.capturedAt,
+      symbol,
+      entityId: entity.id,
+      companyId: entity.identifiers.company,
+      instrumentId: entity.identifiers.instrument,
+      relatedIds: entity.relatedIds,
+      sourceId: entity.lineage.sourceId,
+      sourceType: entity.lineage.sourceType,
+      sourceUrl,
+      tags: [...new Set(["earnings", ...entity.tags])],
+      reasons: classification === "guidance_update" ? ["earnings text included guidance/outlook language"] : ["earnings connector event"],
+    })
+  }
+
+  const classified = classifyNewsEntity(entity)
+  return InvestingEventRecordSchema.parse({
+    id: `classified:${entity.id}`,
+    version: EVENT_SCHEMA_VERSION,
+    connector: input.connector,
+    classification: classified.classification,
+    direction: classified.direction,
+    confidence: classified.confidence,
+    title: entity.title,
+    summary: summarizeNewsEntity(entity, classified.classification),
+    asOf: entity.asOf,
+    capturedAt: input.capturedAt,
+    symbol,
+    entityId: entity.id,
+    companyId: entity.identifiers.company,
+    instrumentId: entity.identifiers.instrument,
+    relatedIds: entity.relatedIds,
+    sourceId: entity.lineage.sourceId,
+    sourceType: entity.lineage.sourceType,
+    sourceUrl,
+    tags: [...new Set(["news", classified.classification, ...entity.tags])],
+    reasons: classified.reasons,
+  })
+}
+
+function defaultCatalog(): InvestingEventCatalog {
+  return {
+    version: EVENT_SCHEMA_VERSION,
+    updatedAt: 0,
+    events: {},
+  }
+}
+
+async function readCatalog(stateFile = EVENT_STATE_FILE): Promise<InvestingEventCatalog> {
+  const raw = await fs.readFile(stateFile, "utf8").catch(() => "")
+  if (!raw) return defaultCatalog()
+  try {
+    return InvestingEventCatalogSchema.parse(JSON.parse(raw))
+  } catch {
+    return defaultCatalog()
+  }
+}
+
+async function writeCatalog(catalog: InvestingEventCatalog, stateFile = EVENT_STATE_FILE): Promise<void> {
+  await fs.mkdir(path.dirname(stateFile), { recursive: true })
+  await fs.writeFile(stateFile, JSON.stringify(catalog, null, 2) + "\n", "utf8")
+}
+
+function buildStatus(catalog: InvestingEventCatalog): InvestingEventCatalogStatus {
+  const countsByConnector = withDefaultCounts(INVESTING_EVENT_CONNECTORS)
+  const countsByClassification = withDefaultCounts(INVESTING_EVENT_CLASSIFICATIONS)
+  const countsByDirection = withDefaultCounts(INVESTING_EVENT_DIRECTIONS)
+
+  for (const event of Object.values(catalog.events)) {
+    countsByConnector[event.connector] += 1
+    countsByClassification[event.classification] += 1
+    countsByDirection[event.direction] += 1
+  }
+
+  return {
+    version: 1,
+    updatedAt: catalog.updatedAt,
+    totalEvents: Object.keys(catalog.events).length,
+    countsByConnector,
+    countsByClassification,
+    countsByDirection,
+  }
+}
+
+export function classifyInvestingConnectorEvents(input: {
+  connector: InvestingEventConnector
+  entities: NormalizedInvestingEntity[]
+  capturedAt?: string
+}): InvestingEventRecord[] {
+  const capturedAt = input.capturedAt ?? new Date().toISOString()
+  return dedupeEvents(
+    input.entities
+      .map((entity) =>
+        createEventRecord({
+          connector: input.connector,
+          entity,
+          capturedAt,
+        }),
+      )
+      .filter((event): event is InvestingEventRecord => Boolean(event)),
+  )
+}
+
+export async function upsertInvestingEvents(input: {
+  events: InvestingEventRecord[]
+  stateFile?: string
+}): Promise<InvestingEventCatalogUpdate> {
+  if (input.events.length === 0) {
+    const status = buildStatus(await readCatalog(input.stateFile))
+    return {
+      ...status,
+      batchCount: 0,
+      inserted: 0,
+      updated: 0,
+    }
+  }
+
+  const catalog = await readCatalog(input.stateFile)
+  let inserted = 0
+  let updated = 0
+
+  for (const event of input.events) {
+    const existed = Boolean(catalog.events[event.id])
+    if (existed) updated += 1
+    else inserted += 1
+    catalog.events[event.id] = event
+
+    FluxRecorder.record({
+      traceID: crypto.randomUUID(),
+      direction: "internal",
+      domain: "investing",
+      kind: "investing.event.classified",
+      status: "ok",
+      method: "classifier",
+      path: event.connector,
+      route: event.classification,
+      metadata: {
+        eventId: event.id,
+        entityId: event.entityId,
+        connector: event.connector,
+        classification: event.classification,
+        direction: event.direction,
+        confidence: event.confidence,
+        symbol: event.symbol,
+        mode: existed ? "updated" : "inserted",
+      },
+    })
+  }
+
+  catalog.updatedAt = Date.now()
+  await writeCatalog(catalog, input.stateFile)
+  const status = buildStatus(catalog)
+  return {
+    ...status,
+    batchCount: input.events.length,
+    inserted,
+    updated,
+  }
+}
+
+export async function getInvestingEventCatalogStatus(stateFile = EVENT_STATE_FILE): Promise<InvestingEventCatalogStatus> {
+  return buildStatus(await readCatalog(stateFile))
+}
+
+export async function listInvestingEvents(options: {
+  stateFile?: string
+  connector?: InvestingEventConnector
+  classification?: InvestingEventClassification
+  direction?: InvestingEventDirection
+  symbol?: string
+  limit?: number
+} = {}): Promise<InvestingEventRecord[]> {
+  const catalog = await readCatalog(options.stateFile)
+  const symbol = options.symbol?.trim().toUpperCase()
+  const limit = Math.max(1, Math.min(200, options.limit ?? 20))
+
+  return Object.values(catalog.events)
+    .filter((event) => (options.connector ? event.connector === options.connector : true))
+    .filter((event) => (options.classification ? event.classification === options.classification : true))
+    .filter((event) => (options.direction ? event.direction === options.direction : true))
+    .filter((event) => (symbol ? event.symbol === symbol : true))
+    .sort((left, right) => right.asOf.localeCompare(left.asOf))
+    .slice(0, limit)
+}
+
+export async function getInvestingEvent(eventId: string, stateFile = EVENT_STATE_FILE): Promise<InvestingEventRecord | undefined> {
+  const catalog = await readCatalog(stateFile)
+  return catalog.events[eventId]
+}

--- a/packages/zee/src/investing/ingestion.ts
+++ b/packages/zee/src/investing/ingestion.ts
@@ -13,6 +13,7 @@ import {
   upsertInvestingEntities,
   type NormalizedInvestingEntity,
 } from "@/investing/entities"
+import { classifyInvestingConnectorEvents, upsertInvestingEvents } from "@/investing/events"
 
 const log = Log.create({ service: "investing:ingestion" })
 
@@ -476,6 +477,7 @@ export async function executeInvestingConnectorRun(input: {
   executor?: InvestingConnectorExecutor
   stateFile?: string
   entityStateFile?: string
+  eventStateFile?: string
   now?: number
 }): Promise<InvestingConnectorRunRecord> {
   const startedAt = input.now ?? Date.now()
@@ -494,6 +496,21 @@ export async function executeInvestingConnectorRun(input: {
         })
       : undefined
     const finishedAt = Date.now()
+    const classifiedEvents =
+      summary.entities?.length && (input.connector === "earnings" || input.connector === "news")
+        ? classifyInvestingConnectorEvents({
+            connector: input.connector,
+            entities: summary.entities,
+            capturedAt: new Date(finishedAt).toISOString(),
+          })
+        : []
+    const eventUpdate =
+      classifiedEvents.length > 0
+        ? await upsertInvestingEvents({
+            events: classifiedEvents,
+            stateFile: input.eventStateFile,
+          })
+        : undefined
     const record: InvestingConnectorRunRecord = {
       connector: input.connector,
       enabled: input.config.enabled,
@@ -537,6 +554,10 @@ export async function executeInvestingConnectorRun(input: {
         requestCount: record.requestCount,
         normalizedEntityCount: record.normalizedEntityCount,
         normalizedKinds: record.normalizedKinds,
+        classifiedEventCount: classifiedEvents.length,
+        classifiedEventTypes: [...new Set(classifiedEvents.map((event) => event.classification))],
+        eventInserted: eventUpdate?.inserted ?? 0,
+        eventUpdated: eventUpdate?.updated ?? 0,
         freshnessStatus: record.freshnessStatus,
         freshnessSloMinutes: record.freshnessSloMinutes,
         retryAttempts: record.retryAttempts,
@@ -611,6 +632,7 @@ export async function executeInvestingConnectorRunWithRetry(input: {
   executor?: InvestingConnectorExecutor
   stateFile?: string
   entityStateFile?: string
+  eventStateFile?: string
   now?: number
   sleep?: (ms: number) => Promise<void>
 }): Promise<InvestingConnectorRunRecord> {
@@ -626,6 +648,7 @@ export async function executeInvestingConnectorRunWithRetry(input: {
         executor: input.executor,
         stateFile: input.stateFile,
         entityStateFile: input.entityStateFile,
+        eventStateFile: input.eventStateFile,
         now: attempt === 0 ? input.now : undefined,
       })
     } catch (error) {
@@ -663,6 +686,7 @@ export async function runInvestingConnector(
     config?: unknown
     stateFile?: string
     entityStateFile?: string
+    eventStateFile?: string
   } = {},
 ): Promise<InvestingConnectorRunRecord> {
   const rawConfig = options.config ?? (await Config.get())
@@ -676,6 +700,7 @@ export async function runInvestingConnector(
       client,
       stateFile: options.stateFile,
       entityStateFile: options.entityStateFile,
+      eventStateFile: options.eventStateFile,
     })
   } finally {
     await client.disconnect().catch(() => {})
@@ -686,6 +711,7 @@ export async function runEnabledInvestingConnectors(options: {
   config?: unknown
   stateFile?: string
   entityStateFile?: string
+  eventStateFile?: string
   connectors?: InvestingConnectorKind[]
 } = {}): Promise<InvestingConnectorRunRecord[]> {
   const rawConfig = options.config ?? (await Config.get())
@@ -705,6 +731,7 @@ export async function runEnabledInvestingConnectors(options: {
           client,
           stateFile: options.stateFile,
           entityStateFile: options.entityStateFile,
+          eventStateFile: options.eventStateFile,
         }),
       )
     }
@@ -816,6 +843,7 @@ async function runBackfillWithConnectorConfig(input: {
   rawConfig: unknown
   stateFile?: string
   entityStateFile?: string
+  eventStateFile?: string
 }): Promise<InvestingConnectorRunRecord> {
   const client = await createInvestingClient(input.rawConfig)
   try {
@@ -825,6 +853,7 @@ async function runBackfillWithConnectorConfig(input: {
       client,
       stateFile: input.stateFile,
       entityStateFile: input.entityStateFile,
+      eventStateFile: input.eventStateFile,
     })
   } finally {
     await client.disconnect().catch(() => {})
@@ -873,6 +902,7 @@ export async function runInvestingConnectorBackfill(input: {
   config?: unknown
   stateFile?: string
   entityStateFile?: string
+  eventStateFile?: string
   operationsFile?: string
   symbols?: string[]
   lookbackDays?: number
@@ -921,6 +951,7 @@ export async function runInvestingConnectorBackfill(input: {
           rawConfig,
           stateFile: input.stateFile,
           entityStateFile: input.entityStateFile,
+          eventStateFile: input.eventStateFile,
         })
 
     record.finishedAt = Date.now()

--- a/packages/zee/test/investing/events.test.ts
+++ b/packages/zee/test/investing/events.test.ts
@@ -1,0 +1,158 @@
+import path from "node:path"
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { FluxRecorder } from "../../src/flux"
+import { normalizeInvestingConnectorEntities } from "../../src/investing/entities"
+import {
+  classifyInvestingConnectorEvents,
+  getInvestingEvent,
+  getInvestingEventCatalogStatus,
+  listInvestingEvents,
+  upsertInvestingEvents,
+} from "../../src/investing/events"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe("investing event intelligence", () => {
+  test("classifies earnings entities into structured event records", () => {
+    const entities = normalizeInvestingConnectorEntities({
+      connector: "earnings",
+      symbol: "AAPL",
+      collectedAt: "2026-03-15T10:00:00.000Z",
+      data: {
+        symbol: "AAPL",
+        quarters: [{ quarter: "Q4 2025", reportDate: "2026-01-28" }],
+        epsGrowthYoy: 12,
+        epsGrowth3yrCagr: 8,
+        avgEpsSurprisePercent: 5,
+        beatRate: 0.8,
+        consecutiveBeats: 4,
+        earningsVolatility: 0.1,
+        earningsConsistency: 0.9,
+      },
+    })
+
+    const events = classifyInvestingConnectorEvents({
+      connector: "earnings",
+      entities,
+      capturedAt: "2026-03-15T10:01:00.000Z",
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      connector: "earnings",
+      classification: "earnings_result",
+      direction: "positive",
+      symbol: "AAPL",
+      entityId: "event:earnings:aapl:q4-2025:2026-01-28t00-00-00-000z",
+    })
+    expect(events[0]?.summary).toContain("avg EPS surprise 5.0%")
+  })
+
+  test("classifies news entities with keyword-based topic and direction heuristics", () => {
+    const entities = normalizeInvestingConnectorEntities({
+      connector: "news",
+      collectedAt: "2026-03-15T10:00:00.000Z",
+      data: [
+        {
+          symbol: "MSFT",
+          articleId: "story-1",
+          publishedAt: "2026-03-15T09:00:00.000Z",
+          title: "Microsoft raises guidance after strong Azure growth",
+          summary: "The company raised fiscal guidance after another strong quarter for Azure.",
+          url: "https://example.com/msft-guidance",
+        },
+      ],
+    })
+
+    const events = classifyInvestingConnectorEvents({
+      connector: "news",
+      entities,
+      capturedAt: "2026-03-15T10:02:00.000Z",
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      connector: "news",
+      classification: "guidance_update",
+      direction: "positive",
+      symbol: "MSFT",
+      sourceUrl: "https://example.com/msft-guidance",
+    })
+    expect(events[0]?.reasons[0]).toContain("guidance_update")
+  })
+
+  test("persists classified events, exposes status, and emits telemetry", async () => {
+    await using dir = await tmpdir()
+    const stateFile = path.join(dir.path, "investing-events.json")
+    const recordSpy = spyOn(FluxRecorder, "record")
+
+    const earningsEntities = normalizeInvestingConnectorEntities({
+      connector: "earnings",
+      symbol: "NVDA",
+      collectedAt: "2026-03-15T10:00:00.000Z",
+      data: {
+        symbol: "NVDA",
+        quarters: [{ quarter: "Q1 2026", reportDate: "2026-02-20" }],
+        epsGrowthYoy: 18,
+        avgEpsSurprisePercent: 7,
+        beatRate: 0.9,
+        earningsConsistency: 0.95,
+      },
+    })
+    const newsEntities = normalizeInvestingConnectorEntities({
+      connector: "news",
+      collectedAt: "2026-03-15T10:00:00.000Z",
+      data: [
+        {
+          symbol: "NVDA",
+          articleId: "story-2",
+          publishedAt: "2026-03-15T08:30:00.000Z",
+          title: "Nvidia launches new enterprise AI platform with major cloud partners",
+          summary: "The launch expands Nvidia's enterprise AI reach through new partnerships.",
+        },
+      ],
+    })
+
+    const update = await upsertInvestingEvents({
+      stateFile,
+      events: [
+        ...classifyInvestingConnectorEvents({
+          connector: "earnings",
+          entities: earningsEntities,
+          capturedAt: "2026-03-15T10:03:00.000Z",
+        }),
+        ...classifyInvestingConnectorEvents({
+          connector: "news",
+          entities: newsEntities,
+          capturedAt: "2026-03-15T10:04:00.000Z",
+        }),
+      ],
+    })
+
+    expect(update.batchCount).toBe(2)
+    expect(update.inserted).toBe(2)
+    expect(update.totalEvents).toBe(2)
+    expect(update.countsByConnector.earnings).toBe(1)
+    expect(update.countsByConnector.news).toBe(1)
+    expect(recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.event.classified")).toHaveLength(2)
+
+    const status = await getInvestingEventCatalogStatus(stateFile)
+    expect(status.totalEvents).toBe(2)
+    expect(status.countsByClassification.earnings_result).toBe(1)
+    expect(status.countsByClassification.product_and_partnership).toBe(1)
+
+    const listed = await listInvestingEvents({
+      stateFile,
+      symbol: "NVDA",
+      limit: 5,
+    })
+    expect(listed).toHaveLength(2)
+    expect(listed[0]?.symbol).toBe("NVDA")
+
+    const loaded = await getInvestingEvent(listed[0]!.id, stateFile)
+    expect(loaded?.id).toBe(listed[0]?.id)
+  })
+})

--- a/packages/zee/test/investing/ingestion.test.ts
+++ b/packages/zee/test/investing/ingestion.test.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { FluxRecorder } from "../../src/flux"
 import { normalizeInvestingConnectorEntities } from "../../src/investing/entities"
+import { getInvestingEventCatalogStatus } from "../../src/investing/events"
 import {
   executeInvestingConnectorRun,
   executeInvestingConnectorRunWithRetry,
@@ -84,6 +85,7 @@ describe("executeInvestingConnectorRun", () => {
     await using dir = await tmpdir()
     const stateFile = path.join(dir.path, "investing-ingestion.json")
     const entityStateFile = path.join(dir.path, "investing-entities.json")
+    const eventStateFile = path.join(dir.path, "investing-events.json")
     const recordSpy = spyOn(FluxRecorder, "record")
     const startedAt = 1_700_000_000_000
 
@@ -124,6 +126,7 @@ describe("executeInvestingConnectorRun", () => {
           },
         }),
       }),
+      eventStateFile,
     })
 
     expect(result).toMatchObject({
@@ -141,8 +144,10 @@ describe("executeInvestingConnectorRun", () => {
     })
     expect(result.lastStartedAt).toBe(startedAt)
     expect(result.lastFinishedAt).toBeGreaterThanOrEqual(startedAt)
-    expect(recordSpy).toHaveBeenCalledTimes(2)
-    expect(recordSpy.mock.calls[0]?.[0]).toMatchObject({
+    expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.entity.normalized")).toBe(true)
+    expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.event.classified")).toBe(true)
+    expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.ingestion.run")).toBe(true)
+    expect(recordSpy.mock.calls.find((call) => call[0]?.kind === "investing.entity.normalized")?.[0]).toMatchObject({
       domain: "investing",
       kind: "investing.entity.normalized",
       status: "ok",
@@ -151,7 +156,7 @@ describe("executeInvestingConnectorRun", () => {
         inserted: 3,
       },
     })
-    expect(recordSpy.mock.calls[1]?.[0]).toMatchObject({
+    expect(recordSpy.mock.calls.find((call) => call[0]?.kind === "investing.ingestion.run")?.[0]).toMatchObject({
       domain: "investing",
       kind: "investing.ingestion.run",
       status: "ok",
@@ -161,6 +166,7 @@ describe("executeInvestingConnectorRun", () => {
         itemCount: 4,
         requestCount: 1,
         normalizedEntityCount: 3,
+        classifiedEventCount: 1,
         freshnessStatus: "fresh",
       },
     })
@@ -177,6 +183,10 @@ describe("executeInvestingConnectorRun", () => {
       normalizedEntityCount: 3,
       coverageSymbols: ["AAPL"],
     })
+
+    const eventStatus = await getInvestingEventCatalogStatus(eventStateFile)
+    expect(eventStatus.totalEvents).toBe(1)
+    expect(eventStatus.countsByConnector.earnings).toBe(1)
   })
 
   test("persists failed runs and emits error telemetry", async () => {

--- a/src/domain/investing/tools.ts
+++ b/src/domain/investing/tools.ts
@@ -44,6 +44,14 @@ import {
   getInvestingValuationPacket,
   listInvestingValuationPackets,
 } from "./valuation-packet";
+import {
+  INVESTING_EVENT_CLASSIFICATIONS,
+  INVESTING_EVENT_CONNECTORS,
+  INVESTING_EVENT_DIRECTIONS,
+  getInvestingEvent,
+  getInvestingEventCatalogStatus,
+  listInvestingEvents,
+} from "../../../packages/zee/src/investing/events";
 
 type InvestingResult = {
   ok: boolean;
@@ -777,6 +785,77 @@ export const researchArtifactsTool: ToolDefinition = {
   }),
 };
 
+const EventIntelligenceParams = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("status"),
+  }),
+  z.object({
+    action: z.literal("list"),
+    connector: z.enum(INVESTING_EVENT_CONNECTORS).optional().describe("Optional connector filter"),
+    classification: z.enum(INVESTING_EVENT_CLASSIFICATIONS).optional().describe("Optional classification filter"),
+    direction: z.enum(INVESTING_EVENT_DIRECTIONS).optional().describe("Optional direction filter"),
+    symbol: z.string().optional().describe("Optional symbol filter"),
+    limit: z.number().min(1).max(100).default(10).describe("Maximum number of events to return"),
+  }),
+  z.object({
+    action: z.literal("read"),
+    eventId: z.string().describe("Persisted classified event identifier"),
+  }),
+]);
+
+export const eventIntelligenceTool: ToolDefinition = {
+  id: "zee:invest-events",
+  category: "domain",
+  init: async () => ({
+    description: `Inspect classified earnings and news events produced by Zee's event-intelligence ingestion layer.`,
+    parameters: EventIntelligenceParams,
+    execute: async (args, ctx): Promise<ToolExecutionResult> => {
+      switch (args.action) {
+        case "status": {
+          ctx.metadata({ title: "Loading investing event intelligence status" });
+          const status = await getInvestingEventCatalogStatus();
+          return {
+            title: "Investing Event Intelligence",
+            metadata: { action: args.action, totalEvents: status.totalEvents },
+            output: JSON.stringify(status, null, 2),
+          };
+        }
+        case "list": {
+          ctx.metadata({ title: "Listing investing event intelligence records" });
+          const events = await listInvestingEvents({
+            connector: args.connector,
+            classification: args.classification,
+            direction: args.direction,
+            symbol: args.symbol,
+            limit: args.limit,
+          });
+          return {
+            title: "Investing Event Intelligence",
+            metadata: {
+              action: args.action,
+              count: events.length,
+              connector: args.connector,
+              classification: args.classification,
+              direction: args.direction,
+              symbol: args.symbol,
+            },
+            output: JSON.stringify({ events, count: events.length }, null, 2),
+          };
+        }
+        case "read": {
+          ctx.metadata({ title: `Loading investing event ${args.eventId}` });
+          const event = await getInvestingEvent(args.eventId);
+          return {
+            title: "Investing Event Intelligence",
+            metadata: { action: args.action, eventId: args.eventId, found: Boolean(event) },
+            output: JSON.stringify(event ?? { error: `Event not found: ${args.eventId}` }, null, 2),
+          };
+        }
+      }
+    },
+  }),
+};
+
 const ValuationKernelParams = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("run"),
@@ -1116,6 +1195,7 @@ export const INVESTING_TOOLS = [
   researchPlannerTool,
   researchExecutorTool,
   researchArtifactsTool,
+  eventIntelligenceTool,
   nautilusTool,
   estimatesTool,
   insiderTradesTool,


### PR DESCRIPTION
## Summary
- add a persistent investing event-intelligence ledger and classifier for normalized earnings and news entities
- wire classified-event upserts and telemetry into connector ingestion, plus operator-facing CLI and `zee:invest-events` tool surfaces
- document the slice, add tests, and update the codebase map for the new event-intelligence paths

## Testing
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- cd packages/zee && bun test test/investing/events.test.ts test/investing/ingestion.test.ts
- cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh
- cd packages/zee && bun run --conditions=browser ./src/index.ts investing event status --json
- zee investing event status --json

Closes #506
