### PR TITLE
feat(#508): add briefing event deltas

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -194,11 +194,14 @@ rg "export class Memory|getMemory|getMemoryAsync" src/memory/unified.ts  # Unifi
 - **Johny registration:** `src/domain/learning/tools.ts:504`
 
 ### Feature: Investing Event Intelligence
-**Purpose:** Classify, score, and link normalized earnings and news entities into a persistent event ledger for downstream research automation.
+**Purpose:** Classify, score, link, and render briefing-ready deltas from normalized earnings and news entities.
 - **Event catalog + classifier:** `packages/zee/src/investing/events.ts:1`
+- **Briefing delta builder:** `packages/zee/src/investing/briefing-deltas.ts:212`
 - **Ingestion hook + telemetry:** `packages/zee/src/investing/ingestion.ts:473`
 - **CLI surface (`zee investing event ...`):** `packages/zee/src/cli/cmd/investing.ts:164`
 - **Stanley tool (`zee:invest-events`):** `src/domain/investing/tools.ts:810`
+- **Earnings workflow synthesis integration:** `src/domain/investing/executor.ts:348`
+- **Daily brief integration:** `packages/zee/src/plugin/investing.ts:918`
 - **Operator doc:** `docs/architecture/investing-event-intelligence.md:1`
 
 ### Feature: Memory (Qdrant + Hybrid Search + Markdown Sync)

--- a/docs/architecture/investing-event-intelligence.md
+++ b/docs/architecture/investing-event-intelligence.md
@@ -7,7 +7,7 @@ This document now covers:
 - issue `#506`: ingestion and classification
 - issue `#507`: materiality scoring and entity-linking
 
-Briefing deltas remain the follow-on work for `#508`.
+This document also covers issue `#508`: integrating event deltas into current briefing outputs.
 
 ## Source Of Truth
 
@@ -83,13 +83,19 @@ Domain tool:
   - `list`
   - `read`
 
+Briefing outputs now consume event deltas in two places:
+
+- earnings workflow synthesis and artifact outputs for `earnings-preview` and `earnings-review`
+- the existing `zee_invest_morning_brief` plugin output for daily watchlist/coverage monitoring
+
 ## Ingestion Flow
 
 1. Connector payloads are normalized into canonical entities.
 2. `earnings` and `news` event entities are classified into the event ledger.
 3. Each classified record is enriched with materiality and coverage links using the configured holdings/watchlist context.
 4. Each enriched record is upserted by stable ID (`classified:<entity-id>`).
-5. Connector run telemetry includes classified-event counts, materiality-band counts, and coverage-link counts for that batch.
+5. Briefing builders select the highest-signal scored events and render stable event-delta summaries for daily and earnings-oriented outputs.
+6. Connector run telemetry includes classified-event counts, materiality-band counts, and coverage-link counts for that batch.
 
 ## Telemetry
 
@@ -101,6 +107,9 @@ Flux events emitted for this slice:
 - `investing.event.scored`
   - one event per inserted or updated scored record
   - metadata includes `eventId`, `materialityScore`, `materialityBand`, `audience`, and holding/watchlist linkage flags
+- `investing.event.delta`
+  - one event per generated briefing delta payload
+  - metadata includes `mode`, `symbols`, `itemCount`, `audiences`, and the selected `eventIds`
 - `investing.ingestion.run`
   - now includes `classifiedEventCount`, `classifiedEventTypes`, `eventInserted`, `eventUpdated`, `materialityBands`, `holdingLinkedCount`, and `watchlistLinkedCount` when the connector produces classified events
 
@@ -109,4 +118,4 @@ Flux events emitted for this slice:
 - News classification is heuristic and keyword-driven in this slice.
 - Earnings classification is deterministic from the normalized earnings connector event shape.
 - Materiality scoring is intentionally heuristic in this slice; calibration and precision tuning remain follow-on work.
-- Briefing/thesis integration remains follow-on work.
+- Event deltas currently power the existing daily and earnings-oriented briefing outputs; full portfolio research workflows remain follow-on work.

--- a/docs/architecture/investing-report-artifacts.md
+++ b/docs/architecture/investing-report-artifacts.md
@@ -30,6 +30,8 @@ Each artifact includes:
 - `nextActions[]`
 - `diagnostics[]`
 
+For earnings-oriented workflows, the `Synthesis` section now carries the briefing-ready event delta block generated from scored event intelligence.
+
 Artifact kinds map to workflow phases:
 
 - `scope-note`

--- a/docs/architecture/investing-synthesis-executor.md
+++ b/docs/architecture/investing-synthesis-executor.md
@@ -8,7 +8,7 @@ This slice sits directly after the research planner:
 
 - planner: decide what should be done
 - executor: run the current task across relevant sources
-- later slices: richer analyst packets, event deltas, and thesis artifacts
+- later slices: richer analyst packets and thesis artifacts
 
 Persisted execution packets live at `~/.local/state/zee/investing/research-executions.json`.
 
@@ -34,8 +34,9 @@ When `run` is called, Zee:
 3. Collects evidence items from each source.
 4. Assigns stable evidence citations such as `E1`, `E2`, and stable links such as `evidence:<executionId>:E1`.
 5. Produces a synthesis note that embeds those evidence links.
-6. Appends the standard investing provenance block.
-7. Persists the execution packet and advances the task in the planner.
+6. For `earnings-preview` and `earnings-review`, appends the highest-signal scored event deltas for the symbol scope.
+7. Appends the standard investing provenance block.
+8. Persists the execution packet and advances the task in the planner.
 
 If a task has no directly executable source tools, the executor reuses the latest evidence from dependency tasks so synthesis steps can still cite prior evidence.
 
@@ -86,6 +87,8 @@ The executor emits Flux events under `domain=investing`:
   - one event per execution run with workflow, task, and evidence counts
 - `investing.research.evidence`
   - one event per evidence item with citation, source label, and summary
+
+For earnings-oriented workflows, the executor also consumes `investing.event.delta` telemetry emitted by the event-delta builder when it materializes briefing-ready deltas.
 
 The executor also relies on the planner's `investing.research.plan.task` telemetry when it marks a task `completed` or `blocked` after execution.
 

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -52,6 +52,7 @@ export type FluxKind =
   | "investing.ingestion.schedule"
   | "investing.event.classified"
   | "investing.event.scored"
+  | "investing.event.delta"
   | "investing.research.plan"
   | "investing.research.plan.task"
   | "investing.research.execution"

--- a/packages/zee/src/investing/briefing-deltas.ts
+++ b/packages/zee/src/investing/briefing-deltas.ts
@@ -1,0 +1,302 @@
+import { FluxRecorder } from "@/flux"
+import {
+  listInvestingEvents,
+  type InvestingEventAudience,
+  type InvestingEventClassification,
+  type InvestingEventDirection,
+  type InvestingEventMaterialityBand,
+  type InvestingEventRecord,
+} from "./events"
+
+export const INVESTING_EVENT_DELTA_MODES = ["daily", "pre-earnings", "post-earnings"] as const
+
+export type InvestingEventDeltaMode = (typeof INVESTING_EVENT_DELTA_MODES)[number]
+
+export interface InvestingEventDeltaItem {
+  id: string
+  eventId: string
+  symbol?: string
+  asOf: string
+  headline: string
+  delta: string
+  classification: InvestingEventClassification
+  direction: InvestingEventDirection
+  materialityBand: InvestingEventMaterialityBand
+  materialityScore: number
+  audience: InvestingEventAudience
+  sectors: string[]
+  implications: string[]
+}
+
+export interface InvestingEventDeltaBrief {
+  id: string
+  mode: InvestingEventDeltaMode
+  generatedAt: string
+  symbols: string[]
+  summary: string
+  items: InvestingEventDeltaItem[]
+}
+
+function normalizeSymbol(symbol: string): string {
+  return symbol.trim().toUpperCase()
+}
+
+function normalizeSymbols(symbols?: string[]): string[] {
+  return [...new Set((symbols ?? []).map(normalizeSymbol).filter((symbol) => /^[A-Z][A-Z0-9.\-]{0,9}$/.test(symbol)))]
+}
+
+function bandRank(band: InvestingEventMaterialityBand): number {
+  switch (band) {
+    case "critical":
+      return 3
+    case "high":
+      return 2
+    case "medium":
+      return 1
+    case "low":
+    default:
+      return 0
+  }
+}
+
+function minimumBandForMode(mode: InvestingEventDeltaMode): InvestingEventMaterialityBand {
+  switch (mode) {
+    case "pre-earnings":
+      return "medium"
+    case "post-earnings":
+    case "daily":
+    default:
+      return "high"
+  }
+}
+
+function modeWeight(mode: InvestingEventDeltaMode, event: InvestingEventRecord): number {
+  switch (mode) {
+    case "pre-earnings":
+      if (event.classification === "guidance_update") return 24
+      if (event.classification === "earnings_result") return 18
+      if (event.classification === "legal_regulatory") return 12
+      if (event.classification === "product_and_partnership") return 10
+      return 0
+    case "post-earnings":
+      if (event.classification === "earnings_result") return 24
+      if (event.classification === "guidance_update") return 18
+      if (event.classification === "legal_regulatory") return 10
+      return 0
+    case "daily":
+    default:
+      if (event.entityLinks.audience === "holding") return 18
+      if (event.entityLinks.audience === "watchlist") return 10
+      return 0
+  }
+}
+
+function dedupeEvents(events: InvestingEventRecord[]): InvestingEventRecord[] {
+  const byId = new Map<string, InvestingEventRecord>()
+  for (const event of events) {
+    byId.set(event.id, event)
+  }
+  return [...byId.values()]
+}
+
+function classificationLabel(classification: InvestingEventClassification): string {
+  return classification.replace(/_/g, " ")
+}
+
+function audienceLabel(audience: InvestingEventAudience): string {
+  switch (audience) {
+    case "holding":
+      return "holding"
+    case "watchlist":
+      return "watchlist"
+    case "general":
+    default:
+      return "general coverage"
+  }
+}
+
+function implicationsForEvent(event: InvestingEventRecord, mode: InvestingEventDeltaMode): string[] {
+  const symbol = event.symbol ?? "this name"
+  const actions: string[] = []
+
+  if (mode === "daily") {
+    if (event.entityLinks.audience === "holding") {
+      actions.push(`Review ${symbol} position sizing and today's risk watchpoints.`)
+    } else if (event.entityLinks.audience === "watchlist") {
+      actions.push(`Refresh the ${symbol} watchlist setup before the next research pass.`)
+    } else {
+      actions.push(`Track whether ${symbol} belongs in today's broader market scan.`)
+    }
+  }
+
+  if (mode === "pre-earnings") {
+    actions.push(`Refresh the ${symbol} pre-earnings scenario grid with this event delta.`)
+    if (event.classification === "guidance_update" || event.classification === "earnings_result") {
+      actions.push(`Update the ${symbol} management question list and expectation map.`)
+    }
+  }
+
+  if (mode === "post-earnings") {
+    actions.push(`Compare this event against the reported ${symbol} outcome and update the post-earnings review.`)
+  }
+
+  if (event.direction === "negative" || event.materiality.band === "critical") {
+    actions.push(`Escalate risk review for ${symbol}.`)
+  } else if (event.direction === "positive") {
+    actions.push(`Check whether upside catalysts or estimate expectations should move for ${symbol}.`)
+  }
+
+  return [...new Set(actions)]
+}
+
+function renderDeltaLine(event: InvestingEventRecord): string {
+  const parts = [
+    `${event.title}`,
+    `${classificationLabel(event.classification)} / ${event.direction}`,
+    `${event.materiality.band} ${event.materiality.score}/100`,
+    audienceLabel(event.entityLinks.audience),
+  ]
+  if (event.entityLinks.sectorLabels.length > 0) {
+    parts.push(`sectors: ${event.entityLinks.sectorLabels.join(", ")}`)
+  }
+  parts.push(event.summary)
+  return parts.join(" | ")
+}
+
+async function collectCandidateEvents(input: {
+  mode: InvestingEventDeltaMode
+  stateFile?: string
+  symbols: string[]
+  limit: number
+}): Promise<InvestingEventRecord[]> {
+  const fetchLimit = Math.max(input.limit * 3, 12)
+  if (input.symbols.length > 0) {
+    const batches = await Promise.all(
+      input.symbols.map((symbol) =>
+        listInvestingEvents({
+          stateFile: input.stateFile,
+          symbol,
+          limit: fetchLimit,
+        }),
+      ),
+    )
+    return dedupeEvents(batches.flat())
+  }
+
+  if (input.mode === "daily") {
+    const [holdingEvents, watchlistEvents, generalEvents] = await Promise.all([
+      listInvestingEvents({
+        stateFile: input.stateFile,
+        holdingOnly: true,
+        limit: fetchLimit,
+      }),
+      listInvestingEvents({
+        stateFile: input.stateFile,
+        watchlistOnly: true,
+        limit: fetchLimit,
+      }),
+      listInvestingEvents({
+        stateFile: input.stateFile,
+        limit: fetchLimit,
+      }),
+    ])
+    return dedupeEvents([...holdingEvents, ...watchlistEvents, ...generalEvents])
+  }
+
+  return listInvestingEvents({
+    stateFile: input.stateFile,
+    limit: fetchLimit,
+  })
+}
+
+export async function buildInvestingEventDeltaBrief(input: {
+  mode: InvestingEventDeltaMode
+  stateFile?: string
+  symbols?: string[]
+  limit?: number
+}): Promise<InvestingEventDeltaBrief> {
+  const symbols = normalizeSymbols(input.symbols)
+  const limit = Math.max(1, Math.min(10, input.limit ?? 5))
+  const minimumBand = minimumBandForMode(input.mode)
+  const candidates = await collectCandidateEvents({
+    mode: input.mode,
+    stateFile: input.stateFile,
+    symbols,
+    limit,
+  })
+  const filtered = candidates
+    .filter((event) => bandRank(event.materiality.band) >= bandRank(minimumBand))
+    .sort((left, right) => {
+      const weightedLeft = left.materiality.score + modeWeight(input.mode, left)
+      const weightedRight = right.materiality.score + modeWeight(input.mode, right)
+      if (weightedRight !== weightedLeft) return weightedRight - weightedLeft
+      return right.asOf.localeCompare(left.asOf)
+    })
+    .slice(0, limit)
+
+  const generatedAt = new Date().toISOString()
+  const items = filtered.map<InvestingEventDeltaItem>((event) => ({
+    id: `event-delta:${input.mode}:${event.id}`,
+    eventId: event.id,
+    symbol: event.symbol,
+    asOf: event.asOf,
+    headline: event.title,
+    delta: renderDeltaLine(event),
+    classification: event.classification,
+    direction: event.direction,
+    materialityBand: event.materiality.band,
+    materialityScore: event.materiality.score,
+    audience: event.entityLinks.audience,
+    sectors: event.entityLinks.sectorLabels,
+    implications: implicationsForEvent(event, input.mode),
+  }))
+  const scope = symbols.length > 0 ? symbols.join(", ") : "current coverage"
+  const summary =
+    items.length > 0
+      ? `${items.length} event delta(s) selected for ${input.mode} briefing across ${scope}.`
+      : `No qualifying event deltas for ${input.mode} briefing across ${scope}.`
+
+  FluxRecorder.record({
+    traceID: `event-delta:${input.mode}:${generatedAt}`,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.event.delta",
+    status: "ok",
+    method: "briefing",
+    path: input.mode,
+    route: symbols.join(",") || "coverage",
+    metadata: {
+      mode: input.mode,
+      symbols,
+      itemCount: items.length,
+      maxMaterialityScore: items[0]?.materialityScore ?? 0,
+      audiences: [...new Set(items.map((item) => item.audience))],
+      eventIds: items.map((item) => item.eventId),
+    },
+  })
+
+  return {
+    id: `event-delta-brief:${input.mode}:${generatedAt}`,
+    mode: input.mode,
+    generatedAt,
+    symbols,
+    summary,
+    items,
+  }
+}
+
+export function renderInvestingEventDeltaBrief(brief: InvestingEventDeltaBrief): string {
+  if (brief.items.length === 0) {
+    return ["Event Deltas:", `- ${brief.summary}`].join("\n")
+  }
+
+  const lines = ["Event Deltas:", `- ${brief.summary}`]
+  for (const item of brief.items) {
+    lines.push(
+      `- ${item.symbol ?? "MARKET"} ${classificationLabel(item.classification)} (${item.materialityBand} ${item.materialityScore}/100, ${item.direction}, ${item.audience})`,
+    )
+    lines.push(`  ${item.delta}`)
+    lines.push(`  Implications: ${item.implications.join(" | ")}`)
+  }
+  return lines.join("\n")
+}

--- a/packages/zee/src/investing/events.ts
+++ b/packages/zee/src/investing/events.ts
@@ -7,7 +7,10 @@ import { Global } from "@/global"
 import type { NormalizedInvestingEntity } from "./entities"
 
 const EVENT_SCHEMA_VERSION = 1 as const
-const EVENT_STATE_FILE = path.join(Global.Path.state, "investing-event-intelligence.json")
+
+function defaultEventStateFile(): string {
+  return path.join(Global.Path.state, "investing-event-intelligence.json")
+}
 
 export const INVESTING_EVENT_CONNECTORS = ["earnings", "news"] as const
 export const INVESTING_EVENT_CLASSIFICATIONS = [
@@ -535,7 +538,7 @@ function defaultCatalog(): InvestingEventCatalog {
   }
 }
 
-async function readCatalog(stateFile = EVENT_STATE_FILE): Promise<InvestingEventCatalog> {
+async function readCatalog(stateFile = defaultEventStateFile()): Promise<InvestingEventCatalog> {
   const raw = await fs.readFile(stateFile, "utf8").catch(() => "")
   if (!raw) return defaultCatalog()
   try {
@@ -545,7 +548,7 @@ async function readCatalog(stateFile = EVENT_STATE_FILE): Promise<InvestingEvent
   }
 }
 
-async function writeCatalog(catalog: InvestingEventCatalog, stateFile = EVENT_STATE_FILE): Promise<void> {
+async function writeCatalog(catalog: InvestingEventCatalog, stateFile = defaultEventStateFile()): Promise<void> {
   await fs.mkdir(path.dirname(stateFile), { recursive: true })
   await fs.writeFile(stateFile, JSON.stringify(catalog, null, 2) + "\n", "utf8")
 }
@@ -925,7 +928,7 @@ export async function upsertInvestingEvents(input: {
   }
 }
 
-export async function getInvestingEventCatalogStatus(stateFile = EVENT_STATE_FILE): Promise<InvestingEventCatalogStatus> {
+export async function getInvestingEventCatalogStatus(stateFile = defaultEventStateFile()): Promise<InvestingEventCatalogStatus> {
   return buildStatus(await readCatalog(stateFile))
 }
 
@@ -961,7 +964,10 @@ export async function listInvestingEvents(options: {
     .slice(0, limit)
 }
 
-export async function getInvestingEvent(eventId: string, stateFile = EVENT_STATE_FILE): Promise<InvestingEventRecord | undefined> {
+export async function getInvestingEvent(
+  eventId: string,
+  stateFile = defaultEventStateFile(),
+): Promise<InvestingEventRecord | undefined> {
   const catalog = await readCatalog(stateFile)
   return catalog.events[eventId]
 }

--- a/packages/zee/src/plugin/investing.ts
+++ b/packages/zee/src/plugin/investing.ts
@@ -16,6 +16,7 @@ import {
   InvestingNotRunningError,
   InvestingTimeoutError,
 } from "@zee/investing-sdk"
+import { buildInvestingEventDeltaBrief, renderInvestingEventDeltaBrief } from "../investing/briefing-deltas"
 import { Log } from "../util/log"
 import { Investing } from "../paths"
 
@@ -938,6 +939,12 @@ export async function InvestingPlugin(input: PluginInput): Promise<Hooks> {
               }
             }
           }
+
+          const eventDeltas = await buildInvestingEventDeltaBrief({
+            mode: "daily",
+            symbols: args.watchlist,
+          })
+          sections.push(renderInvestingEventDeltaBrief(eventDeltas))
 
           return sections.join("\n\n")
         },

--- a/packages/zee/test/investing/briefing-deltas.test.ts
+++ b/packages/zee/test/investing/briefing-deltas.test.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { FluxRecorder } from "../../src/flux"
+import { buildInvestingEventDeltaBrief, renderInvestingEventDeltaBrief } from "../../src/investing/briefing-deltas"
+import { normalizeInvestingConnectorEntities } from "../../src/investing/entities"
+import { classifyInvestingConnectorEvents, upsertInvestingEvents } from "../../src/investing/events"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe("investing briefing deltas", () => {
+  test("builds daily and pre-earnings briefing deltas from scored events", async () => {
+    await using dir = await tmpdir()
+    const stateFile = path.join(dir.path, "investing-events.json")
+    const portfolioFile = path.join(dir.path, "portfolio.json")
+    const watchlistFile = path.join(dir.path, "watchlist.json")
+    const recordSpy = spyOn(FluxRecorder, "record")
+
+    await fs.writeFile(
+      portfolioFile,
+      JSON.stringify(
+        {
+          positions: [{ symbol: "NVDA", shares: 5, averageCost: 400, sector: "Semiconductors" }],
+        },
+        null,
+        2,
+      ),
+    )
+    await fs.writeFile(
+      watchlistFile,
+      JSON.stringify(
+        {
+          items: [{ symbol: "MSFT", sector: "Software" }],
+        },
+        null,
+        2,
+      ),
+    )
+
+    const events = [
+      ...classifyInvestingConnectorEvents({
+        connector: "earnings",
+        entities: normalizeInvestingConnectorEntities({
+          connector: "earnings",
+          symbol: "NVDA",
+          collectedAt: "2026-03-15T10:00:00.000Z",
+          data: {
+            symbol: "NVDA",
+            quarters: [{ quarter: "Q1 2026", reportDate: "2026-03-15" }],
+            avgEpsSurprisePercent: 6,
+            beatRate: 0.9,
+            earningsConsistency: 0.95,
+          },
+        }),
+      }),
+      ...classifyInvestingConnectorEvents({
+        connector: "news",
+        entities: normalizeInvestingConnectorEntities({
+          connector: "news",
+          collectedAt: "2026-03-15T10:00:00.000Z",
+          data: [
+            {
+              symbol: "MSFT",
+              articleId: "story-3",
+              publishedAt: "2026-03-15T09:30:00.000Z",
+              title: "Microsoft raises guidance after strong Azure growth",
+              summary: "Azure momentum pushed management to raise guidance.",
+              sector: "Software",
+            },
+          ],
+        }),
+      }),
+    ]
+
+    await upsertInvestingEvents({
+      events,
+      stateFile,
+      portfolioFile,
+      watchlistFile,
+    })
+
+    const daily = await buildInvestingEventDeltaBrief({
+      stateFile,
+      mode: "daily",
+      limit: 5,
+    })
+    expect(daily.items).toHaveLength(2)
+    expect(daily.items[0]?.materialityScore).toBeGreaterThanOrEqual(daily.items[1]?.materialityScore ?? 0)
+    expect(renderInvestingEventDeltaBrief(daily)).toContain("Event Deltas:")
+
+    const preview = await buildInvestingEventDeltaBrief({
+      stateFile,
+      mode: "pre-earnings",
+      symbols: ["MSFT"],
+      limit: 5,
+    })
+    expect(preview.items).toHaveLength(1)
+    expect(preview.items[0]).toMatchObject({
+      symbol: "MSFT",
+      classification: "guidance_update",
+      audience: "watchlist",
+    })
+    expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.event.delta")).toBe(true)
+  })
+})

--- a/packages/zee/test/investing/research-artifacts.test.ts
+++ b/packages/zee/test/investing/research-artifacts.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, spyOn, test } from "bun:test"
 import { FluxRecorder } from "../../src/flux"
+import { normalizeInvestingConnectorEntities } from "../../src/investing/entities"
+import { classifyInvestingConnectorEvents, upsertInvestingEvents } from "../../src/investing/events"
 import { tmpdir } from "../fixture/fixture"
 import {
   createInvestingResearchPlan,
@@ -19,6 +21,27 @@ function makeToolContext() {
     abort: new AbortController().signal,
     metadata: () => {},
   }
+}
+
+async function seedEventDelta(symbol: string) {
+  const events = classifyInvestingConnectorEvents({
+    connector: "news",
+    entities: normalizeInvestingConnectorEntities({
+      connector: "news",
+      collectedAt: "2026-03-15T10:00:00.000Z",
+      data: [
+        {
+          symbol,
+          articleId: `${symbol.toLowerCase()}-guidance`,
+          publishedAt: "2026-03-15T09:30:00.000Z",
+          title: `${symbol} raises guidance after a strong quarter`,
+          summary: `Management raised guidance for ${symbol} after a strong quarter.`,
+          sector: "Technology",
+        },
+      ],
+    }),
+  })
+  await upsertInvestingEvents({ events })
 }
 
 async function withArtifactState<T>(fn: () => Promise<T>): Promise<T> {
@@ -68,6 +91,7 @@ describe("investing research artifacts", () => {
       const plan = createInvestingResearchPlan({
         objective: "Prepare a pre-earnings preview for NVDA",
       })
+      await seedEventDelta("NVDA")
       updateInvestingResearchTask({
         planId: plan.id,
         taskId: "coverage-check",
@@ -84,6 +108,7 @@ describe("investing research artifacts", () => {
       expect(artifact.kind).toBe("source-delta")
       expect(artifact.status).toBe("ready")
       expect(artifact.sections.map((section) => section.title)).toEqual(["Overview", "Synthesis", "Evidence"])
+      expect(artifact.sections.find((section) => section.title === "Synthesis")?.body).toContain("Event Deltas:")
       expect(artifact.citations.map((item) => item.citation)).toEqual(["E1", "E2"])
       expect(artifact.nextActions).toContain("Run the next task: Map consensus and management setup.")
       expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.research.artifact")).toBe(true)
@@ -100,6 +125,7 @@ describe("investing research artifacts", () => {
       const plan = createInvestingResearchPlan({
         objective: "Prepare a pre-earnings preview for NVDA",
       })
+      await seedEventDelta("NVDA")
       updateInvestingResearchTask({
         planId: plan.id,
         taskId: "coverage-check",
@@ -150,6 +176,7 @@ describe("investing research artifacts", () => {
       const plan = createInvestingResearchPlan({
         objective: "Prepare a pre-earnings preview for NVDA",
       })
+      await seedEventDelta("NVDA")
       updateInvestingResearchTask({
         planId: plan.id,
         taskId: "coverage-check",

--- a/packages/zee/test/investing/research-executor.test.ts
+++ b/packages/zee/test/investing/research-executor.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, spyOn, test } from "bun:test"
 import fs from "node:fs/promises"
 import { FluxRecorder } from "../../src/flux"
+import { normalizeInvestingConnectorEntities } from "../../src/investing/entities"
+import { classifyInvestingConnectorEvents, upsertInvestingEvents } from "../../src/investing/events"
 import { tmpdir } from "../fixture/fixture"
 import {
   createInvestingResearchPlan,
@@ -23,6 +25,27 @@ function makeToolContext() {
     abort: new AbortController().signal,
     metadata: () => {},
   }
+}
+
+async function seedEventDelta(symbol: string) {
+  const events = classifyInvestingConnectorEvents({
+    connector: "news",
+    entities: normalizeInvestingConnectorEntities({
+      connector: "news",
+      collectedAt: "2026-03-15T10:00:00.000Z",
+      data: [
+        {
+          symbol,
+          articleId: `${symbol.toLowerCase()}-guidance`,
+          publishedAt: "2026-03-15T09:30:00.000Z",
+          title: `${symbol} raises guidance after a strong quarter`,
+          summary: `Management raised guidance for ${symbol} after a strong quarter.`,
+          sector: "Technology",
+        },
+      ],
+    }),
+  })
+  await upsertInvestingEvents({ events })
 }
 
 async function withExecutorState<T>(fn: () => Promise<T>): Promise<T> {
@@ -72,6 +95,7 @@ describe("investing research executor", () => {
       const plan = createInvestingResearchPlan({
         objective: "Prepare a pre-earnings preview for NVDA",
       })
+      await seedEventDelta("NVDA")
       updateInvestingResearchTask({
         planId: plan.id,
         taskId: "coverage-check",
@@ -87,6 +111,8 @@ describe("investing research executor", () => {
       expect(execution.evidence[1]?.citation).toBe("E2")
       expect(execution.synthesis).toContain("[E1]")
       expect(execution.synthesis).toContain("[E2]")
+      expect(execution.synthesis).toContain("Event Deltas:")
+      expect(execution.synthesis).toContain("NVDA")
       expect(execution.synthesis).toContain("Source Used:")
       expect(execution.synthesis).toContain("Primary source: zee:invest-research")
       expect(execution.artifactId).toBeDefined()
@@ -135,6 +161,7 @@ describe("investing research executor", () => {
       const plan = createInvestingResearchPlan({
         objective: "Prepare a pre-earnings preview for NVDA",
       })
+      await seedEventDelta("NVDA")
       updateInvestingResearchTask({
         planId: plan.id,
         taskId: "coverage-check",

--- a/src/domain/investing/executor.ts
+++ b/src/domain/investing/executor.ts
@@ -11,6 +11,10 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { FluxRecorder } from "../../../packages/zee/src/flux";
 import {
+  buildInvestingEventDeltaBrief,
+  renderInvestingEventDeltaBrief,
+} from "../../../packages/zee/src/investing/briefing-deltas";
+import {
   appendInvestingProvenance,
   summarizeInvestingProvenance,
   type InvestingProvenanceSummary,
@@ -341,12 +345,12 @@ async function collectToolEvidence(input: {
   }
 }
 
-function buildSynthesis(input: {
+async function buildSynthesis(input: {
   plan: InvestingResearchPlan;
   task: InvestingResearchTask;
   evidence: InvestingResearchEvidence[];
   provenance: InvestingProvenanceSummary | null;
-}): string {
+}): Promise<string> {
   const evidenceLines =
     input.evidence.length > 0
       ? input.evidence
@@ -354,7 +358,7 @@ function buildSynthesis(input: {
           .join("\n")
       : "- No evidence items were collected."
 
-  const synthesis = [
+  const sections = [
     `${input.task.title}`,
     `Objective: ${input.plan.objective}`,
     `Workflow: ${input.plan.workflow}`,
@@ -362,7 +366,17 @@ function buildSynthesis(input: {
     "",
     "Evidence Links:",
     evidenceLines,
-  ].join("\n");
+  ];
+
+  if (input.plan.workflow === "earnings-preview" || input.plan.workflow === "earnings-review") {
+    const eventDeltaBrief = await buildInvestingEventDeltaBrief({
+      mode: input.plan.workflow === "earnings-preview" ? "pre-earnings" : "post-earnings",
+      symbols: input.plan.symbols,
+    });
+    sections.push("", renderInvestingEventDeltaBrief(eventDeltaBrief));
+  }
+
+  const synthesis = sections.join("\n");
 
   return input.provenance ? appendInvestingProvenance(synthesis, input.provenance) : synthesis;
 }
@@ -471,7 +485,7 @@ export async function runInvestingResearchExecution(
     status,
     startedAt,
     finishedAt,
-    synthesis: buildSynthesis({
+    synthesis: await buildSynthesis({
       plan,
       task,
       evidence,


### PR DESCRIPTION
## Summary
- add briefing-ready investing event delta generation and rendering for daily, pre-earnings, and post-earnings flows
- integrate event deltas into morning brief output and investing research synthesis artifacts
- document the event intelligence flow and cover it with delta, executor, and artifact tests

## Testing
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh

Closes #508
