### PR TITLE
feat(#510): enforce thesis confidence rules

### DIFF
--- a/atris/MAP.md
+++ b/atris/MAP.md
@@ -206,12 +206,13 @@ rg "export class Memory|getMemory|getMemoryAsync" src/memory/unified.ts  # Unifi
 
 ### Feature: Investing Thesis Ledger
 **Purpose:** Persist canonical thesis records, sync valuation context, and append versioned thesis revisions from thesis-refresh workflows.
-- **Thesis draft + snapshot builder:** `src/domain/investing/thesis.ts:320`
-- **Record sync + revision store:** `src/domain/investing/thesis.ts:358`, `src/domain/investing/thesis.ts:409`
+- **Confidence rule + thesis draft builder:** `src/domain/investing/thesis.ts:293`, `src/domain/investing/thesis.ts:409`
+- **Record sync + revision store:** `src/domain/investing/thesis.ts:476`, `src/domain/investing/thesis.ts:528`
 - **Executor thesis-refresh integration:** `src/domain/investing/executor.ts:384`, `src/domain/investing/executor.ts:563`
 - **Valuation packet sync hook:** `src/domain/investing/valuation-packet.ts:280`
 - **CLI surface (`zee investing thesis status`):** `packages/zee/src/cli/cmd/investing.ts:320`
 - **Operator doc:** `docs/architecture/investing-thesis-ledger.md:1`
+- **Confidence rule doc:** `docs/architecture/investing-thesis-confidence.md:1`
 
 ### Feature: Memory (Qdrant + Hybrid Search + Markdown Sync)
 **Purpose:** Store and retrieve semantic/keyword/hybrid memories with local Qdrant.

--- a/docs/architecture/investing-thesis-confidence.md
+++ b/docs/architecture/investing-thesis-confidence.md
@@ -1,0 +1,68 @@
+# Investing Thesis Confidence Rules
+
+This slice closes `#510`.
+
+The thesis ledger now requires evidence links for every persisted thesis revision and applies a deterministic confidence rule before any conviction change is accepted.
+
+## Rule contract
+
+Rule ID:
+
+- `thesis-confidence.v1`
+
+Each revision now carries a `confidence` block with:
+
+- `requestedConviction`
+  - the conviction requested by the caller or carried forward from the prior thesis state
+- `appliedConviction`
+  - the conviction actually written after the rule runs
+- `maxAllowedConviction`
+  - the highest conviction the linked evidence bundle is allowed to support
+- `score`
+  - rule score derived from evidence count, tool diversity, and linked valuation context
+- `evidenceCount`
+  - number of linked evidence references on the revision
+- `uniqueTools[]`
+  - distinct tool paths represented by the evidence
+- `reasons[]`
+  - operator-readable explanation for the resulting conviction
+
+## Current rules
+
+`thesis-confidence.v1` applies these checks:
+
+1. A thesis revision must include at least one evidence reference.
+2. Evidence count contributes to the confidence score.
+3. Distinct tool-path coverage contributes to the confidence score.
+4. Linked valuation context contributes to the confidence score.
+5. A `balanced` valuation signal caps conviction at `medium` even when evidence is otherwise strong.
+6. If the requested conviction is stronger than the rule allows, Zee downshifts it and records the reason.
+
+The rule is intentionally simple and deterministic. It gives operators an explicit audit trail now, while leaving room for richer scoring and policy later.
+
+## Execution integration
+
+The `thesis-refresh` path now does two things before it writes a revision:
+
+- converts completed research evidence into thesis evidence references
+- runs `thesis-confidence.v1` and stores the result on both the revision and the current thesis record
+
+The thesis snapshot appended to synthesis output now also shows the applied confidence rule and reasons so operators can audit the conviction before reading the persisted change log.
+
+## Telemetry
+
+This slice emits:
+
+- `investing.thesis.confidence`
+  - one event per thesis revision confidence evaluation
+- `investing.thesis.revision`
+  - now includes requested and applied conviction metadata
+
+## Operator checks
+
+Use the thesis ledger record or revision payload to inspect:
+
+- whether the revision had evidence links
+- which tools backed the change
+- whether the requested conviction was downgraded
+- why the rule accepted the final conviction level

--- a/docs/architecture/investing-thesis-ledger.md
+++ b/docs/architecture/investing-thesis-ledger.md
@@ -32,6 +32,8 @@ Each record stores:
   - next monitoring items that should trigger a refresh
 - `valuation`
   - latest linked valuation case, packet, run, and signal metadata
+- `confidence`
+  - latest applied thesis confidence assessment
 - `revisions[]`
   - append-only change log for the thesis
 
@@ -57,6 +59,8 @@ Each revision stores:
   - linked valuation snapshot for later diffing
 - `evidence[]`
   - references to persisted evidence or valuation packets
+- `confidence`
+  - applied confidence rule, capped conviction, and operator-readable reasons
 - `source`
   - workflow/task/execution/artifact pointers when the revision came from automation
 
@@ -83,6 +87,8 @@ zee investing thesis status --json
 
 `zee investing thesis status` reports total theses, total revisions, and current counts by status and conviction.
 
+Confidence rules and downgrade behavior are documented in `docs/architecture/investing-thesis-confidence.md`.
+
 ## Telemetry
 
 Flux events emitted for this slice:
@@ -91,3 +97,5 @@ Flux events emitted for this slice:
   - emitted whenever a thesis record is created, updated, or advanced by a revision
 - `investing.thesis.revision`
   - emitted whenever a new thesis revision is appended to the change log
+- `investing.thesis.confidence`
+  - emitted whenever Zee evaluates the confidence rule for a thesis revision

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -68,6 +68,7 @@ export type FluxKind =
   | "investing.valuation.packet.export"
   | "investing.thesis.record"
   | "investing.thesis.revision"
+  | "investing.thesis.confidence"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"
   | "provider.fallback.used"

--- a/packages/zee/test/investing/thesis-ledger.test.ts
+++ b/packages/zee/test/investing/thesis-ledger.test.ts
@@ -72,6 +72,22 @@ describe("investing thesis ledger", () => {
           currentPrice: 100,
           upsidePercent: 40,
         },
+        evidence: [
+          {
+            kind: "research-evidence",
+            id: "evidence-1",
+            label: "[E1] Research endpoint",
+            link: "evidence:execution-1:E1",
+            toolId: "zee:invest-research",
+          },
+          {
+            kind: "valuation-packet",
+            id: "valuation-packet-1",
+            label: "Valuation packet for NVDA",
+            link: "valuation-packet:valuation-packet-1",
+            toolId: "zee:invest-valuation",
+          },
+        ],
       })
 
       const updated = recordInvestingThesisRevision({
@@ -80,7 +96,7 @@ describe("investing thesis ledger", () => {
         changeType: "refresh",
         summary: "NVDA thesis moved back to a neutral stance after estimate volatility.",
         thesis: "The setup is intact, but the margin of safety is narrower than the prior refresh.",
-        conviction: "medium",
+        conviction: "high",
         posture: "neutral",
         watchpoints: ["Monitor estimate volatility before increasing exposure."],
         valuation: {
@@ -92,6 +108,15 @@ describe("investing thesis ledger", () => {
           currentPrice: 105,
           upsidePercent: 6.7,
         },
+        evidence: [
+          {
+            kind: "research-evidence",
+            id: "evidence-2",
+            label: "[E1] Analyst estimates",
+            link: "evidence:execution-2:E1",
+            toolId: "zee:invest-estimates",
+          },
+        ],
       })
 
       expect(updated.currentVersion).toBe(2)
@@ -110,6 +135,24 @@ describe("investing thesis ledger", () => {
       expect(await Bun.file(getInvestingThesisStateFile()).exists()).toBe(true)
       expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.thesis.record")).toBe(true)
       expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.thesis.revision")).toBe(true)
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.thesis.confidence")).toBe(true)
+      expect(updated.confidence?.appliedConviction).toBe("medium")
+      expect(updated.revisions[0]?.confidence.appliedConviction).toBe("medium")
+      expect(updated.revisions[0]?.confidence.reasons.some((reason) => reason.includes("downshifted"))).toBe(true)
+    })
+  })
+
+  test("rejects thesis revisions that do not carry evidence links", async () => {
+    await withThesisState(async () => {
+      expect(() =>
+        recordInvestingThesisRevision({
+          thesisKey: thesisKeyForSymbol("MSFT"),
+          symbol: "MSFT",
+          changeType: "initialize",
+          summary: "MSFT thesis without evidence.",
+          thesis: "This should fail because no evidence references were provided.",
+        }),
+      ).toThrow("Thesis revisions require at least one evidence link.")
     })
   })
 
@@ -214,9 +257,12 @@ describe("investing thesis ledger", () => {
       expect(thesis?.currentVersion).toBe(1)
       expect(thesis?.summary).toContain("NVDA thesis")
       expect(thesis?.valuation?.valuationCaseId).toContain("valuation_case:equity:nvda:")
+      expect(thesis?.confidence?.ruleVersion).toBe("thesis-confidence.v1")
       expect(thesis?.revisions[0]?.source.executionId).toBe(thesisExecution.id)
       expect(thesis?.revisions[0]?.source.artifactId).toBe(thesisExecution.artifactId)
       expect(thesis?.revisions[0]?.evidence.some((item) => item.kind === "valuation-packet")).toBe(true)
+      expect(thesis?.revisions[0]?.confidence.evidenceCount).toBeGreaterThan(0)
+      expect(thesisExecution.synthesis).toContain("confidenceRule=thesis-confidence.v1")
     })
   })
 })

