### PR TITLE
feat(#509): add thesis ledger

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -204,6 +204,15 @@ rg "export class Memory|getMemory|getMemoryAsync" src/memory/unified.ts  # Unifi
 - **Daily brief integration:** `packages/zee/src/plugin/investing.ts:918`
 - **Operator doc:** `docs/architecture/investing-event-intelligence.md:1`
 
+### Feature: Investing Thesis Ledger
+**Purpose:** Persist canonical thesis records, sync valuation context, and append versioned thesis revisions from thesis-refresh workflows.
+- **Thesis draft + snapshot builder:** `src/domain/investing/thesis.ts:320`
+- **Record sync + revision store:** `src/domain/investing/thesis.ts:358`, `src/domain/investing/thesis.ts:409`
+- **Executor thesis-refresh integration:** `src/domain/investing/executor.ts:384`, `src/domain/investing/executor.ts:563`
+- **Valuation packet sync hook:** `src/domain/investing/valuation-packet.ts:280`
+- **CLI surface (`zee investing thesis status`):** `packages/zee/src/cli/cmd/investing.ts:320`
+- **Operator doc:** `docs/architecture/investing-thesis-ledger.md:1`
+
 ### Feature: Memory (Qdrant + Hybrid Search + Markdown Sync)
 **Purpose:** Store and retrieve semantic/keyword/hybrid memories with local Qdrant.
 - **Memory class:** `src/memory/unified.ts:352`

--- a/docs/architecture/investing-entity-schema.md
+++ b/docs/architecture/investing-entity-schema.md
@@ -15,7 +15,7 @@ The schema supports these entity kinds:
 - `risk`
 - `valuation_case`
 
-Current ingestion connectors emit `company`, `instrument`, `filing`, and `event`. The valuation kernel now also mints canonical `valuation_case` identifiers for downstream thesis linkage. The remaining kinds are reserved for later research-orchestration issues.
+Current ingestion connectors emit `company`, `instrument`, `filing`, and `event`. The valuation kernel now also mints canonical `valuation_case` identifiers for downstream thesis linkage, and the thesis ledger persists records keyed by the canonical `thesisKey`. `catalyst` and `risk` remain reserved for later research-orchestration issues.
 
 ## Identifier strategy
 

--- a/docs/architecture/investing-report-artifacts.md
+++ b/docs/architecture/investing-report-artifacts.md
@@ -32,6 +32,8 @@ Each artifact includes:
 
 For earnings-oriented workflows, the `Synthesis` section now carries the briefing-ready event delta block generated from scored event intelligence.
 
+For `thesis-refresh`, the generated artifact ID is also written into the thesis ledger so later revisions can trace back to the exact synthesized packet that produced the change log entry.
+
 Artifact kinds map to workflow phases:
 
 - `scope-note`

--- a/docs/architecture/investing-synthesis-executor.md
+++ b/docs/architecture/investing-synthesis-executor.md
@@ -8,7 +8,8 @@ This slice sits directly after the research planner:
 
 - planner: decide what should be done
 - executor: run the current task across relevant sources
-- later slices: richer analyst packets and thesis artifacts
+- thesis ledger: capture versioned thesis revisions from completed refreshes
+- later slices: richer thesis diff/query and portfolio views
 
 Persisted execution packets live at `~/.local/state/zee/investing/research-executions.json`.
 
@@ -35,8 +36,10 @@ When `run` is called, Zee:
 4. Assigns stable evidence citations such as `E1`, `E2`, and stable links such as `evidence:<executionId>:E1`.
 5. Produces a synthesis note that embeds those evidence links.
 6. For `earnings-preview` and `earnings-review`, appends the highest-signal scored event deltas for the symbol scope.
-7. Appends the standard investing provenance block.
-8. Persists the execution packet and advances the task in the planner.
+7. For `thesis-refresh`, appends a structured thesis snapshot derived from the latest valuation evidence.
+8. Appends the standard investing provenance block.
+9. Persists the execution packet and advances the task in the planner.
+10. After the execution artifact is written, records a new thesis revision for `thesis-refresh-brief`.
 
 If a task has no directly executable source tools, the executor reuses the latest evidence from dependency tasks so synthesis steps can still cite prior evidence.
 
@@ -89,6 +92,8 @@ The executor emits Flux events under `domain=investing`:
   - one event per evidence item with citation, source label, and summary
 
 For earnings-oriented workflows, the executor also consumes `investing.event.delta` telemetry emitted by the event-delta builder when it materializes briefing-ready deltas.
+
+For thesis-refresh workflows, the executor also triggers `investing.thesis.revision` once the versioned thesis change log is updated.
 
 The executor also relies on the planner's `investing.research.plan.task` telemetry when it marks a task `completed` or `blocked` after execution.
 

--- a/docs/architecture/investing-thesis-ledger.md
+++ b/docs/architecture/investing-thesis-ledger.md
@@ -1,0 +1,93 @@
+# Investing Thesis Ledger
+
+The thesis ledger persists one canonical thesis record per `thesisKey` and a versioned revision log that later diff, query, and portfolio workflows can build on.
+
+This slice closes `#509`.
+
+## Record contract
+
+State file:
+
+- `~/.local/state/zee/investing/theses.json`
+
+Each record stores:
+
+- `id`
+  - stable thesis key such as `thesis:nvda`
+- `symbol`
+  - normalized equity ticker
+- `status`
+  - current lifecycle state for the thesis record
+- `conviction`
+  - current conviction label carried across revisions
+- `posture`
+  - current directional posture (`bullish`, `neutral`, `bearish`)
+- `currentVersion`
+  - latest revision number for the thesis
+- `summary`
+  - operator-facing one-line thesis summary
+- `thesis`
+  - latest persisted thesis body
+- `watchpoints[]`
+  - next monitoring items that should trigger a refresh
+- `valuation`
+  - latest linked valuation case, packet, run, and signal metadata
+- `revisions[]`
+  - append-only change log for the thesis
+
+## Revision contract
+
+Each revision stores:
+
+- `version`
+  - monotonic revision number per thesis
+- `changeType`
+  - `initialize`, `refresh`, `valuation-sync`, or `operator-update`
+- `summary`
+  - concise statement of what changed
+- `thesis`
+  - full persisted thesis body at that revision
+- `conviction`
+  - conviction label at that revision
+- `posture`
+  - directional posture at that revision
+- `watchpoints[]`
+  - operator follow-up list captured for that revision
+- `valuation`
+  - linked valuation snapshot for later diffing
+- `evidence[]`
+  - references to persisted evidence or valuation packets
+- `source`
+  - workflow/task/execution/artifact pointers when the revision came from automation
+
+## Automatic updates
+
+Two flows now keep the ledger warm:
+
+- valuation packet creation syncs the base thesis record and latest valuation context from `thesisContext.thesisKey`
+- `thesis-refresh` synthesis execution appends a new revision after the execution artifact is created
+
+That gives the thesis lifecycle epic a stable handoff:
+
+- the thesis record already exists by the time a research refresh runs
+- the revision log already carries workflow, execution, artifact, and valuation references
+
+## Operator checks
+
+CLI:
+
+```bash
+zee investing thesis status
+zee investing thesis status --json
+```
+
+`zee investing thesis status` reports total theses, total revisions, and current counts by status and conviction.
+
+## Telemetry
+
+Flux events emitted for this slice:
+
+- `investing.thesis.record`
+  - emitted whenever a thesis record is created, updated, or advanced by a revision
+- `investing.thesis.revision`
+  - emitted whenever a new thesis revision is appended to the change log

--- a/docs/architecture/investing-valuation-provenance.md
+++ b/docs/architecture/investing-valuation-provenance.md
@@ -55,6 +55,11 @@ That is the forward-compatible handoff for the thesis lifecycle epic:
 - thesis systems can link a thesis record to a valuation case without re-deriving IDs
 - valuation signal changes can be diffed against later thesis revisions
 
+The thesis ledger now consumes that handoff directly:
+
+- valuation packet creation keeps the base thesis record warm
+- `thesisKey`, `valuationCaseId`, and the valuation signal are copied into the persisted thesis ledger for later refreshes
+
 ## Telemetry
 
 This slice emits:

--- a/packages/zee/src/cli/cmd/investing.ts
+++ b/packages/zee/src/cli/cmd/investing.ts
@@ -23,6 +23,7 @@ import {
   runInvestingConnector,
   type InvestingConnectorKind,
 } from "@/investing/ingestion"
+import { getInvestingThesisLedgerStatus } from "@root/domain/investing/thesis"
 
 const InvestingIngestStatusCommand = cmd({
   command: "status",
@@ -316,6 +317,36 @@ const InvestingEventCommand = cmd({
   async handler() {},
 })
 
+const InvestingThesisStatusCommand = cmd({
+  command: "status",
+  describe: "show persisted thesis ledger status",
+  builder: (yargs: Argv) =>
+    yargs.option("json", {
+      type: "boolean",
+      default: false,
+      describe: "output as JSON",
+    }),
+  handler: async (args: { json?: boolean }) => {
+    const status = getInvestingThesisLedgerStatus()
+    if (args.json) {
+      console.log(JSON.stringify(status, null, 2))
+      return
+    }
+
+    const updatedAt = status.updatedAt > 0 ? new Date(status.updatedAt).toISOString() : "never"
+    console.log(`theses: total=${status.totalTheses} revisions=${status.totalRevisions} updatedAt=${updatedAt}`)
+    console.log(`- by status: ${JSON.stringify(status.countsByStatus)}`)
+    console.log(`- by conviction: ${JSON.stringify(status.countsByConviction)}`)
+  },
+})
+
+const InvestingThesisCommand = cmd({
+  command: "thesis",
+  describe: "persisted thesis ledger and version history",
+  builder: (yargs: Argv) => yargs.command(InvestingThesisStatusCommand).demandCommand(),
+  async handler() {},
+})
+
 const InvestingIngestScheduleCommand = cmd({
   command: "schedule",
   describe: "register connector schedules in the current always-on process",
@@ -358,6 +389,11 @@ export const InvestingCommand = cmd({
   command: "investing",
   describe: "investing platform operations",
   builder: (yargs: Argv) =>
-    yargs.command(InvestingIngestCommand).command(InvestingEntityCommand).command(InvestingEventCommand).demandCommand(),
+    yargs
+      .command(InvestingIngestCommand)
+      .command(InvestingEntityCommand)
+      .command(InvestingEventCommand)
+      .command(InvestingThesisCommand)
+      .demandCommand(),
   async handler() {},
 })

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -66,6 +66,8 @@ export type FluxKind =
   | "investing.valuation.sensitivity"
   | "investing.valuation.packet"
   | "investing.valuation.packet.export"
+  | "investing.thesis.record"
+  | "investing.thesis.revision"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"
   | "provider.fallback.used"

--- a/packages/zee/test/investing/thesis-ledger.test.ts
+++ b/packages/zee/test/investing/thesis-ledger.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import { FluxRecorder } from "../../src/flux"
+import { tmpdir } from "../fixture/fixture"
+import {
+  getInvestingThesis,
+  getInvestingThesisLedgerStatus,
+  getInvestingThesisStateFile,
+  recordInvestingThesisRevision,
+  syncInvestingThesisContext,
+  thesisKeyForSymbol,
+} from "../../../../src/domain/investing/thesis"
+import { createInvestingResearchPlan, updateInvestingResearchTask } from "../../../../src/domain/investing/planner"
+import { runInvestingResearchExecution } from "../../../../src/domain/investing/executor"
+
+async function withThesisState<T>(fn: () => Promise<T>): Promise<T> {
+  await using dir = await tmpdir()
+  const originalStateHome = process.env.XDG_STATE_HOME
+  const originalFetch = globalThis.fetch
+  process.env.XDG_STATE_HOME = dir.path
+  try {
+    return await fn()
+  } finally {
+    globalThis.fetch = originalFetch
+    if (originalStateHome === undefined) {
+      delete process.env.XDG_STATE_HOME
+    } else {
+      process.env.XDG_STATE_HOME = originalStateHome
+    }
+  }
+}
+
+describe("investing thesis ledger", () => {
+  test("syncs valuation context and appends versioned thesis revisions", async () => {
+    await withThesisState(async () => {
+      const recordSpy = spyOn(FluxRecorder, "record")
+      const thesisKey = thesisKeyForSymbol("NVDA")
+
+      const initial = syncInvestingThesisContext({
+        thesisKey,
+        symbol: "NVDA",
+        summary: "Initial valuation sync for NVDA.",
+        valuation: {
+          valuationCaseId: "valuation_case:equity:nvda:base",
+          packetId: "valuation-packet-1",
+          runId: "valuation-run-1",
+          signal: "re-rate-up",
+          fairValue: 140,
+          currentPrice: 100,
+          upsidePercent: 40,
+        },
+      })
+
+      expect(initial.currentVersion).toBe(0)
+      expect(initial.posture).toBe("bullish")
+      expect(initial.valuation?.packetId).toBe("valuation-packet-1")
+
+      recordInvestingThesisRevision({
+        thesisKey,
+        symbol: "NVDA",
+        changeType: "initialize",
+        summary: "NVDA thesis remains bullish after refreshed valuation.",
+        thesis: "Demand remains strong and valuation still supports upside.",
+        conviction: "high",
+        posture: "bullish",
+        watchpoints: ["Track whether revenue growth sustains the current upside case."],
+        valuation: {
+          valuationCaseId: "valuation_case:equity:nvda:base",
+          packetId: "valuation-packet-1",
+          runId: "valuation-run-1",
+          signal: "re-rate-up",
+          fairValue: 140,
+          currentPrice: 100,
+          upsidePercent: 40,
+        },
+      })
+
+      const updated = recordInvestingThesisRevision({
+        thesisKey,
+        symbol: "NVDA",
+        changeType: "refresh",
+        summary: "NVDA thesis moved back to a neutral stance after estimate volatility.",
+        thesis: "The setup is intact, but the margin of safety is narrower than the prior refresh.",
+        conviction: "medium",
+        posture: "neutral",
+        watchpoints: ["Monitor estimate volatility before increasing exposure."],
+        valuation: {
+          valuationCaseId: "valuation_case:equity:nvda:refresh",
+          packetId: "valuation-packet-2",
+          runId: "valuation-run-2",
+          signal: "balanced",
+          fairValue: 112,
+          currentPrice: 105,
+          upsidePercent: 6.7,
+        },
+      })
+
+      expect(updated.currentVersion).toBe(2)
+      expect(updated.latestRevisionId).toBeDefined()
+      expect(updated.conviction).toBe("medium")
+      expect(updated.posture).toBe("neutral")
+      expect(updated.revisions).toHaveLength(2)
+      expect(updated.revisions[0]?.version).toBe(2)
+      expect(updated.revisions[1]?.version).toBe(1)
+      expect(getInvestingThesis(thesisKey)?.valuation?.valuationCaseId).toBe("valuation_case:equity:nvda:refresh")
+
+      const status = getInvestingThesisLedgerStatus()
+      expect(status.totalTheses).toBe(1)
+      expect(status.totalRevisions).toBe(2)
+      expect(status.countsByConviction.medium).toBe(1)
+      expect(await Bun.file(getInvestingThesisStateFile()).exists()).toBe(true)
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.thesis.record")).toBe(true)
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.thesis.revision")).toBe(true)
+    })
+  })
+
+  test("records a thesis revision from thesis-refresh execution output", async () => {
+    await withThesisState(async () => {
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.endsWith("/api/accounting/NVDA/filings")) {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              data: [{ form: "10-K", filedAt: "2026-02-20" }],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        if (url.endsWith("/api/research/NVDA")) {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              data: { symbol: "NVDA", summary: "AI demand remains strong." },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        if (url.endsWith("/api/valuation/NVDA?include_dcf=true")) {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              data: {
+                symbol: "NVDA",
+                fairValue: 140,
+                currentPrice: 100,
+                upsidePercent: 40,
+                assumptions: { revenueGrowth: 0.18 },
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        if (url.endsWith("/api/research/NVDA/dcf")) {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              data: {
+                symbol: "NVDA",
+                dcf: { intrinsicValue: 150, currentPrice: 100, upsidePercentage: 50 },
+                assumptions: { discountRate: 0.1, terminalGrowth: 0.03 },
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        if (url.includes("/api/peers/NVDA")) {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              data: {
+                fairValueRange: { low: 90, high: 130 },
+                target: { currentPrice: 100 },
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        if (url.endsWith("/api/market/NVDA")) {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              data: { symbol: "NVDA", price: 100, marketCap: 1_000_000_000 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        if (url.endsWith("/api/valuation/NVDA")) {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              data: { symbol: "NVDA", fairValue: 140, currentPrice: 100, upsidePercent: 40 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        }
+        throw new Error(`Unexpected URL ${url}`)
+      }) as typeof fetch
+
+      const plan = createInvestingResearchPlan({
+        objective: "Refresh the thesis on NVDA",
+      })
+      updateInvestingResearchTask({ planId: plan.id, taskId: "coverage-check", status: "completed" })
+      updateInvestingResearchTask({ planId: plan.id, taskId: "source-refresh", status: "completed" })
+      updateInvestingResearchTask({ planId: plan.id, taskId: "thesis-delta", status: "completed" })
+
+      const valuationExecution = await runInvestingResearchExecution({ planId: plan.id })
+      expect(valuationExecution.taskId).toBe("valuation-check")
+
+      const thesisExecution = await runInvestingResearchExecution({ planId: plan.id })
+      expect(thesisExecution.taskId).toBe("thesis-refresh-brief")
+      expect(thesisExecution.synthesis).toContain("Thesis Snapshot:")
+
+      const thesis = getInvestingThesis(thesisKeyForSymbol("NVDA"))
+      expect(thesis?.currentVersion).toBe(1)
+      expect(thesis?.summary).toContain("NVDA thesis")
+      expect(thesis?.valuation?.valuationCaseId).toContain("valuation_case:equity:nvda:")
+      expect(thesis?.revisions[0]?.source.executionId).toBe(thesisExecution.id)
+      expect(thesis?.revisions[0]?.source.artifactId).toBe(thesisExecution.artifactId)
+      expect(thesis?.revisions[0]?.evidence.some((item) => item.kind === "valuation-packet")).toBe(true)
+    })
+  })
+})

--- a/packages/zee/test/investing/valuation-kernel.test.ts
+++ b/packages/zee/test/investing/valuation-kernel.test.ts
@@ -107,11 +107,21 @@ describe("investing valuation kernel", () => {
       expect(run.thesisContext.thesisKey).toBe("thesis:nvda")
       expect(getInvestingValuationKernel(run.id)?.id).toBe(run.id)
       expect(getInvestingValuationPacket(run.packetId!)?.runId).toBe(run.id)
-      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.valuation.kernel")).toBe(true)
-      expect(recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.valuation.method")).toHaveLength(3)
-      expect(recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.valuation.scenario")).toHaveLength(3)
-      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.valuation.assumption")).toBe(true)
-      expect(recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.valuation.sensitivity")).toHaveLength(3)
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.valuation.kernel" && call[0]?.traceID === run.id)).toBe(
+        true,
+      )
+      expect(
+        recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.valuation.method" && call[0]?.traceID === run.id),
+      ).toHaveLength(3)
+      expect(
+        recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.valuation.scenario" && call[0]?.traceID === run.id),
+      ).toHaveLength(3)
+      expect(
+        recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.valuation.assumption" && call[0]?.traceID === run.id),
+      ).toBe(true)
+      expect(
+        recordSpy.mock.calls.filter((call) => call[0]?.kind === "investing.valuation.sensitivity" && call[0]?.traceID === run.id),
+      ).toHaveLength(3)
       expect(await Bun.file(getInvestingValuationKernelStateFile()).exists()).toBe(true)
     })
   })

--- a/src/domain/investing/executor.ts
+++ b/src/domain/investing/executor.ts
@@ -23,6 +23,11 @@ import {
 import { Log } from "../../../packages/zee/src/util/log";
 import { Investing } from "../../paths";
 import { createInvestingResearchArtifact } from "./artifacts";
+import {
+  buildInvestingThesisDraft,
+  recordInvestingThesisRevisionFromExecution,
+  renderInvestingThesisSnapshot,
+} from "./thesis";
 import { runInvestingValuationKernel } from "./valuation";
 import {
   getInvestingResearchPlan,
@@ -376,6 +381,17 @@ async function buildSynthesis(input: {
     sections.push("", renderInvestingEventDeltaBrief(eventDeltaBrief));
   }
 
+  if (input.plan.workflow === "thesis-refresh") {
+    const primarySymbol = normalizeSymbol(input.plan.symbols[0]);
+    if (primarySymbol) {
+      const thesisDraft = buildInvestingThesisDraft({
+        symbol: primarySymbol,
+        evidence: input.evidence,
+      });
+      sections.push("", renderInvestingThesisSnapshot(thesisDraft));
+    }
+  }
+
   const synthesis = sections.join("\n");
 
   return input.provenance ? appendInvestingProvenance(synthesis, input.provenance) : synthesis;
@@ -542,6 +558,21 @@ export async function runInvestingResearchExecution(
       executionId: execution.id,
       error: error instanceof Error ? error.message : String(error),
     });
+  }
+
+  if (execution.status === "ok" && updatedPlan.workflow === "thesis-refresh" && updatedTask.id === "thesis-refresh-brief") {
+    try {
+      recordInvestingThesisRevisionFromExecution({
+        plan: updatedPlan,
+        task: updatedTask,
+        execution,
+      });
+    } catch (error) {
+      log.warn("failed to record thesis revision", {
+        executionId: execution.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   return execution;

--- a/src/domain/investing/thesis.ts
+++ b/src/domain/investing/thesis.ts
@@ -1,0 +1,613 @@
+/**
+ * Investing Thesis Ledger
+ *
+ * Persists thesis records, valuation-linked context, and a versioned revision
+ * log so later operator and portfolio flows can diff thesis state safely.
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { FluxRecorder } from "../../../packages/zee/src/flux";
+import { Log } from "../../../packages/zee/src/util/log";
+import type { InvestingValuationThesisContext } from "./valuation";
+
+const log = Log.create({ service: "investing:thesis" });
+
+export const INVESTING_THESIS_RECORD_STATUSES = ["active", "invalidated", "archived"] as const;
+export type InvestingThesisRecordStatus = (typeof INVESTING_THESIS_RECORD_STATUSES)[number];
+
+export const INVESTING_THESIS_CONVICTIONS = ["low", "medium", "high"] as const;
+export type InvestingThesisConviction = (typeof INVESTING_THESIS_CONVICTIONS)[number];
+
+export const INVESTING_THESIS_POSTURES = ["bullish", "neutral", "bearish"] as const;
+export type InvestingThesisPosture = (typeof INVESTING_THESIS_POSTURES)[number];
+
+export const INVESTING_THESIS_CHANGE_TYPES = ["initialize", "refresh", "valuation-sync", "operator-update"] as const;
+export type InvestingThesisChangeType = (typeof INVESTING_THESIS_CHANGE_TYPES)[number];
+
+export interface InvestingThesisValuationSnapshot {
+  valuationCaseId?: string;
+  packetId?: string;
+  runId?: string;
+  signal?: InvestingValuationThesisContext["signal"];
+  fairValue?: number | null;
+  currentPrice?: number | null;
+  upsidePercent?: number | null;
+}
+
+export interface InvestingThesisEvidenceReference {
+  kind: "research-evidence" | "valuation-packet";
+  id: string;
+  label: string;
+  link?: string;
+}
+
+export interface InvestingThesisRevision {
+  id: string;
+  version: number;
+  changeType: InvestingThesisChangeType;
+  createdAt: string;
+  summary: string;
+  thesis: string;
+  conviction: InvestingThesisConviction;
+  posture: InvestingThesisPosture;
+  watchpoints: string[];
+  valuation: InvestingThesisValuationSnapshot | null;
+  evidence: InvestingThesisEvidenceReference[];
+  source: {
+    workflow?: string;
+    planId?: string;
+    taskId?: string;
+    executionId?: string;
+    artifactId?: string;
+  };
+}
+
+export interface InvestingThesisRecord {
+  id: string;
+  schemaVersion: "investing-thesis.v1";
+  symbol: string;
+  createdAt: string;
+  updatedAt: string;
+  status: InvestingThesisRecordStatus;
+  conviction: InvestingThesisConviction;
+  posture: InvestingThesisPosture;
+  currentVersion: number;
+  latestRevisionId?: string;
+  summary: string;
+  thesis: string;
+  watchpoints: string[];
+  valuation: InvestingThesisValuationSnapshot | null;
+  revisions: InvestingThesisRevision[];
+}
+
+type ThesisState = {
+  version: 1;
+  updatedAt: number;
+  records: InvestingThesisRecord[];
+};
+
+export type InvestingThesisLedgerStatus = {
+  version: 1;
+  updatedAt: number;
+  totalTheses: number;
+  totalRevisions: number;
+  countsByStatus: Record<InvestingThesisRecordStatus, number>;
+  countsByConviction: Record<InvestingThesisConviction, number>;
+};
+
+type SyncInvestingThesisContextInput = {
+  thesisKey: string;
+  symbol: string;
+  summary: string;
+  status?: InvestingThesisRecordStatus;
+  conviction?: InvestingThesisConviction;
+  posture?: InvestingThesisPosture;
+  valuation?: InvestingThesisValuationSnapshot | null;
+};
+
+type RecordInvestingThesisRevisionInput = {
+  thesisKey: string;
+  symbol: string;
+  changeType: InvestingThesisChangeType;
+  summary: string;
+  thesis: string;
+  status?: InvestingThesisRecordStatus;
+  conviction?: InvestingThesisConviction;
+  posture?: InvestingThesisPosture;
+  watchpoints?: string[];
+  valuation?: InvestingThesisValuationSnapshot | null;
+  evidence?: InvestingThesisEvidenceReference[];
+  source?: InvestingThesisRevision["source"];
+};
+
+type ThesisExecutionEvidence = {
+  id: string;
+  citation: string;
+  link: string;
+  toolId: string;
+  sourceLabel: string;
+  status: "completed" | "error";
+  data?: unknown;
+};
+
+type RecordInvestingThesisRevisionFromExecutionInput = {
+  plan: {
+    id: string;
+    workflow: string;
+    objective: string;
+    symbols: string[];
+  };
+  task: {
+    id: string;
+    title: string;
+  };
+  execution: {
+    id: string;
+    synthesis: string;
+    artifactId?: string;
+    evidence: ThesisExecutionEvidence[];
+  };
+};
+
+export interface InvestingThesisDraft {
+  thesisKey: string;
+  symbol: string;
+  summary: string;
+  conviction: InvestingThesisConviction;
+  posture: InvestingThesisPosture;
+  watchpoints: string[];
+  valuation: InvestingThesisValuationSnapshot | null;
+}
+
+function getThesisStateDir(): string {
+  const stateDir = process.env.XDG_STATE_HOME
+    ? path.join(process.env.XDG_STATE_HOME, "zee")
+    : path.join(os.homedir(), ".local", "state", "zee");
+  return path.join(stateDir, "investing");
+}
+
+export function getInvestingThesisStateFile(): string {
+  return path.join(getThesisStateDir(), "theses.json");
+}
+
+function ensureThesisStateDir(): void {
+  mkdirSync(getThesisStateDir(), { recursive: true });
+}
+
+function readThesisState(): ThesisState {
+  const filePath = getInvestingThesisStateFile();
+  if (!existsSync(filePath)) {
+    return { version: 1, updatedAt: 0, records: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as Partial<ThesisState>;
+    return {
+      version: 1,
+      updatedAt: Number(parsed.updatedAt ?? 0),
+      records: Array.isArray(parsed.records) ? parsed.records : [],
+    };
+  } catch (error) {
+    log.warn("failed to read thesis state", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { version: 1, updatedAt: 0, records: [] };
+  }
+}
+
+function writeThesisState(state: ThesisState): void {
+  ensureThesisStateDir();
+  state.updatedAt = Date.now();
+  writeFileSync(getInvestingThesisStateFile(), JSON.stringify(state, null, 2) + "\n", "utf-8");
+}
+
+function normalizeSymbol(symbol: string): string {
+  return symbol.trim().toUpperCase();
+}
+
+export function thesisKeyForSymbol(symbol: string): string {
+  return `thesis:${normalizeSymbol(symbol).toLowerCase()}`;
+}
+
+function withDefaultCounts<const T extends readonly string[]>(items: T): Record<T[number], number> {
+  return Object.fromEntries(items.map((item) => [item, 0])) as Record<T[number], number>;
+}
+
+function finiteNumberOrNull(value: unknown): number | null | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return value;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asSignal(value: unknown): InvestingValuationThesisContext["signal"] | undefined {
+  return value === "re-rate-up" || value === "re-rate-down" || value === "balanced" ? value : undefined;
+}
+
+function postureFromSignal(signal?: InvestingValuationThesisContext["signal"]): InvestingThesisPosture {
+  switch (signal) {
+    case "re-rate-up":
+      return "bullish";
+    case "re-rate-down":
+      return "bearish";
+    default:
+      return "neutral";
+  }
+}
+
+function defaultWatchpoints(symbol: string, valuation: InvestingThesisValuationSnapshot | null): string[] {
+  if (valuation?.upsidePercent != null && valuation.upsidePercent >= 15) {
+    return [
+      `Validate that ${symbol} can sustain the upside implied by the current valuation case.`,
+      `Monitor estimate revisions and news flow for any break in the upside path.`,
+    ];
+  }
+  if (valuation?.upsidePercent != null && valuation.upsidePercent <= -15) {
+    return [
+      `Check whether the downside implied for ${symbol} is already reflected in current positioning.`,
+      `Monitor for estimate cuts, guidance resets, or event-driven deterioration that confirms the bear case.`,
+    ];
+  }
+  return [
+    `Refresh the ${symbol} thesis when new filings, event deltas, or valuation inputs materially change the setup.`,
+    `Monitor the next evidence refresh for a directional break in the current neutral posture.`,
+  ];
+}
+
+function buildEmptyRecord(input: {
+  thesisKey: string;
+  symbol: string;
+  summary: string;
+  conviction?: InvestingThesisConviction;
+  posture?: InvestingThesisPosture;
+  status?: InvestingThesisRecordStatus;
+  valuation?: InvestingThesisValuationSnapshot | null;
+}): InvestingThesisRecord {
+  const createdAt = new Date().toISOString();
+  return {
+    id: input.thesisKey,
+    schemaVersion: "investing-thesis.v1",
+    symbol: normalizeSymbol(input.symbol),
+    createdAt,
+    updatedAt: createdAt,
+    status: input.status ?? "active",
+    conviction: input.conviction ?? "medium",
+    posture: input.posture ?? postureFromSignal(input.valuation?.signal),
+    currentVersion: 0,
+    summary: input.summary,
+    thesis: input.summary,
+    watchpoints: defaultWatchpoints(input.symbol, input.valuation ?? null),
+    valuation: input.valuation ?? null,
+    revisions: [],
+  };
+}
+
+function valuationSnapshotFromEvidence(evidence: ThesisExecutionEvidence[]): InvestingThesisValuationSnapshot | null {
+  for (const item of evidence) {
+    if (item.toolId !== "zee:invest-valuation" || item.status !== "completed") continue;
+    const data = asRecord(item.data);
+    if (!data) continue;
+    const thesisContext = asRecord(data.thesisContext);
+    return {
+      valuationCaseId: typeof data.valuationCaseId === "string" ? data.valuationCaseId : undefined,
+      packetId: typeof data.packetId === "string" ? data.packetId : undefined,
+      runId: typeof data.id === "string" ? data.id : undefined,
+      signal: asSignal(thesisContext?.signal),
+      fairValue: finiteNumberOrNull(data.blendedFairValue),
+      currentPrice: finiteNumberOrNull(data.currentPrice),
+      upsidePercent: finiteNumberOrNull(data.upsidePercent),
+    };
+  }
+  return null;
+}
+
+function persistRecord(state: ThesisState, record: InvestingThesisRecord): InvestingThesisRecord {
+  record.updatedAt = new Date().toISOString();
+  state.records = [record, ...state.records.filter((entry) => entry.id !== record.id)].sort((a, b) =>
+    b.updatedAt.localeCompare(a.updatedAt),
+  );
+  writeThesisState(state);
+  return record;
+}
+
+export function buildInvestingThesisDraft(input: {
+  symbol: string;
+  thesisKey?: string;
+  conviction?: InvestingThesisConviction;
+  evidence: ThesisExecutionEvidence[];
+}): InvestingThesisDraft {
+  const symbol = normalizeSymbol(input.symbol);
+  const valuation = valuationSnapshotFromEvidence(input.evidence);
+  const posture = postureFromSignal(valuation?.signal);
+  const conviction = input.conviction ?? "medium";
+
+  const summary = valuation?.signal
+    ? `${symbol} thesis remains ${posture} with ${valuation.signal} valuation signal.`
+    : `${symbol} thesis refresh captured updated research evidence and monitoring changes.`;
+
+  return {
+    thesisKey: input.thesisKey ?? thesisKeyForSymbol(symbol),
+    symbol,
+    summary,
+    conviction,
+    posture,
+    watchpoints: defaultWatchpoints(symbol, valuation),
+    valuation,
+  };
+}
+
+export function renderInvestingThesisSnapshot(draft: InvestingThesisDraft): string {
+  return [
+    "Thesis Snapshot:",
+    `- thesisKey=${draft.thesisKey}`,
+    `- posture=${draft.posture}`,
+    `- conviction=${draft.conviction}`,
+    `- valuationSignal=${draft.valuation?.signal ?? "n/a"}`,
+    `- valuationCaseId=${draft.valuation?.valuationCaseId ?? "n/a"}`,
+    `- watchpoints=${draft.watchpoints.join("; ") || "n/a"}`,
+  ].join("\n");
+}
+
+export function syncInvestingThesisContext(input: SyncInvestingThesisContextInput): InvestingThesisRecord {
+  const state = readThesisState();
+  const existing = state.records.find((record) => record.id === input.thesisKey);
+  const record = existing
+    ? {
+        ...existing,
+        symbol: normalizeSymbol(input.symbol),
+        status: input.status ?? existing.status,
+        conviction: input.conviction ?? existing.conviction,
+        posture: input.posture ?? existing.posture ?? postureFromSignal(input.valuation?.signal),
+        summary: existing.currentVersion > 0 ? existing.summary : input.summary,
+        thesis: existing.currentVersion > 0 ? existing.thesis : input.summary,
+        watchpoints:
+          existing.currentVersion > 0
+            ? existing.watchpoints
+            : defaultWatchpoints(input.symbol, input.valuation ?? existing.valuation ?? null),
+        valuation: input.valuation ?? existing.valuation,
+      }
+    : buildEmptyRecord({
+        thesisKey: input.thesisKey,
+        symbol: input.symbol,
+        summary: input.summary,
+        conviction: input.conviction,
+        posture: input.posture,
+        status: input.status,
+        valuation: input.valuation,
+      });
+
+  persistRecord(state, record);
+
+  FluxRecorder.record({
+    traceID: record.id,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.thesis.record",
+    status: "ok",
+    method: existing ? "update" : "create",
+    path: record.symbol,
+    route: record.id,
+    metadata: {
+      schemaVersion: record.schemaVersion,
+      currentVersion: record.currentVersion,
+      conviction: record.conviction,
+      posture: record.posture,
+      valuationCaseId: record.valuation?.valuationCaseId,
+    },
+  });
+
+  return record;
+}
+
+export function recordInvestingThesisRevision(input: RecordInvestingThesisRevisionInput): InvestingThesisRecord {
+  const state = readThesisState();
+  const existing = state.records.find((record) => record.id === input.thesisKey);
+  const base =
+    existing ??
+    buildEmptyRecord({
+      thesisKey: input.thesisKey,
+      symbol: input.symbol,
+      summary: input.summary,
+      conviction: input.conviction,
+      posture: input.posture,
+      status: input.status,
+      valuation: input.valuation,
+    });
+
+  const version = base.currentVersion + 1;
+  const revision: InvestingThesisRevision = {
+    id: `thesis-revision-${randomUUID().slice(0, 12)}`,
+    version,
+    changeType: input.changeType,
+    createdAt: new Date().toISOString(),
+    summary: input.summary,
+    thesis: input.thesis,
+    conviction: input.conviction ?? base.conviction,
+    posture: input.posture ?? base.posture,
+    watchpoints: input.watchpoints ?? base.watchpoints,
+    valuation: input.valuation ?? base.valuation,
+    evidence: input.evidence ?? [],
+    source: input.source ?? {},
+  };
+
+  const record: InvestingThesisRecord = {
+    ...base,
+    symbol: normalizeSymbol(input.symbol),
+    status: input.status ?? base.status,
+    conviction: revision.conviction,
+    posture: revision.posture,
+    currentVersion: version,
+    latestRevisionId: revision.id,
+    summary: revision.summary,
+    thesis: revision.thesis,
+    watchpoints: revision.watchpoints,
+    valuation: revision.valuation,
+    revisions: [...base.revisions.filter((entry) => entry.id !== revision.id), revision].sort((a, b) => b.version - a.version),
+  };
+
+  persistRecord(state, record);
+
+  FluxRecorder.record({
+    traceID: revision.id,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.thesis.revision",
+    status: "ok",
+    method: input.changeType,
+    path: record.symbol,
+    route: record.id,
+    metadata: {
+      version: revision.version,
+      conviction: revision.conviction,
+      posture: revision.posture,
+      workflow: revision.source.workflow,
+      planId: revision.source.planId,
+      taskId: revision.source.taskId,
+      executionId: revision.source.executionId,
+      artifactId: revision.source.artifactId,
+      valuationCaseId: revision.valuation?.valuationCaseId,
+      evidenceCount: revision.evidence.length,
+    },
+  });
+
+  FluxRecorder.record({
+    traceID: record.id,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.thesis.record",
+    status: "ok",
+    method: "revision",
+    path: record.symbol,
+    route: record.id,
+    metadata: {
+      currentVersion: record.currentVersion,
+      conviction: record.conviction,
+      posture: record.posture,
+      latestRevisionId: record.latestRevisionId,
+      valuationCaseId: record.valuation?.valuationCaseId,
+    },
+  });
+
+  return record;
+}
+
+export function recordInvestingThesisRevisionFromExecution(
+  input: RecordInvestingThesisRevisionFromExecutionInput,
+): InvestingThesisRecord {
+  const symbol = normalizeSymbol(input.plan.symbols[0] ?? "");
+  if (!symbol) {
+    throw new Error("A symbol is required to record a thesis revision.");
+  }
+
+  const thesisKey = thesisKeyForSymbol(symbol);
+  const existing = getInvestingThesis(thesisKey);
+  const draft = buildInvestingThesisDraft({
+    symbol,
+    thesisKey,
+    conviction: existing?.conviction,
+    evidence: input.execution.evidence,
+  });
+
+  const evidence = input.execution.evidence
+    .filter((item) => item.status === "completed")
+    .map<InvestingThesisEvidenceReference>((item) => ({
+      kind: "research-evidence",
+      id: item.id,
+      label: `[${item.citation}] ${item.sourceLabel}`,
+      link: item.link,
+    }));
+
+  if (draft.valuation?.packetId) {
+    evidence.push({
+      kind: "valuation-packet",
+      id: draft.valuation.packetId,
+      label: `Valuation packet for ${symbol}`,
+      link: `valuation-packet:${draft.valuation.packetId}`,
+    });
+  }
+
+  const thesis = [
+    draft.summary,
+    "",
+    `Objective: ${input.plan.objective}`,
+    `Workflow: ${input.plan.workflow}`,
+    `Task: ${input.task.title}`,
+    `Posture: ${draft.posture}`,
+    `Conviction: ${draft.conviction}`,
+    `Valuation case: ${draft.valuation?.valuationCaseId ?? "n/a"}`,
+    `Valuation signal: ${draft.valuation?.signal ?? "n/a"}`,
+    "",
+    "Watchpoints:",
+    ...(draft.watchpoints.length > 0 ? draft.watchpoints.map((item) => `- ${item}`) : ["- none"]),
+    "",
+    "Execution Synthesis:",
+    input.execution.synthesis,
+  ].join("\n");
+
+  return recordInvestingThesisRevision({
+    thesisKey,
+    symbol,
+    changeType: existing ? "refresh" : "initialize",
+    summary: draft.summary,
+    thesis,
+    conviction: draft.conviction,
+    posture: draft.posture,
+    watchpoints: draft.watchpoints,
+    valuation: draft.valuation,
+    evidence,
+    source: {
+      workflow: input.plan.workflow,
+      planId: input.plan.id,
+      taskId: input.task.id,
+      executionId: input.execution.id,
+      artifactId: input.execution.artifactId,
+    },
+  });
+}
+
+export function getInvestingThesis(thesisKey: string): InvestingThesisRecord | null {
+  const state = readThesisState();
+  return state.records.find((record) => record.id === thesisKey) ?? null;
+}
+
+export function listInvestingTheses(options?: {
+  symbol?: string;
+  status?: InvestingThesisRecordStatus;
+  limit?: number;
+}): InvestingThesisRecord[] {
+  const normalizedSymbol = options?.symbol ? normalizeSymbol(options.symbol) : undefined;
+  const state = readThesisState();
+  return state.records
+    .filter((record) => (normalizedSymbol ? record.symbol === normalizedSymbol : true))
+    .filter((record) => (options?.status ? record.status === options.status : true))
+    .slice(0, options?.limit ?? 20);
+}
+
+export function getInvestingThesisLedgerStatus(): InvestingThesisLedgerStatus {
+  const state = readThesisState();
+  const countsByStatus = withDefaultCounts(INVESTING_THESIS_RECORD_STATUSES);
+  const countsByConviction = withDefaultCounts(INVESTING_THESIS_CONVICTIONS);
+  let totalRevisions = 0;
+
+  for (const record of state.records) {
+    countsByStatus[record.status] += 1;
+    countsByConviction[record.conviction] += 1;
+    totalRevisions += record.revisions.length;
+  }
+
+  return {
+    version: 1,
+    updatedAt: state.updatedAt,
+    totalTheses: state.records.length,
+    totalRevisions,
+    countsByStatus,
+    countsByConviction,
+  };
+}

--- a/src/domain/investing/valuation-packet.ts
+++ b/src/domain/investing/valuation-packet.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import { FluxRecorder } from "../../../packages/zee/src/flux";
 import { Log } from "../../../packages/zee/src/util/log";
 import { Investing } from "../../paths";
+import { syncInvestingThesisContext } from "./thesis";
 import type {
   InvestingValuationKernelRun,
   InvestingValuationMethodResult,
@@ -274,6 +275,28 @@ export function createInvestingValuationPacket(
       schemaVersion: packet.schemaVersion,
     },
   });
+
+  try {
+    syncInvestingThesisContext({
+      thesisKey: packet.thesisContext.thesisKey,
+      symbol: packet.symbol,
+      summary: packet.summary,
+      valuation: {
+        valuationCaseId: packet.valuationCaseId,
+        packetId: packet.id,
+        runId: packet.runId,
+        signal: packet.thesisContext.signal,
+        fairValue: packet.verdict.fairValue,
+        currentPrice: packet.verdict.currentPrice,
+        upsidePercent: packet.verdict.upsidePercent,
+      },
+    });
+  } catch (error) {
+    log.warn("failed to sync thesis context from valuation packet", {
+      packetId: packet.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   return packet;
 }


### PR DESCRIPTION
## Summary
- add a persisted investing thesis ledger with canonical thesis records, valuation-linked context, and versioned revisions
- sync thesis records from valuation packets and append thesis-refresh revisions after research execution artifacts are created
- document the operator model, add `zee investing thesis status`, and cover the ledger with thesis, executor, and valuation tests

## Testing
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- cd packages/zee && bun test test/investing/thesis-ledger.test.ts test/investing/research-executor.test.ts test/investing/valuation-kernel.test.ts test/investing/valuation-packet.test.ts
- cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh
- zee investing thesis status --json

Closes #509
