### PR TITLE
feat(#507): score and link investing events

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -188,17 +188,17 @@ rg "export class Memory|getMemory|getMemoryAsync" src/memory/unified.ts  # Unifi
 **Purpose:** Provide user-facing capabilities across life admin, investing, and learning.
 - **Zee tools collection:** `src/domain/zee/tools.ts:1884`
 - **Zee tool registration:** `src/domain/zee/tools.ts:1909`
-- **Stanley tools collection:** `src/domain/investing/tools.ts:1187`
-- **Stanley registration:** `src/domain/investing/tools.ts:1206`
+- **Stanley tools collection:** `src/domain/investing/tools.ts:1197`
+- **Stanley registration:** `src/domain/investing/tools.ts:1216`
 - **Johny tools collection:** `src/domain/learning/tools.ts:502`
 - **Johny registration:** `src/domain/learning/tools.ts:504`
 
 ### Feature: Investing Event Intelligence
-**Purpose:** Classify normalized earnings and news entities into a persistent event ledger for downstream research automation.
+**Purpose:** Classify, score, and link normalized earnings and news entities into a persistent event ledger for downstream research automation.
 - **Event catalog + classifier:** `packages/zee/src/investing/events.ts:1`
 - **Ingestion hook + telemetry:** `packages/zee/src/investing/ingestion.ts:473`
-- **CLI surface (`zee investing event ...`):** `packages/zee/src/cli/cmd/investing.ts:162`
-- **Stanley tool (`zee:invest-events`):** `src/domain/investing/tools.ts:806`
+- **CLI surface (`zee investing event ...`):** `packages/zee/src/cli/cmd/investing.ts:164`
+- **Stanley tool (`zee:invest-events`):** `src/domain/investing/tools.ts:810`
 - **Operator doc:** `docs/architecture/investing-event-intelligence.md:1`
 
 ### Feature: Memory (Qdrant + Hybrid Search + Markdown Sync)

--- a/docs/architecture/investing-event-intelligence.md
+++ b/docs/architecture/investing-event-intelligence.md
@@ -1,14 +1,20 @@
 # Investing Event Intelligence
 
-Zee's event-intelligence layer classifies normalized `earnings` and `news` entities into a persistent event ledger for downstream research automation.
+Zee's event-intelligence layer classifies normalized `earnings` and `news` entities into a persistent event ledger, then scores and links those events for downstream research automation.
 
-This slice implements issue `#506`: ingestion and classification.
-It does not yet assign materiality scores or briefing deltas; those remain the follow-on work for `#507` and `#508`.
+This document now covers:
+
+- issue `#506`: ingestion and classification
+- issue `#507`: materiality scoring and entity-linking
+
+Briefing deltas remain the follow-on work for `#508`.
 
 ## Source Of Truth
 
 - Event ledger: `~/.local/state/zee/investing-event-intelligence.json`
 - Entity catalog dependency: `~/.local/state/zee/investing-entity-catalog.json`
+- Portfolio coverage file: `~/.zee/investing/portfolio.json` or `ZEE_INVESTING_PORTFOLIO_FILE`
+- Watchlist coverage file: `~/.zee/investing/watchlist.json` or `ZEE_INVESTING_WATCHLIST_FILE`
 
 ## Classification Scope
 
@@ -36,6 +42,28 @@ Each record also carries:
 - canonical entity linkage (`entityId`, `companyId`, `instrumentId`, `relatedIds`)
 - source provenance (`sourceId`, `sourceType`, optional `sourceUrl`)
 
+## Materiality And Linking
+
+Each persisted event is enriched with:
+
+- `entityLinks`
+  - issuer and instrument IDs
+  - derived sector IDs and labels when source or coverage data exposes sector metadata
+  - optional holding and watchlist entity IDs (`holding:equity:<symbol>`, `watchlist:equity:<symbol>`)
+  - an audience classification of `holding`, `watchlist`, or `general`
+- `materiality`
+  - numeric score from `0` to `100`
+  - band: `critical`, `high`, `medium`, or `low`
+  - human-readable scoring reasons
+
+Materiality inputs in this slice:
+
+- event classification
+- event direction and classifier confidence
+- recency
+- sector context
+- linkage to holdings and watchlist symbols
+
 ## Operator Surfaces
 
 CLI:
@@ -44,6 +72,7 @@ CLI:
 zee investing event status
 zee investing event list --limit 20
 zee investing event list --connector news --classification guidance_update --symbol MSFT
+zee investing event list --materiality-band high --holding
 zee investing event read classified:event:news:msft:story-1
 ```
 
@@ -58,8 +87,9 @@ Domain tool:
 
 1. Connector payloads are normalized into canonical entities.
 2. `earnings` and `news` event entities are classified into the event ledger.
-3. Each classified record is upserted by stable ID (`classified:<entity-id>`).
-4. Connector run telemetry includes classified-event counts and unique event types for that batch.
+3. Each classified record is enriched with materiality and coverage links using the configured holdings/watchlist context.
+4. Each enriched record is upserted by stable ID (`classified:<entity-id>`).
+5. Connector run telemetry includes classified-event counts, materiality-band counts, and coverage-link counts for that batch.
 
 ## Telemetry
 
@@ -68,11 +98,15 @@ Flux events emitted for this slice:
 - `investing.event.classified`
   - one event per inserted or updated classified record
   - metadata includes `eventId`, `entityId`, `connector`, `classification`, `direction`, `confidence`, `symbol`, and `mode`
+- `investing.event.scored`
+  - one event per inserted or updated scored record
+  - metadata includes `eventId`, `materialityScore`, `materialityBand`, `audience`, and holding/watchlist linkage flags
 - `investing.ingestion.run`
-  - now includes `classifiedEventCount`, `classifiedEventTypes`, `eventInserted`, and `eventUpdated` when the connector produces classified events
+  - now includes `classifiedEventCount`, `classifiedEventTypes`, `eventInserted`, `eventUpdated`, `materialityBands`, `holdingLinkedCount`, and `watchlistLinkedCount` when the connector produces classified events
 
 ## Notes
 
 - News classification is heuristic and keyword-driven in this slice.
 - Earnings classification is deterministic from the normalized earnings connector event shape.
-- Materiality scoring, precision tuning, and briefing/thesis integration remain follow-on work.
+- Materiality scoring is intentionally heuristic in this slice; calibration and precision tuning remain follow-on work.
+- Briefing/thesis integration remains follow-on work.

--- a/packages/zee/src/cli/cmd/investing.ts
+++ b/packages/zee/src/cli/cmd/investing.ts
@@ -5,12 +5,14 @@ import {
   INVESTING_EVENT_CLASSIFICATIONS,
   INVESTING_EVENT_CONNECTORS,
   INVESTING_EVENT_DIRECTIONS,
+  INVESTING_EVENT_MATERIALITY_BANDS,
   getInvestingEvent,
   getInvestingEventCatalogStatus,
   listInvestingEvents,
   type InvestingEventClassification,
   type InvestingEventConnector,
   type InvestingEventDirection,
+  type InvestingEventMaterialityBand,
 } from "@/investing/events"
 import {
   INVESTING_CONNECTOR_KINDS,
@@ -180,6 +182,8 @@ const InvestingEventStatusCommand = cmd({
     console.log(`- by connector: ${JSON.stringify(status.countsByConnector)}`)
     console.log(`- by classification: ${JSON.stringify(status.countsByClassification)}`)
     console.log(`- by direction: ${JSON.stringify(status.countsByDirection)}`)
+    console.log(`- by materiality: ${JSON.stringify(status.countsByMaterialityBand)}`)
+    console.log(`- linked coverage: holdings=${status.holdingLinkedCount} watchlist=${status.watchlistLinkedCount}`)
   },
 })
 
@@ -203,9 +207,24 @@ const InvestingEventListCommand = cmd({
         choices: [...INVESTING_EVENT_DIRECTIONS],
         describe: "optional direction filter",
       })
+      .option("materiality-band", {
+        type: "string",
+        choices: [...INVESTING_EVENT_MATERIALITY_BANDS],
+        describe: "optional materiality band filter",
+      })
       .option("symbol", {
         type: "string",
         describe: "optional symbol filter",
+      })
+      .option("holding", {
+        type: "boolean",
+        default: false,
+        describe: "only include events linked to holdings",
+      })
+      .option("watchlist", {
+        type: "boolean",
+        default: false,
+        describe: "only include events linked to watchlist symbols",
       })
       .option("limit", {
         type: "number",
@@ -221,7 +240,10 @@ const InvestingEventListCommand = cmd({
     connector?: InvestingEventConnector
     classification?: InvestingEventClassification
     direction?: InvestingEventDirection
+    materialityBand?: InvestingEventMaterialityBand
     symbol?: string
+    holding?: boolean
+    watchlist?: boolean
     limit?: number
     json?: boolean
   }) => {
@@ -229,7 +251,10 @@ const InvestingEventListCommand = cmd({
       connector: args.connector,
       classification: args.classification,
       direction: args.direction,
+      materialityBand: args.materialityBand,
       symbol: args.symbol,
+      holdingOnly: args.holding,
+      watchlistOnly: args.watchlist,
       limit: args.limit,
     })
     if (args.json) {
@@ -238,7 +263,7 @@ const InvestingEventListCommand = cmd({
     }
     for (const event of events) {
       console.log(
-        `- ${event.id}: ${event.classification} connector=${event.connector} direction=${event.direction} confidence=${event.confidence.toFixed(2)} symbol=${event.symbol ?? "n/a"} asOf=${event.asOf} title=${event.title}`,
+        `- ${event.id}: ${event.classification} connector=${event.connector} direction=${event.direction} materiality=${event.materiality.band}:${event.materiality.score} audience=${event.entityLinks.audience} confidence=${event.confidence.toFixed(2)} symbol=${event.symbol ?? "n/a"} asOf=${event.asOf} title=${event.title}`,
       )
     }
   },
@@ -272,10 +297,14 @@ const InvestingEventReadCommand = cmd({
 
     console.log(`${event.id}`)
     console.log(`- classification=${event.classification} connector=${event.connector} direction=${event.direction}`)
+    console.log(`- materiality=${event.materiality.band} score=${event.materiality.score} audience=${event.entityLinks.audience}`)
     console.log(`- confidence=${event.confidence.toFixed(2)} symbol=${event.symbol ?? "n/a"} asOf=${event.asOf}`)
+    console.log(`- sectors=${event.entityLinks.sectorLabels.join(", ") || "n/a"}`)
+    console.log(`- holding=${event.entityLinks.holdingId ?? "n/a"} watchlist=${event.entityLinks.watchlistId ?? "n/a"}`)
     console.log(`- title=${event.title}`)
     console.log(`- summary=${event.summary}`)
     console.log(`- reasons=${event.reasons.join("; ") || "n/a"}`)
+    console.log(`- materiality-reasons=${event.materiality.reasons.join("; ") || "n/a"}`)
   },
 })
 

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -51,6 +51,7 @@ export type FluxKind =
   | "investing.ingestion.run"
   | "investing.ingestion.schedule"
   | "investing.event.classified"
+  | "investing.event.scored"
   | "investing.research.plan"
   | "investing.research.plan.task"
   | "investing.research.execution"

--- a/packages/zee/src/investing/events.ts
+++ b/packages/zee/src/investing/events.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises"
+import os from "node:os"
 import path from "node:path"
 import z from "zod"
 import { FluxRecorder } from "@/flux"
@@ -20,14 +21,48 @@ export const INVESTING_EVENT_CLASSIFICATIONS = [
   "general_news",
 ] as const
 export const INVESTING_EVENT_DIRECTIONS = ["positive", "negative", "neutral", "mixed", "unknown"] as const
+export const INVESTING_EVENT_MATERIALITY_BANDS = ["critical", "high", "medium", "low"] as const
+export const INVESTING_EVENT_AUDIENCES = ["general", "watchlist", "holding"] as const
 
 export type InvestingEventConnector = (typeof INVESTING_EVENT_CONNECTORS)[number]
 export type InvestingEventClassification = (typeof INVESTING_EVENT_CLASSIFICATIONS)[number]
 export type InvestingEventDirection = (typeof INVESTING_EVENT_DIRECTIONS)[number]
+export type InvestingEventMaterialityBand = (typeof INVESTING_EVENT_MATERIALITY_BANDS)[number]
+export type InvestingEventAudience = (typeof INVESTING_EVENT_AUDIENCES)[number]
 
 const InvestingEventConnectorSchema = z.enum(INVESTING_EVENT_CONNECTORS)
 const InvestingEventClassificationSchema = z.enum(INVESTING_EVENT_CLASSIFICATIONS)
 const InvestingEventDirectionSchema = z.enum(INVESTING_EVENT_DIRECTIONS)
+const InvestingEventMaterialityBandSchema = z.enum(INVESTING_EVENT_MATERIALITY_BANDS)
+const InvestingEventAudienceSchema = z.enum(INVESTING_EVENT_AUDIENCES)
+
+const InvestingEventEntityLinksSchema = z
+  .object({
+    issuerId: z.string().optional(),
+    instrumentId: z.string().optional(),
+    sectorIds: z.array(z.string()).default([]),
+    sectorLabels: z.array(z.string()).default([]),
+    holdingId: z.string().optional(),
+    watchlistId: z.string().optional(),
+    audience: InvestingEventAudienceSchema.default("general"),
+  })
+  .default({
+    sectorIds: [],
+    sectorLabels: [],
+    audience: "general",
+  })
+
+const InvestingEventMaterialitySchema = z
+  .object({
+    score: z.number().min(0).max(100),
+    band: InvestingEventMaterialityBandSchema,
+    reasons: z.array(z.string()).default([]),
+  })
+  .default({
+    score: 0,
+    band: "low",
+    reasons: [],
+  })
 
 export const InvestingEventRecordSchema = z.object({
   id: z.string(),
@@ -50,6 +85,8 @@ export const InvestingEventRecordSchema = z.object({
   sourceUrl: z.string().optional(),
   tags: z.array(z.string()).default([]),
   reasons: z.array(z.string()).default([]),
+  entityLinks: InvestingEventEntityLinksSchema,
+  materiality: InvestingEventMaterialitySchema,
 })
 
 export const InvestingEventCatalogSchema = z.object({
@@ -68,15 +105,31 @@ export type InvestingEventCatalogStatus = {
   countsByConnector: Record<InvestingEventConnector, number>
   countsByClassification: Record<InvestingEventClassification, number>
   countsByDirection: Record<InvestingEventDirection, number>
+  countsByMaterialityBand: Record<InvestingEventMaterialityBand, number>
+  holdingLinkedCount: number
+  watchlistLinkedCount: number
 }
 
 export type InvestingEventCatalogUpdate = InvestingEventCatalogStatus & {
   batchCount: number
   inserted: number
   updated: number
+  batchCountsByMaterialityBand: Record<InvestingEventMaterialityBand, number>
+  batchHoldingLinkedCount: number
+  batchWatchlistLinkedCount: number
 }
 
 type GenericRecord = Record<string, unknown>
+type InvestingCoveragePosition = {
+  symbol: string
+  shares: number
+  averageCost?: number
+  sectorLabels: string[]
+}
+type InvestingWatchlistEntry = {
+  symbol: string
+  sectorLabels: string[]
+}
 
 const POSITIVE_KEYWORDS = [
   "beat",
@@ -96,7 +149,7 @@ const POSITIVE_KEYWORDS = [
   "buyback",
   "partnership",
   "launch",
-]
+] as const
 
 const NEGATIVE_KEYWORDS = [
   "miss",
@@ -119,7 +172,18 @@ const NEGATIVE_KEYWORDS = [
   "slump",
   "drop",
   "antitrust",
-]
+] as const
+
+const MATERIALITY_BASE_SCORES: Record<InvestingEventClassification, number> = {
+  earnings_result: 70,
+  guidance_update: 82,
+  mna: 88,
+  management_change: 58,
+  legal_regulatory: 90,
+  product_and_partnership: 60,
+  capital_allocation: 55,
+  general_news: 35,
+}
 
 const NEWS_CLASSIFICATION_RULES: Array<{
   classification: InvestingEventClassification
@@ -164,10 +228,29 @@ function normalizeText(value: string | undefined): string {
   return (value ?? "").trim().toLowerCase()
 }
 
+function normalizeSegment(value: unknown, fallback = "unknown"): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(Math.trunc(value))
+  }
+  if (typeof value !== "string") return fallback
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return normalized || fallback
+}
+
+function normalizeSymbol(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const normalized = value.trim().toUpperCase()
+  return normalized || undefined
+}
+
 function trimSentence(value: string, maxLength = 280): string {
   const normalized = value.replace(/\s+/g, " ").trim()
   if (normalized.length <= maxLength) return normalized
-  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}...`
 }
 
 function withDefaultCounts<const T extends readonly string[]>(items: T): Record<T[number], number> {
@@ -176,6 +259,14 @@ function withDefaultCounts<const T extends readonly string[]>(items: T): Record<
 
 function clampConfidence(value: number): number {
   return Math.max(0, Math.min(1, Number.parseFloat(value.toFixed(2))))
+}
+
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+function uniqueStrings(values: Array<string | undefined>): string[] {
+  return [...new Set(values.map((value) => value?.trim()).filter((value): value is string => Boolean(value)))]
 }
 
 function dedupeEvents(events: InvestingEventRecord[]): InvestingEventRecord[] {
@@ -193,6 +284,56 @@ function extractSourceUrl(entity: NormalizedInvestingEntity): string | undefined
     if (evidence.url) return evidence.url
   }
   return undefined
+}
+
+function extractString(record: GenericRecord, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === "string" && value.trim()) return value.trim()
+  }
+  return undefined
+}
+
+function extractStringValues(value: unknown): string[] {
+  if (typeof value === "string") {
+    return value.trim() ? [value.trim()] : []
+  }
+  if (Array.isArray(value)) {
+    return uniqueStrings(
+      value.flatMap((entry) => {
+        if (typeof entry === "string") return [entry]
+        const record = asRecord(entry)
+        if (!record) return []
+        return [
+          extractString(record, "name", "label", "title", "sector", "industry"),
+          ...Object.keys(record).filter((key) => record[key] === true),
+        ]
+      }),
+    )
+  }
+  const record = asRecord(value)
+  if (!record) return []
+  return uniqueStrings([
+    extractString(record, "name", "label", "title", "sector", "industry"),
+    ...Object.keys(record),
+  ])
+}
+
+function extractSectorLabels(record: GenericRecord): string[] {
+  return uniqueStrings([
+    ...extractStringValues(record.sector),
+    ...extractStringValues(record.sectors),
+    ...extractStringValues(record.industry),
+    ...extractStringValues(record.industries),
+    ...extractStringValues(record.group),
+    ...extractStringValues(record.groups),
+  ])
+}
+
+function extractSectorLabelsFromEntity(entity: NormalizedInvestingEntity): string[] {
+  const attributes = asRecord(entity.attributes) ?? {}
+  const external = asRecord(entity.identifiers.external) ?? {}
+  return uniqueStrings([...extractSectorLabels(attributes), ...extractSectorLabels(external)])
 }
 
 function entityText(entity: NormalizedInvestingEntity): string {
@@ -276,6 +417,37 @@ function summarizeNewsEntity(entity: NormalizedInvestingEntity, classification: 
   return trimSentence(`${classification.replace(/_/g, " ")} :: ${summary}`)
 }
 
+function sectorEntityId(label: string): string {
+  return `sector:${normalizeSegment(label)}`
+}
+
+function holdingEntityId(symbol: string): string {
+  return `holding:equity:${normalizeSegment(symbol)}`
+}
+
+function watchlistEntityId(symbol: string): string {
+  return `watchlist:equity:${normalizeSegment(symbol)}`
+}
+
+function baseEntityLinks(entity: NormalizedInvestingEntity): z.infer<typeof InvestingEventEntityLinksSchema> {
+  const sectorLabels = extractSectorLabelsFromEntity(entity)
+  return {
+    issuerId: entity.identifiers.company,
+    instrumentId: entity.identifiers.instrument,
+    sectorIds: sectorLabels.map(sectorEntityId),
+    sectorLabels,
+    audience: "general",
+  }
+}
+
+function defaultMateriality(): z.infer<typeof InvestingEventMaterialitySchema> {
+  return {
+    score: 0,
+    band: "low",
+    reasons: ["materiality pending enrichment"],
+  }
+}
+
 function createEventRecord(input: {
   connector: InvestingEventConnector
   entity: NormalizedInvestingEntity
@@ -323,6 +495,8 @@ function createEventRecord(input: {
       sourceUrl,
       tags: [...new Set(["earnings", ...entity.tags])],
       reasons: classification === "guidance_update" ? ["earnings text included guidance/outlook language"] : ["earnings connector event"],
+      entityLinks: baseEntityLinks(entity),
+      materiality: defaultMateriality(),
     })
   }
 
@@ -348,6 +522,8 @@ function createEventRecord(input: {
     sourceUrl,
     tags: [...new Set(["news", classified.classification, ...entity.tags])],
     reasons: classified.reasons,
+    entityLinks: baseEntityLinks(entity),
+    materiality: defaultMateriality(),
   })
 }
 
@@ -374,15 +550,29 @@ async function writeCatalog(catalog: InvestingEventCatalog, stateFile = EVENT_ST
   await fs.writeFile(stateFile, JSON.stringify(catalog, null, 2) + "\n", "utf8")
 }
 
+function buildBatchCountsByMaterialityBand(events: InvestingEventRecord[]): Record<InvestingEventMaterialityBand, number> {
+  const countsByMaterialityBand = withDefaultCounts(INVESTING_EVENT_MATERIALITY_BANDS)
+  for (const event of events) {
+    countsByMaterialityBand[event.materiality.band] += 1
+  }
+  return countsByMaterialityBand
+}
+
 function buildStatus(catalog: InvestingEventCatalog): InvestingEventCatalogStatus {
   const countsByConnector = withDefaultCounts(INVESTING_EVENT_CONNECTORS)
   const countsByClassification = withDefaultCounts(INVESTING_EVENT_CLASSIFICATIONS)
   const countsByDirection = withDefaultCounts(INVESTING_EVENT_DIRECTIONS)
+  const countsByMaterialityBand = withDefaultCounts(INVESTING_EVENT_MATERIALITY_BANDS)
+  let holdingLinkedCount = 0
+  let watchlistLinkedCount = 0
 
   for (const event of Object.values(catalog.events)) {
     countsByConnector[event.connector] += 1
     countsByClassification[event.classification] += 1
     countsByDirection[event.direction] += 1
+    countsByMaterialityBand[event.materiality.band] += 1
+    if (event.entityLinks.holdingId) holdingLinkedCount += 1
+    if (event.entityLinks.watchlistId) watchlistLinkedCount += 1
   }
 
   return {
@@ -392,7 +582,233 @@ function buildStatus(catalog: InvestingEventCatalog): InvestingEventCatalogStatu
     countsByConnector,
     countsByClassification,
     countsByDirection,
+    countsByMaterialityBand,
+    holdingLinkedCount,
+    watchlistLinkedCount,
   }
+}
+
+function defaultPortfolioFile(): string {
+  return process.env.ZEE_INVESTING_PORTFOLIO_FILE || path.join(os.homedir(), ".zee", "investing", "portfolio.json")
+}
+
+function defaultWatchlistFile(): string {
+  return process.env.ZEE_INVESTING_WATCHLIST_FILE || path.join(os.homedir(), ".zee", "investing", "watchlist.json")
+}
+
+async function readJsonFile(filePath: string): Promise<unknown> {
+  const raw = await fs.readFile(filePath, "utf8").catch(() => "")
+  if (!raw) return undefined
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+}
+
+function parseNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return undefined
+}
+
+async function loadPortfolioCoverage(portfolioFile = defaultPortfolioFile()): Promise<Map<string, InvestingCoveragePosition>> {
+  const parsed = await readJsonFile(portfolioFile)
+  const record = asRecord(parsed)
+  const positions = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(record?.positions)
+      ? record.positions
+      : Array.isArray(record?.holdings)
+        ? record.holdings
+        : []
+  const bySymbol = new Map<string, InvestingCoveragePosition>()
+
+  for (const position of positions) {
+    const candidate = asRecord(position)
+    if (!candidate) continue
+    const symbol = normalizeSymbol(extractString(candidate, "symbol", "ticker"))
+    const shares = parseNumber(candidate.shares ?? candidate.quantity ?? candidate.position)
+    if (!symbol || typeof shares !== "number" || shares <= 0) continue
+    const averageCost = parseNumber(
+      candidate.averageCost ??
+        candidate.average_cost ??
+        candidate.avg_cost ??
+        candidate.entryPrice ??
+        candidate.entry_price ??
+        candidate.price,
+    )
+    bySymbol.set(symbol, {
+      symbol,
+      shares,
+      averageCost,
+      sectorLabels: extractSectorLabels(candidate),
+    })
+  }
+
+  return bySymbol
+}
+
+async function loadWatchlistCoverage(watchlistFile = defaultWatchlistFile()): Promise<Map<string, InvestingWatchlistEntry>> {
+  const parsed = await readJsonFile(watchlistFile)
+  const record = asRecord(parsed)
+  const items = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(record?.items)
+      ? record.items
+      : Array.isArray(record?.watchlist)
+        ? record.watchlist
+        : Array.isArray(record?.symbols)
+          ? record.symbols
+          : []
+  const bySymbol = new Map<string, InvestingWatchlistEntry>()
+
+  for (const item of items) {
+    if (typeof item === "string") {
+      const symbol = normalizeSymbol(item)
+      if (!symbol) continue
+      bySymbol.set(symbol, { symbol, sectorLabels: [] })
+      continue
+    }
+
+    const candidate = asRecord(item)
+    if (!candidate) continue
+    const symbol = normalizeSymbol(extractString(candidate, "symbol", "ticker", "code"))
+    if (!symbol) continue
+    const existing = bySymbol.get(symbol)
+    bySymbol.set(symbol, {
+      symbol,
+      sectorLabels: uniqueStrings([...(existing?.sectorLabels ?? []), ...extractSectorLabels(candidate)]),
+    })
+  }
+
+  return bySymbol
+}
+
+function materialityBandForScore(score: number): InvestingEventMaterialityBand {
+  if (score >= 90) return "critical"
+  if (score >= 75) return "high"
+  if (score >= 55) return "medium"
+  return "low"
+}
+
+function eventAgeHours(asOf: string): number | undefined {
+  const parsed = Date.parse(asOf)
+  if (!Number.isFinite(parsed)) return undefined
+  return (Date.now() - parsed) / 3_600_000
+}
+
+function enrichInvestingEventRecord(input: {
+  event: InvestingEventRecord
+  holdings: Map<string, InvestingCoveragePosition>
+  watchlist: Map<string, InvestingWatchlistEntry>
+}): InvestingEventRecord {
+  const event = input.event
+  const symbol = normalizeSymbol(event.symbol)
+  const holding = symbol ? input.holdings.get(symbol) : undefined
+  const watched = symbol ? input.watchlist.get(symbol) : undefined
+  const sectorLabels = uniqueStrings([
+    ...event.entityLinks.sectorLabels,
+    ...(holding?.sectorLabels ?? []),
+    ...(watched?.sectorLabels ?? []),
+  ])
+  const audience: InvestingEventAudience = holding ? "holding" : watched ? "watchlist" : "general"
+
+  let score = MATERIALITY_BASE_SCORES[event.classification]
+  const reasons = [`base score for ${event.classification.replace(/_/g, " ")}`]
+
+  switch (event.direction) {
+    case "negative":
+      score += 10
+      reasons.push("negative direction raises urgency")
+      break
+    case "mixed":
+      score += 8
+      reasons.push("mixed direction still indicates decision-relevant change")
+      break
+    case "positive":
+      score += 5
+      reasons.push("positive direction still matters for portfolio actions")
+      break
+    case "unknown":
+      score -= 4
+      reasons.push("unknown direction reduces conviction")
+      break
+  }
+
+  const confidenceAdjustment = Math.round((event.confidence - 0.5) * 20)
+  score += confidenceAdjustment
+  reasons.push(`classifier confidence ${event.confidence.toFixed(2)}`)
+
+  const ageHours = eventAgeHours(event.asOf)
+  if (typeof ageHours === "number") {
+    if (ageHours <= 24) {
+      score += 6
+      reasons.push("captured within the last 24 hours")
+    } else if (ageHours <= 72) {
+      score += 3
+      reasons.push("captured within the last 72 hours")
+    } else if (ageHours > 24 * 7) {
+      score -= 8
+      reasons.push("older than seven days")
+    }
+  }
+
+  if (holding && symbol) {
+    score += 15
+    reasons.push(`linked to holding ${symbol}`)
+  }
+
+  if (watched && symbol) {
+    score += holding ? 4 : 8
+    reasons.push(`linked to watchlist ${symbol}`)
+  }
+
+  if (sectorLabels.length > 0) {
+    score += Math.min(4, sectorLabels.length * 2)
+    reasons.push(`linked sector context: ${sectorLabels.join(", ")}`)
+  }
+
+  const normalizedScore = clampScore(score)
+  return InvestingEventRecordSchema.parse({
+    ...event,
+    entityLinks: {
+      issuerId: event.companyId ?? event.entityLinks.issuerId,
+      instrumentId: event.instrumentId ?? event.entityLinks.instrumentId,
+      sectorIds: sectorLabels.map(sectorEntityId),
+      sectorLabels,
+      holdingId: symbol && holding ? holdingEntityId(symbol) : undefined,
+      watchlistId: symbol && watched ? watchlistEntityId(symbol) : undefined,
+      audience,
+    },
+    materiality: {
+      score: normalizedScore,
+      band: materialityBandForScore(normalizedScore),
+      reasons,
+    },
+  })
+}
+
+async function enrichInvestingEvents(input: {
+  events: InvestingEventRecord[]
+  portfolioFile?: string
+  watchlistFile?: string
+}): Promise<InvestingEventRecord[]> {
+  const [holdings, watchlist] = await Promise.all([
+    loadPortfolioCoverage(input.portfolioFile),
+    loadWatchlistCoverage(input.watchlistFile),
+  ])
+
+  return input.events.map((event) =>
+    enrichInvestingEventRecord({
+      event,
+      holdings,
+      watchlist,
+    }),
+  )
 }
 
 export function classifyInvestingConnectorEvents(input: {
@@ -417,6 +833,8 @@ export function classifyInvestingConnectorEvents(input: {
 export async function upsertInvestingEvents(input: {
   events: InvestingEventRecord[]
   stateFile?: string
+  portfolioFile?: string
+  watchlistFile?: string
 }): Promise<InvestingEventCatalogUpdate> {
   if (input.events.length === 0) {
     const status = buildStatus(await readCatalog(input.stateFile))
@@ -425,14 +843,25 @@ export async function upsertInvestingEvents(input: {
       batchCount: 0,
       inserted: 0,
       updated: 0,
+      batchCountsByMaterialityBand: withDefaultCounts(INVESTING_EVENT_MATERIALITY_BANDS),
+      batchHoldingLinkedCount: 0,
+      batchWatchlistLinkedCount: 0,
     }
   }
 
   const catalog = await readCatalog(input.stateFile)
+  const enrichedEvents = await enrichInvestingEvents({
+    events: input.events,
+    portfolioFile: input.portfolioFile,
+    watchlistFile: input.watchlistFile,
+  })
+  const batchCountsByMaterialityBand = buildBatchCountsByMaterialityBand(enrichedEvents)
+  const batchHoldingLinkedCount = enrichedEvents.filter((event) => Boolean(event.entityLinks.holdingId)).length
+  const batchWatchlistLinkedCount = enrichedEvents.filter((event) => Boolean(event.entityLinks.watchlistId)).length
   let inserted = 0
   let updated = 0
 
-  for (const event of input.events) {
+  for (const event of enrichedEvents) {
     const existed = Boolean(catalog.events[event.id])
     if (existed) updated += 1
     else inserted += 1
@@ -458,6 +887,28 @@ export async function upsertInvestingEvents(input: {
         mode: existed ? "updated" : "inserted",
       },
     })
+
+    FluxRecorder.record({
+      traceID: crypto.randomUUID(),
+      direction: "internal",
+      domain: "investing",
+      kind: "investing.event.scored",
+      status: "ok",
+      method: "materiality",
+      path: event.connector,
+      route: event.materiality.band,
+      metadata: {
+        eventId: event.id,
+        entityId: event.entityId,
+        symbol: event.symbol,
+        materialityScore: event.materiality.score,
+        materialityBand: event.materiality.band,
+        audience: event.entityLinks.audience,
+        holdingLinked: Boolean(event.entityLinks.holdingId),
+        watchlistLinked: Boolean(event.entityLinks.watchlistId),
+        sectorIds: event.entityLinks.sectorIds,
+      },
+    })
   }
 
   catalog.updatedAt = Date.now()
@@ -465,9 +916,12 @@ export async function upsertInvestingEvents(input: {
   const status = buildStatus(catalog)
   return {
     ...status,
-    batchCount: input.events.length,
+    batchCount: enrichedEvents.length,
     inserted,
     updated,
+    batchCountsByMaterialityBand,
+    batchHoldingLinkedCount,
+    batchWatchlistLinkedCount,
   }
 }
 
@@ -480,19 +934,30 @@ export async function listInvestingEvents(options: {
   connector?: InvestingEventConnector
   classification?: InvestingEventClassification
   direction?: InvestingEventDirection
+  materialityBand?: InvestingEventMaterialityBand
   symbol?: string
+  holdingOnly?: boolean
+  watchlistOnly?: boolean
   limit?: number
 } = {}): Promise<InvestingEventRecord[]> {
   const catalog = await readCatalog(options.stateFile)
-  const symbol = options.symbol?.trim().toUpperCase()
+  const symbol = normalizeSymbol(options.symbol)
   const limit = Math.max(1, Math.min(200, options.limit ?? 20))
 
   return Object.values(catalog.events)
     .filter((event) => (options.connector ? event.connector === options.connector : true))
     .filter((event) => (options.classification ? event.classification === options.classification : true))
     .filter((event) => (options.direction ? event.direction === options.direction : true))
+    .filter((event) => (options.materialityBand ? event.materiality.band === options.materialityBand : true))
     .filter((event) => (symbol ? event.symbol === symbol : true))
-    .sort((left, right) => right.asOf.localeCompare(left.asOf))
+    .filter((event) => (options.holdingOnly ? Boolean(event.entityLinks.holdingId) : true))
+    .filter((event) => (options.watchlistOnly ? Boolean(event.entityLinks.watchlistId) : true))
+    .sort((left, right) => {
+      if (right.materiality.score !== left.materiality.score) {
+        return right.materiality.score - left.materiality.score
+      }
+      return right.asOf.localeCompare(left.asOf)
+    })
     .slice(0, limit)
 }
 

--- a/packages/zee/src/investing/ingestion.ts
+++ b/packages/zee/src/investing/ingestion.ts
@@ -478,6 +478,8 @@ export async function executeInvestingConnectorRun(input: {
   stateFile?: string
   entityStateFile?: string
   eventStateFile?: string
+  portfolioFile?: string
+  watchlistFile?: string
   now?: number
 }): Promise<InvestingConnectorRunRecord> {
   const startedAt = input.now ?? Date.now()
@@ -509,6 +511,8 @@ export async function executeInvestingConnectorRun(input: {
         ? await upsertInvestingEvents({
             events: classifiedEvents,
             stateFile: input.eventStateFile,
+            portfolioFile: input.portfolioFile,
+            watchlistFile: input.watchlistFile,
           })
         : undefined
     const record: InvestingConnectorRunRecord = {
@@ -558,6 +562,9 @@ export async function executeInvestingConnectorRun(input: {
         classifiedEventTypes: [...new Set(classifiedEvents.map((event) => event.classification))],
         eventInserted: eventUpdate?.inserted ?? 0,
         eventUpdated: eventUpdate?.updated ?? 0,
+        materialityBands: eventUpdate?.batchCountsByMaterialityBand ?? undefined,
+        holdingLinkedCount: eventUpdate?.batchHoldingLinkedCount ?? 0,
+        watchlistLinkedCount: eventUpdate?.batchWatchlistLinkedCount ?? 0,
         freshnessStatus: record.freshnessStatus,
         freshnessSloMinutes: record.freshnessSloMinutes,
         retryAttempts: record.retryAttempts,
@@ -633,6 +640,8 @@ export async function executeInvestingConnectorRunWithRetry(input: {
   stateFile?: string
   entityStateFile?: string
   eventStateFile?: string
+  portfolioFile?: string
+  watchlistFile?: string
   now?: number
   sleep?: (ms: number) => Promise<void>
 }): Promise<InvestingConnectorRunRecord> {
@@ -649,6 +658,8 @@ export async function executeInvestingConnectorRunWithRetry(input: {
         stateFile: input.stateFile,
         entityStateFile: input.entityStateFile,
         eventStateFile: input.eventStateFile,
+        portfolioFile: input.portfolioFile,
+        watchlistFile: input.watchlistFile,
         now: attempt === 0 ? input.now : undefined,
       })
     } catch (error) {
@@ -687,6 +698,8 @@ export async function runInvestingConnector(
     stateFile?: string
     entityStateFile?: string
     eventStateFile?: string
+    portfolioFile?: string
+    watchlistFile?: string
   } = {},
 ): Promise<InvestingConnectorRunRecord> {
   const rawConfig = options.config ?? (await Config.get())
@@ -701,6 +714,8 @@ export async function runInvestingConnector(
       stateFile: options.stateFile,
       entityStateFile: options.entityStateFile,
       eventStateFile: options.eventStateFile,
+      portfolioFile: options.portfolioFile,
+      watchlistFile: options.watchlistFile,
     })
   } finally {
     await client.disconnect().catch(() => {})
@@ -712,6 +727,8 @@ export async function runEnabledInvestingConnectors(options: {
   stateFile?: string
   entityStateFile?: string
   eventStateFile?: string
+  portfolioFile?: string
+  watchlistFile?: string
   connectors?: InvestingConnectorKind[]
 } = {}): Promise<InvestingConnectorRunRecord[]> {
   const rawConfig = options.config ?? (await Config.get())
@@ -732,6 +749,8 @@ export async function runEnabledInvestingConnectors(options: {
           stateFile: options.stateFile,
           entityStateFile: options.entityStateFile,
           eventStateFile: options.eventStateFile,
+          portfolioFile: options.portfolioFile,
+          watchlistFile: options.watchlistFile,
         }),
       )
     }
@@ -844,6 +863,8 @@ async function runBackfillWithConnectorConfig(input: {
   stateFile?: string
   entityStateFile?: string
   eventStateFile?: string
+  portfolioFile?: string
+  watchlistFile?: string
 }): Promise<InvestingConnectorRunRecord> {
   const client = await createInvestingClient(input.rawConfig)
   try {
@@ -854,6 +875,8 @@ async function runBackfillWithConnectorConfig(input: {
       stateFile: input.stateFile,
       entityStateFile: input.entityStateFile,
       eventStateFile: input.eventStateFile,
+      portfolioFile: input.portfolioFile,
+      watchlistFile: input.watchlistFile,
     })
   } finally {
     await client.disconnect().catch(() => {})
@@ -903,6 +926,8 @@ export async function runInvestingConnectorBackfill(input: {
   stateFile?: string
   entityStateFile?: string
   eventStateFile?: string
+  portfolioFile?: string
+  watchlistFile?: string
   operationsFile?: string
   symbols?: string[]
   lookbackDays?: number
@@ -952,6 +977,8 @@ export async function runInvestingConnectorBackfill(input: {
           stateFile: input.stateFile,
           entityStateFile: input.entityStateFile,
           eventStateFile: input.eventStateFile,
+          portfolioFile: input.portfolioFile,
+          watchlistFile: input.watchlistFile,
         })
 
     record.finishedAt = Date.now()

--- a/packages/zee/test/investing/events.test.ts
+++ b/packages/zee/test/investing/events.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises"
 import path from "node:path"
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { FluxRecorder } from "../../src/flux"
@@ -47,11 +48,20 @@ describe("investing event intelligence", () => {
       direction: "positive",
       symbol: "AAPL",
       entityId: "event:earnings:aapl:q4-2025:2026-01-28t00-00-00-000z",
+      entityLinks: {
+        issuerId: "company:equity:aapl",
+        instrumentId: "instrument:equity:aapl",
+        audience: "general",
+      },
+      materiality: {
+        score: 0,
+        band: "low",
+      },
     })
     expect(events[0]?.summary).toContain("avg EPS surprise 5.0%")
   })
 
-  test("classifies news entities with keyword-based topic and direction heuristics", () => {
+  test("classifies news entities with keyword-based topic, direction, and sector hints", () => {
     const entities = normalizeInvestingConnectorEntities({
       connector: "news",
       collectedAt: "2026-03-15T10:00:00.000Z",
@@ -62,6 +72,7 @@ describe("investing event intelligence", () => {
           publishedAt: "2026-03-15T09:00:00.000Z",
           title: "Microsoft raises guidance after strong Azure growth",
           summary: "The company raised fiscal guidance after another strong quarter for Azure.",
+          sector: "Software",
           url: "https://example.com/msft-guidance",
         },
       ],
@@ -80,14 +91,40 @@ describe("investing event intelligence", () => {
       direction: "positive",
       symbol: "MSFT",
       sourceUrl: "https://example.com/msft-guidance",
+      entityLinks: {
+        sectorLabels: ["Software"],
+      },
     })
     expect(events[0]?.reasons[0]).toContain("guidance_update")
   })
 
-  test("persists classified events, exposes status, and emits telemetry", async () => {
+  test("scores and links events against holdings and watchlist coverage", async () => {
     await using dir = await tmpdir()
     const stateFile = path.join(dir.path, "investing-events.json")
+    const portfolioFile = path.join(dir.path, "portfolio.json")
+    const watchlistFile = path.join(dir.path, "watchlist.json")
     const recordSpy = spyOn(FluxRecorder, "record")
+
+    await fs.writeFile(
+      portfolioFile,
+      JSON.stringify(
+        {
+          positions: [{ symbol: "NVDA", shares: 12, averageCost: 450, sector: "Semiconductors" }],
+        },
+        null,
+        2,
+      ),
+    )
+    await fs.writeFile(
+      watchlistFile,
+      JSON.stringify(
+        {
+          items: [{ symbol: "MSFT", sector: "Software" }],
+        },
+        null,
+        2,
+      ),
+    )
 
     const earningsEntities = normalizeInvestingConnectorEntities({
       connector: "earnings",
@@ -95,7 +132,7 @@ describe("investing event intelligence", () => {
       collectedAt: "2026-03-15T10:00:00.000Z",
       data: {
         symbol: "NVDA",
-        quarters: [{ quarter: "Q1 2026", reportDate: "2026-02-20" }],
+        quarters: [{ quarter: "Q1 2026", reportDate: "2026-03-15" }],
         epsGrowthYoy: 18,
         avgEpsSurprisePercent: 7,
         beatRate: 0.9,
@@ -107,17 +144,20 @@ describe("investing event intelligence", () => {
       collectedAt: "2026-03-15T10:00:00.000Z",
       data: [
         {
-          symbol: "NVDA",
+          symbol: "MSFT",
           articleId: "story-2",
           publishedAt: "2026-03-15T08:30:00.000Z",
-          title: "Nvidia launches new enterprise AI platform with major cloud partners",
-          summary: "The launch expands Nvidia's enterprise AI reach through new partnerships.",
+          title: "Microsoft raises guidance after strong Azure growth",
+          summary: "The launch expands Microsoft's AI reach and management raised fiscal guidance.",
+          sector: "Software",
         },
       ],
     })
 
     const update = await upsertInvestingEvents({
       stateFile,
+      portfolioFile,
+      watchlistFile,
       events: [
         ...classifyInvestingConnectorEvents({
           connector: "earnings",
@@ -137,22 +177,44 @@ describe("investing event intelligence", () => {
     expect(update.totalEvents).toBe(2)
     expect(update.countsByConnector.earnings).toBe(1)
     expect(update.countsByConnector.news).toBe(1)
+    expect(update.batchCountsByMaterialityBand.critical).toBe(2)
+    expect(update.batchHoldingLinkedCount).toBe(1)
+    expect(update.batchWatchlistLinkedCount).toBe(1)
     expect(recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.event.classified")).toHaveLength(2)
+    expect(recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.event.scored")).toHaveLength(2)
 
     const status = await getInvestingEventCatalogStatus(stateFile)
     expect(status.totalEvents).toBe(2)
     expect(status.countsByClassification.earnings_result).toBe(1)
-    expect(status.countsByClassification.product_and_partnership).toBe(1)
+    expect(status.countsByClassification.guidance_update).toBe(1)
+    expect(status.countsByMaterialityBand.critical).toBe(2)
+    expect(status.holdingLinkedCount).toBe(1)
+    expect(status.watchlistLinkedCount).toBe(1)
 
-    const listed = await listInvestingEvents({
+    const holdingEvents = await listInvestingEvents({
       stateFile,
-      symbol: "NVDA",
+      holdingOnly: true,
       limit: 5,
     })
-    expect(listed).toHaveLength(2)
-    expect(listed[0]?.symbol).toBe("NVDA")
+    expect(holdingEvents).toHaveLength(1)
+    expect(holdingEvents[0]?.symbol).toBe("NVDA")
+    expect(holdingEvents[0]?.entityLinks.holdingId).toBe("holding:equity:nvda")
+    expect(holdingEvents[0]?.entityLinks.sectorLabels).toContain("Semiconductors")
+    expect(holdingEvents[0]?.materiality.band).toBe("critical")
 
-    const loaded = await getInvestingEvent(listed[0]!.id, stateFile)
-    expect(loaded?.id).toBe(listed[0]?.id)
+    const watchlistEvents = await listInvestingEvents({
+      stateFile,
+      watchlistOnly: true,
+      materialityBand: "critical",
+      limit: 5,
+    })
+    expect(watchlistEvents).toHaveLength(1)
+    expect(watchlistEvents[0]?.symbol).toBe("MSFT")
+    expect(watchlistEvents[0]?.entityLinks.watchlistId).toBe("watchlist:equity:msft")
+    expect(watchlistEvents[0]?.entityLinks.sectorLabels).toContain("Software")
+
+    const loaded = await getInvestingEvent(holdingEvents[0]!.id, stateFile)
+    expect(loaded?.id).toBe(holdingEvents[0]?.id)
+    expect(loaded?.materiality.score).toBeGreaterThanOrEqual(90)
   })
 })

--- a/packages/zee/test/investing/ingestion.test.ts
+++ b/packages/zee/test/investing/ingestion.test.ts
@@ -86,8 +86,31 @@ describe("executeInvestingConnectorRun", () => {
     const stateFile = path.join(dir.path, "investing-ingestion.json")
     const entityStateFile = path.join(dir.path, "investing-entities.json")
     const eventStateFile = path.join(dir.path, "investing-events.json")
+    const portfolioFile = path.join(dir.path, "portfolio.json")
+    const watchlistFile = path.join(dir.path, "watchlist.json")
     const recordSpy = spyOn(FluxRecorder, "record")
     const startedAt = 1_700_000_000_000
+
+    await fs.writeFile(
+      portfolioFile,
+      JSON.stringify(
+        {
+          positions: [{ symbol: "AAPL", shares: 8, averageCost: 180, sector: "Technology" }],
+        },
+        null,
+        2,
+      ),
+    )
+    await fs.writeFile(
+      watchlistFile,
+      JSON.stringify(
+        {
+          items: [{ symbol: "MSFT", sector: "Software" }],
+        },
+        null,
+        2,
+      ),
+    )
 
     const result = await executeInvestingConnectorRun({
       connector: "earnings",
@@ -104,6 +127,8 @@ describe("executeInvestingConnectorRun", () => {
       },
       stateFile,
       entityStateFile,
+      portfolioFile,
+      watchlistFile,
       now: startedAt,
       executor: async () => ({
         itemCount: 4,
@@ -146,6 +171,7 @@ describe("executeInvestingConnectorRun", () => {
     expect(result.lastFinishedAt).toBeGreaterThanOrEqual(startedAt)
     expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.entity.normalized")).toBe(true)
     expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.event.classified")).toBe(true)
+    expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.event.scored")).toBe(true)
     expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.ingestion.run")).toBe(true)
     expect(recordSpy.mock.calls.find((call) => call[0]?.kind === "investing.entity.normalized")?.[0]).toMatchObject({
       domain: "investing",
@@ -167,6 +193,8 @@ describe("executeInvestingConnectorRun", () => {
         requestCount: 1,
         normalizedEntityCount: 3,
         classifiedEventCount: 1,
+        holdingLinkedCount: 1,
+        watchlistLinkedCount: 0,
         freshnessStatus: "fresh",
       },
     })
@@ -187,6 +215,8 @@ describe("executeInvestingConnectorRun", () => {
     const eventStatus = await getInvestingEventCatalogStatus(eventStateFile)
     expect(eventStatus.totalEvents).toBe(1)
     expect(eventStatus.countsByConnector.earnings).toBe(1)
+    expect(eventStatus.countsByMaterialityBand.critical).toBe(1)
+    expect(eventStatus.holdingLinkedCount).toBe(1)
   })
 
   test("persists failed runs and emits error telemetry", async () => {

--- a/src/domain/investing/tools.ts
+++ b/src/domain/investing/tools.ts
@@ -48,6 +48,7 @@ import {
   INVESTING_EVENT_CLASSIFICATIONS,
   INVESTING_EVENT_CONNECTORS,
   INVESTING_EVENT_DIRECTIONS,
+  INVESTING_EVENT_MATERIALITY_BANDS,
   getInvestingEvent,
   getInvestingEventCatalogStatus,
   listInvestingEvents,
@@ -794,7 +795,10 @@ const EventIntelligenceParams = z.discriminatedUnion("action", [
     connector: z.enum(INVESTING_EVENT_CONNECTORS).optional().describe("Optional connector filter"),
     classification: z.enum(INVESTING_EVENT_CLASSIFICATIONS).optional().describe("Optional classification filter"),
     direction: z.enum(INVESTING_EVENT_DIRECTIONS).optional().describe("Optional direction filter"),
+    materialityBand: z.enum(INVESTING_EVENT_MATERIALITY_BANDS).optional().describe("Optional materiality band filter"),
     symbol: z.string().optional().describe("Optional symbol filter"),
+    holdingOnly: z.boolean().default(false).describe("Only include events linked to holdings"),
+    watchlistOnly: z.boolean().default(false).describe("Only include events linked to watchlist symbols"),
     limit: z.number().min(1).max(100).default(10).describe("Maximum number of events to return"),
   }),
   z.object({
@@ -826,7 +830,10 @@ export const eventIntelligenceTool: ToolDefinition = {
             connector: args.connector,
             classification: args.classification,
             direction: args.direction,
+            materialityBand: args.materialityBand,
             symbol: args.symbol,
+            holdingOnly: args.holdingOnly,
+            watchlistOnly: args.watchlistOnly,
             limit: args.limit,
           });
           return {
@@ -837,7 +844,10 @@ export const eventIntelligenceTool: ToolDefinition = {
               connector: args.connector,
               classification: args.classification,
               direction: args.direction,
+              materialityBand: args.materialityBand,
               symbol: args.symbol,
+              holdingOnly: args.holdingOnly,
+              watchlistOnly: args.watchlistOnly,
             },
             output: JSON.stringify({ events, count: events.length }, null, 2),
           };


### PR DESCRIPTION
## Summary
- extend investing event records with stable materiality scoring and entity-link fields for issuers, sectors, holdings, and watchlist coverage
- feed the scoring pipeline through ingestion telemetry and expose the new filters/details through `zee investing event ...` and `zee:invest-events`
- document the scoring model, update the map, and add focused tests for coverage linking and telemetry

## Testing
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- ./node_modules/.bin/tsc --noEmit -p packages/zee/tsconfig.typecheck.json
- cd packages/zee && bun test test/investing/events.test.ts test/investing/ingestion.test.ts
- cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh
- zee investing event status --json
- zee investing event list --materiality-band high --holding --json

Closes #507