--- a/src/domain/investing/executor.ts
+++ b/src/domain/investing/executor.ts
@@ -383,7 +383,7 @@ async function buildSynthesis(input: {
 
   if (input.plan.workflow === "thesis-refresh") {
     const primarySymbol = normalizeSymbol(input.plan.symbols[0]);
-    if (primarySymbol) {
+    if (primarySymbol && input.evidence.some((item) => item.status === "completed")) {
       const thesisDraft = buildInvestingThesisDraft({
         symbol: primarySymbol,
         evidence: input.evidence,

--- a/src/domain/investing/thesis.ts
+++ b/src/domain/investing/thesis.ts
@@ -42,6 +42,18 @@ export interface InvestingThesisEvidenceReference {
   id: string;
   label: string;
   link?: string;
+  toolId?: string;
+}
+
+export interface InvestingThesisConfidenceAssessment {
+  ruleVersion: "thesis-confidence.v1";
+  requestedConviction: InvestingThesisConviction;
+  appliedConviction: InvestingThesisConviction;
+  maxAllowedConviction: InvestingThesisConviction;
+  score: number;
+  evidenceCount: number;
+  uniqueTools: string[];
+  reasons: string[];
 }
 
 export interface InvestingThesisRevision {
@@ -56,6 +68,7 @@ export interface InvestingThesisRevision {
   watchpoints: string[];
   valuation: InvestingThesisValuationSnapshot | null;
   evidence: InvestingThesisEvidenceReference[];
+  confidence: InvestingThesisConfidenceAssessment;
   source: {
     workflow?: string;
     planId?: string;
@@ -80,6 +93,7 @@ export interface InvestingThesisRecord {
   thesis: string;
   watchpoints: string[];
   valuation: InvestingThesisValuationSnapshot | null;
+  confidence: InvestingThesisConfidenceAssessment | null;
   revisions: InvestingThesisRevision[];
 }
 
@@ -160,7 +174,14 @@ export interface InvestingThesisDraft {
   posture: InvestingThesisPosture;
   watchpoints: string[];
   valuation: InvestingThesisValuationSnapshot | null;
+  confidence: InvestingThesisConfidenceAssessment;
 }
+
+const CONVICTION_ORDER: Record<InvestingThesisConviction, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+};
 
 function getThesisStateDir(): string {
   const stateDir = process.env.XDG_STATE_HOME
@@ -261,6 +282,73 @@ function defaultWatchpoints(symbol: string, valuation: InvestingThesisValuationS
   ];
 }
 
+function lowerConviction(
+  left: InvestingThesisConviction,
+  right: InvestingThesisConviction,
+): InvestingThesisConviction {
+  return CONVICTION_ORDER[left] <= CONVICTION_ORDER[right] ? left : right;
+}
+
+function unique(items: string[]): string[] {
+  return [...new Set(items.filter(Boolean))];
+}
+
+function evaluateInvestingThesisConfidence(input: {
+  requestedConviction?: InvestingThesisConviction;
+  priorConviction?: InvestingThesisConviction;
+  evidence: InvestingThesisEvidenceReference[];
+  valuation: InvestingThesisValuationSnapshot | null;
+}): InvestingThesisConfidenceAssessment {
+  if (input.evidence.length === 0) {
+    throw new Error("Thesis revisions require at least one evidence link.");
+  }
+
+  const requestedConviction = input.requestedConviction ?? input.priorConviction ?? "medium";
+  const uniqueTools = unique(input.evidence.map((item) => item.toolId ?? item.kind));
+  let score = 0;
+
+  if (input.evidence.length >= 1) score += 1;
+  if (uniqueTools.length >= 2) score += 1;
+  if (input.valuation?.valuationCaseId && input.valuation.signal) score += 1;
+
+  let maxAllowedConviction: InvestingThesisConviction =
+    score >= 3 ? "high" : score >= 2 ? "medium" : "low";
+
+  const reasons = [
+    `Linked ${input.evidence.length} evidence reference(s).`,
+    `Coverage spans ${uniqueTools.length} tool path(s): ${uniqueTools.join(", ") || "none"}.`,
+  ];
+
+  if (input.valuation?.valuationCaseId && input.valuation.signal) {
+    reasons.push(`Valuation signal ${input.valuation.signal} is linked via ${input.valuation.valuationCaseId}.`);
+  } else {
+    reasons.push("No linked valuation signal was available for this revision.");
+  }
+
+  if (input.valuation?.signal === "balanced" && maxAllowedConviction === "high") {
+    maxAllowedConviction = "medium";
+    reasons.push("Balanced valuation signal caps conviction at medium until the setup breaks directionally.");
+  }
+
+  const appliedConviction = lowerConviction(requestedConviction, maxAllowedConviction);
+  if (appliedConviction !== requestedConviction) {
+    reasons.push(
+      `Requested conviction ${requestedConviction} was downshifted to ${appliedConviction} by thesis-confidence.v1.`,
+    );
+  }
+
+  return {
+    ruleVersion: "thesis-confidence.v1",
+    requestedConviction,
+    appliedConviction,
+    maxAllowedConviction,
+    score,
+    evidenceCount: input.evidence.length,
+    uniqueTools,
+    reasons,
+  };
+}
+
 function buildEmptyRecord(input: {
   thesisKey: string;
   symbol: string;
@@ -285,6 +373,7 @@ function buildEmptyRecord(input: {
     thesis: input.summary,
     watchpoints: defaultWatchpoints(input.symbol, input.valuation ?? null),
     valuation: input.valuation ?? null,
+    confidence: null,
     revisions: [],
   };
 }
@@ -326,7 +415,33 @@ export function buildInvestingThesisDraft(input: {
   const symbol = normalizeSymbol(input.symbol);
   const valuation = valuationSnapshotFromEvidence(input.evidence);
   const posture = postureFromSignal(valuation?.signal);
-  const conviction = input.conviction ?? "medium";
+  const evidence = input.evidence
+    .filter((item) => item.status === "completed")
+    .map<InvestingThesisEvidenceReference>((item) => ({
+      kind: "research-evidence",
+      id: item.id,
+      label: `[${item.citation}] ${item.sourceLabel}`,
+      link: item.link,
+      toolId: item.toolId,
+    }));
+
+  if (valuation?.packetId) {
+    evidence.push({
+      kind: "valuation-packet",
+      id: valuation.packetId,
+      label: `Valuation packet for ${symbol}`,
+      link: `valuation-packet:${valuation.packetId}`,
+      toolId: "zee:invest-valuation",
+    });
+  }
+
+  const confidence = evaluateInvestingThesisConfidence({
+    requestedConviction: input.conviction,
+    priorConviction: input.conviction,
+    evidence,
+    valuation,
+  });
+  const conviction = confidence.appliedConviction;
 
   const summary = valuation?.signal
     ? `${symbol} thesis remains ${posture} with ${valuation.signal} valuation signal.`
@@ -340,6 +455,7 @@ export function buildInvestingThesisDraft(input: {
     posture,
     watchpoints: defaultWatchpoints(symbol, valuation),
     valuation,
+    confidence,
   };
 }
 
@@ -349,8 +465,10 @@ export function renderInvestingThesisSnapshot(draft: InvestingThesisDraft): stri
     `- thesisKey=${draft.thesisKey}`,
     `- posture=${draft.posture}`,
     `- conviction=${draft.conviction}`,
+    `- confidenceRule=${draft.confidence.ruleVersion}:${draft.confidence.appliedConviction}`,
     `- valuationSignal=${draft.valuation?.signal ?? "n/a"}`,
     `- valuationCaseId=${draft.valuation?.valuationCaseId ?? "n/a"}`,
+    `- confidenceReasons=${draft.confidence.reasons.join(" ")}`,
     `- watchpoints=${draft.watchpoints.join("; ") || "n/a"}`,
   ].join("\n");
 }
@@ -372,6 +490,7 @@ export function syncInvestingThesisContext(input: SyncInvestingThesisContextInpu
             ? existing.watchpoints
             : defaultWatchpoints(input.symbol, input.valuation ?? existing.valuation ?? null),
         valuation: input.valuation ?? existing.valuation,
+        confidence: existing.confidence,
       }
     : buildEmptyRecord({
         thesisKey: input.thesisKey,
@@ -409,6 +528,13 @@ export function syncInvestingThesisContext(input: SyncInvestingThesisContextInpu
 export function recordInvestingThesisRevision(input: RecordInvestingThesisRevisionInput): InvestingThesisRecord {
   const state = readThesisState();
   const existing = state.records.find((record) => record.id === input.thesisKey);
+  const evidence = input.evidence ?? [];
+  const confidence = evaluateInvestingThesisConfidence({
+    requestedConviction: input.conviction,
+    priorConviction: existing?.conviction,
+    evidence,
+    valuation: input.valuation ?? existing?.valuation ?? null,
+  });
   const base =
     existing ??
     buildEmptyRecord({
@@ -429,11 +555,12 @@ export function recordInvestingThesisRevision(input: RecordInvestingThesisRevisi
     createdAt: new Date().toISOString(),
     summary: input.summary,
     thesis: input.thesis,
-    conviction: input.conviction ?? base.conviction,
+    conviction: confidence.appliedConviction,
     posture: input.posture ?? base.posture,
     watchpoints: input.watchpoints ?? base.watchpoints,
     valuation: input.valuation ?? base.valuation,
-    evidence: input.evidence ?? [],
+    evidence,
+    confidence,
     source: input.source ?? {},
   };
 
@@ -449,6 +576,7 @@ export function recordInvestingThesisRevision(input: RecordInvestingThesisRevisi
     thesis: revision.thesis,
     watchpoints: revision.watchpoints,
     valuation: revision.valuation,
+    confidence: revision.confidence,
     revisions: [...base.revisions.filter((entry) => entry.id !== revision.id), revision].sort((a, b) => b.version - a.version),
   };
 
@@ -474,6 +602,31 @@ export function recordInvestingThesisRevision(input: RecordInvestingThesisRevisi
       artifactId: revision.source.artifactId,
       valuationCaseId: revision.valuation?.valuationCaseId,
       evidenceCount: revision.evidence.length,
+      ruleVersion: revision.confidence.ruleVersion,
+      requestedConviction: revision.confidence.requestedConviction,
+      appliedConviction: revision.confidence.appliedConviction,
+    },
+  });
+
+  FluxRecorder.record({
+    traceID: revision.id,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.thesis.confidence",
+    status: "ok",
+    method: "evaluate",
+    path: record.symbol,
+    route: record.id,
+    metadata: {
+      version: revision.version,
+      ruleVersion: revision.confidence.ruleVersion,
+      requestedConviction: revision.confidence.requestedConviction,
+      appliedConviction: revision.confidence.appliedConviction,
+      maxAllowedConviction: revision.confidence.maxAllowedConviction,
+      score: revision.confidence.score,
+      evidenceCount: revision.confidence.evidenceCount,
+      uniqueTools: revision.confidence.uniqueTools,
+      reasons: revision.confidence.reasons,
     },
   });
 
@@ -492,6 +645,7 @@ export function recordInvestingThesisRevision(input: RecordInvestingThesisRevisi
       posture: record.posture,
       latestRevisionId: record.latestRevisionId,
       valuationCaseId: record.valuation?.valuationCaseId,
+      ruleVersion: record.confidence?.ruleVersion,
     },
   });
 
@@ -522,6 +676,7 @@ export function recordInvestingThesisRevisionFromExecution(
       id: item.id,
       label: `[${item.citation}] ${item.sourceLabel}`,
       link: item.link,
+      toolId: item.toolId,
     }));
 
   if (draft.valuation?.packetId) {
@@ -530,6 +685,7 @@ export function recordInvestingThesisRevisionFromExecution(
       id: draft.valuation.packetId,
       label: `Valuation packet for ${symbol}`,
       link: `valuation-packet:${draft.valuation.packetId}`,
+      toolId: "zee:invest-valuation",
     });
   }
 
@@ -541,6 +697,8 @@ export function recordInvestingThesisRevisionFromExecution(
     `Task: ${input.task.title}`,
     `Posture: ${draft.posture}`,
     `Conviction: ${draft.conviction}`,
+    `Confidence rule: ${draft.confidence.ruleVersion}`,
+    `Confidence reasons: ${draft.confidence.reasons.join(" ")}`,
     `Valuation case: ${draft.valuation?.valuationCaseId ?? "n/a"}`,
     `Valuation signal: ${draft.valuation?.signal ?? "n/a"}`,
     "",


### PR DESCRIPTION
## Summary
- require evidence links for every persisted thesis revision and store the applied confidence assessment on the revision and current thesis record
- add `thesis-confidence.v1` to cap conviction from evidence coverage, tool diversity, and linked valuation context while surfacing the rule in thesis snapshots
- document the confidence policy and extend thesis-ledger tests and telemetry for evidence enforcement and conviction downgrades

## Testing
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- cd packages/zee && bun test test/investing/thesis-ledger.test.ts test/investing/research-executor.test.ts
- cd packages/zee && CI=true bun test --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh
- zee investing thesis status --json

Closes #510
