### PR TITLE
feat(#512): add portfolio briefings

### DIFF
--- a/docs/architecture/investing-portfolio-briefings.md
+++ b/docs/architecture/investing-portfolio-briefings.md
@@ -1,0 +1,68 @@
+# Investing Portfolio Briefings
+
+This slice closes `#512`.
+
+The portfolio briefing layer turns existing research outputs into a daily holdings and watchlist workflow instead of making operators stitch together thesis records and event deltas by hand.
+
+## Daily brief contract
+
+State file:
+
+- `~/.local/state/zee/investing/portfolio-briefings.json`
+
+Each briefing stores:
+
+- `schemaVersion`
+  - current value: `portfolio-brief.v1`
+- `kind`
+  - current value: `daily-portfolio-brief`
+- `summary`
+  - high-level daily ops summary across holdings and watchlist coverage
+- `coverage`
+  - counts for holdings, watchlist names, thesis-backed symbols, and event deltas
+- `symbols[]`
+  - one row per holding or watchlist name with:
+    - audience (`holding` or `watchlist`)
+    - optional position context
+    - current thesis summary/conviction/posture/version
+    - latest linked valuation snapshot from thesis state
+    - relevant daily event deltas
+- `sections[]`
+  - rendered operator sections for overview, holdings, and watchlist review
+
+## Inputs
+
+The daily briefing consumes three already-persisted research layers:
+
+- portfolio holdings from the configured portfolio file
+- watchlist symbols from the configured watchlist file or explicit overrides
+- thesis state from the thesis ledger
+- daily event deltas from event intelligence
+
+That means the workflow stays lightweight and deterministic:
+
+- no new research execution is required to create the brief
+- the brief is always grounded in the latest persisted thesis and event state
+
+## Tool surface
+
+The operator surface is `zee:invest-briefings`.
+
+Supported actions:
+
+- `create`
+  - inputs: `kind`, optional `watchlistSymbols`
+- `read`
+  - inputs: `briefingId`
+- `list`
+  - inputs: optional `kind`, `symbol`, `audience`, `limit`
+
+The existing `zee_invest_morning_brief` plugin output now appends the rendered portfolio briefing so the daily user-facing brief also reflects holdings and watchlist deltas.
+
+## Telemetry
+
+This slice emits:
+
+- `investing.portfolio.briefing`
+  - one event per persisted daily portfolio briefing
+  - metadata includes symbol coverage, thesis coverage, and event-delta counts

--- a/packages/zee/src/cli/cmd/investing.ts
+++ b/packages/zee/src/cli/cmd/investing.ts
@@ -24,6 +24,14 @@ import {
   type InvestingConnectorKind,
 } from "@/investing/ingestion"
 import { getInvestingThesisLedgerStatus } from "@root/domain/investing/thesis"
+import {
+  INVESTING_PORTFOLIO_BRIEFING_KINDS,
+  createInvestingPortfolioBriefing,
+  getInvestingPortfolioBriefing,
+  listInvestingPortfolioBriefings,
+  type InvestingPortfolioBriefingAudience,
+  type InvestingPortfolioBriefingKind,
+} from "@root/domain/investing/briefings"
 
 const InvestingIngestStatusCommand = cmd({
   command: "status",
@@ -347,6 +355,137 @@ const InvestingThesisCommand = cmd({
   async handler() {},
 })
 
+const InvestingBriefingCreateCommand = cmd({
+  command: "create",
+  describe: "create a persisted daily portfolio briefing",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("kind", {
+        type: "string",
+        choices: [...INVESTING_PORTFOLIO_BRIEFING_KINDS],
+        default: "daily-portfolio-brief",
+        describe: "briefing kind to create",
+      })
+      .option("watchlist-symbol", {
+        type: "array",
+        string: true,
+        describe: "optional explicit watchlist symbol override",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: { kind?: string; watchlistSymbol?: string[]; json?: boolean }) => {
+    const briefing = await createInvestingPortfolioBriefing({
+      watchlistSymbols: args.watchlistSymbol,
+    })
+    if (args.json) {
+      console.log(JSON.stringify(briefing, null, 2))
+      return
+    }
+
+    console.log(`${briefing.id}`)
+    console.log(`- kind=${briefing.kind} createdAt=${briefing.createdAt}`)
+    console.log(`- summary=${briefing.summary}`)
+    console.log(
+      `- coverage holdings=${briefing.coverage.holdingsCount} watchlist=${briefing.coverage.watchlistCount} theses=${briefing.coverage.thesisTrackedCount} deltas=${briefing.coverage.eventDeltaCount}`,
+    )
+  },
+})
+
+const InvestingBriefingReadCommand = cmd({
+  command: "read <briefingId>",
+  describe: "read one persisted portfolio briefing",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("briefingId", {
+        type: "string",
+        demandOption: true,
+        describe: "portfolio briefing identifier",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: { briefingId?: string; json?: boolean }) => {
+    if (!args.briefingId) {
+      throw new Error("briefingId is required")
+    }
+    const briefing = getInvestingPortfolioBriefing(args.briefingId)
+    const payload = briefing ?? { error: `Portfolio briefing not found: ${args.briefingId}` }
+    if (args.json || !briefing) {
+      console.log(JSON.stringify(payload, null, 2))
+      return
+    }
+
+    console.log(`${briefing.id}`)
+    console.log(`- kind=${briefing.kind} createdAt=${briefing.createdAt}`)
+    console.log(`- summary=${briefing.summary}`)
+    for (const section of briefing.sections) {
+      console.log(`\n${section.title}`)
+      console.log(section.body)
+    }
+  },
+})
+
+const InvestingBriefingListCommand = cmd({
+  command: "list",
+  describe: "list persisted portfolio briefings",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("kind", {
+        type: "string",
+        choices: [...INVESTING_PORTFOLIO_BRIEFING_KINDS],
+        describe: "optional briefing kind filter",
+      })
+      .option("symbol", {
+        type: "string",
+        describe: "optional symbol filter",
+      })
+      .option("audience", {
+        type: "string",
+        choices: ["holding", "watchlist"],
+        describe: "optional audience filter",
+      })
+      .option("limit", {
+        type: "number",
+        default: 10,
+        describe: "maximum number of briefings to return",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: { kind?: string; symbol?: string; audience?: string; limit?: number; json?: boolean }) => {
+    const briefings = listInvestingPortfolioBriefings({
+      kind: args.kind as InvestingPortfolioBriefingKind | undefined,
+      symbol: args.symbol,
+      audience: args.audience as InvestingPortfolioBriefingAudience | undefined,
+      limit: args.limit,
+    })
+    if (args.json) {
+      console.log(JSON.stringify({ briefings, count: briefings.length }, null, 2))
+      return
+    }
+    for (const briefing of briefings) {
+      console.log(
+        `- ${briefing.id}: kind=${briefing.kind} holdings=${briefing.coverage.holdingsCount} watchlist=${briefing.coverage.watchlistCount} theses=${briefing.coverage.thesisTrackedCount} deltas=${briefing.coverage.eventDeltaCount} summary=${briefing.summary}`,
+      )
+    }
+  },
+})
+
+const InvestingBriefingCommand = cmd({
+  command: "briefing",
+  describe: "persisted daily portfolio briefings",
+  builder: (yargs: Argv) =>
+    yargs.command(InvestingBriefingCreateCommand).command(InvestingBriefingReadCommand).command(InvestingBriefingListCommand).demandCommand(),
+  async handler() {},
+})
+
 const InvestingIngestScheduleCommand = cmd({
   command: "schedule",
   describe: "register connector schedules in the current always-on process",
@@ -394,6 +533,7 @@ export const InvestingCommand = cmd({
       .command(InvestingEntityCommand)
       .command(InvestingEventCommand)
       .command(InvestingThesisCommand)
+      .command(InvestingBriefingCommand)
       .demandCommand(),
   async handler() {},
 })

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -69,6 +69,7 @@ export type FluxKind =
   | "investing.thesis.record"
   | "investing.thesis.revision"
   | "investing.thesis.confidence"
+  | "investing.portfolio.briefing"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"
   | "provider.fallback.used"

--- a/packages/zee/src/plugin/investing.ts
+++ b/packages/zee/src/plugin/investing.ts
@@ -16,7 +16,7 @@ import {
   InvestingNotRunningError,
   InvestingTimeoutError,
 } from "@zee/investing-sdk"
-import { buildInvestingEventDeltaBrief, renderInvestingEventDeltaBrief } from "../investing/briefing-deltas"
+import { buildInvestingPortfolioBriefing, renderInvestingPortfolioBriefing } from "@root/domain/investing/briefings"
 import { Log } from "../util/log"
 import { Investing } from "../paths"
 
@@ -940,11 +940,10 @@ export async function InvestingPlugin(input: PluginInput): Promise<Hooks> {
             }
           }
 
-          const eventDeltas = await buildInvestingEventDeltaBrief({
-            mode: "daily",
-            symbols: args.watchlist,
+          const portfolioBriefing = await buildInvestingPortfolioBriefing({
+            watchlistSymbols: args.watchlist,
           })
-          sections.push(renderInvestingEventDeltaBrief(eventDeltas))
+          sections.push(renderInvestingPortfolioBriefing(portfolioBriefing))
 
           return sections.join("\n\n")
         },

--- a/packages/zee/test/investing/portfolio-briefings.test.ts
+++ b/packages/zee/test/investing/portfolio-briefings.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import { FluxRecorder } from "../../src/flux"
+import { normalizeInvestingConnectorEntities } from "../../src/investing/entities"
+import { classifyInvestingConnectorEvents, upsertInvestingEvents } from "../../src/investing/events"
+import { tmpdir } from "../fixture/fixture"
+import {
+  createInvestingPortfolioBriefing,
+  getInvestingPortfolioBriefing,
+  getInvestingPortfolioBriefingStateFile,
+  renderInvestingPortfolioBriefing,
+} from "../../../../src/domain/investing/briefings"
+import { portfolioBriefingsTool } from "../../../../src/domain/investing/tools"
+import { recordInvestingThesisRevision, syncInvestingThesisContext, thesisKeyForSymbol } from "../../../../src/domain/investing/thesis"
+
+function makeToolContext() {
+  return {
+    sessionId: "session-1",
+    messageId: "message-1",
+    agent: "zee",
+    abort: new AbortController().signal,
+    metadata: () => {},
+  }
+}
+
+async function seedEventDelta(symbol: string, headline: string) {
+  const events = classifyInvestingConnectorEvents({
+    connector: "news",
+    entities: normalizeInvestingConnectorEntities({
+      connector: "news",
+      collectedAt: "2026-03-15T10:00:00.000Z",
+      data: [
+        {
+          symbol,
+          articleId: `${symbol.toLowerCase()}-delta`,
+          publishedAt: "2026-03-15T09:30:00.000Z",
+          title: headline,
+          summary: `${headline} for ${symbol}.`,
+          sector: "Technology",
+        },
+      ],
+    }),
+  })
+  await upsertInvestingEvents({ events })
+}
+
+function seedThesis(symbol: string, summary: string) {
+  const thesisKey = thesisKeyForSymbol(symbol)
+  syncInvestingThesisContext({
+    thesisKey,
+    symbol,
+    summary,
+    valuation: {
+      valuationCaseId: `valuation_case:equity:${symbol.toLowerCase()}:base`,
+      packetId: `valuation-packet-${symbol.toLowerCase()}`,
+      runId: `valuation-run-${symbol.toLowerCase()}`,
+      signal: symbol === "NVDA" ? "re-rate-up" : "balanced",
+      fairValue: symbol === "NVDA" ? 140 : 110,
+      currentPrice: symbol === "NVDA" ? 100 : 105,
+      upsidePercent: symbol === "NVDA" ? 40 : 5,
+    },
+  })
+  recordInvestingThesisRevision({
+    thesisKey,
+    symbol,
+    changeType: "initialize",
+    summary,
+    thesis: `${summary} Thesis body for ${symbol}.`,
+    conviction: symbol === "NVDA" ? "high" : "medium",
+    posture: symbol === "NVDA" ? "bullish" : "neutral",
+    evidence: [
+      {
+        kind: "research-evidence",
+        id: `evidence-${symbol.toLowerCase()}`,
+        label: `[E1] Research summary for ${symbol}`,
+        link: `evidence:research-${symbol}:E1`,
+        toolId: "zee:invest-research",
+      },
+      {
+        kind: "valuation-packet",
+        id: `valuation-packet-${symbol.toLowerCase()}`,
+        label: `Valuation packet for ${symbol}`,
+        link: `valuation-packet:valuation-packet-${symbol.toLowerCase()}`,
+        toolId: "zee:invest-valuation",
+      },
+    ],
+    valuation: {
+      valuationCaseId: `valuation_case:equity:${symbol.toLowerCase()}:base`,
+      packetId: `valuation-packet-${symbol.toLowerCase()}`,
+      runId: `valuation-run-${symbol.toLowerCase()}`,
+      signal: symbol === "NVDA" ? "re-rate-up" : "balanced",
+      fairValue: symbol === "NVDA" ? 140 : 110,
+      currentPrice: symbol === "NVDA" ? 100 : 105,
+      upsidePercent: symbol === "NVDA" ? 40 : 5,
+    },
+  })
+}
+
+async function withPortfolioBriefingState<T>(fn: () => Promise<T>): Promise<T> {
+  await using dir = await tmpdir()
+  const originalStateHome = process.env.XDG_STATE_HOME
+  const originalPortfolioFile = process.env.ZEE_INVESTING_PORTFOLIO_FILE
+  const originalWatchlistFile = process.env.ZEE_INVESTING_WATCHLIST_FILE
+  process.env.XDG_STATE_HOME = dir.path
+  process.env.ZEE_INVESTING_PORTFOLIO_FILE = `${dir.path}/portfolio.json`
+  process.env.ZEE_INVESTING_WATCHLIST_FILE = `${dir.path}/watchlist.json`
+
+  await Bun.write(
+    process.env.ZEE_INVESTING_PORTFOLIO_FILE,
+    JSON.stringify({
+      positions: [{ symbol: "NVDA", shares: 10, average_cost: 95 }],
+    }),
+  )
+  await Bun.write(
+    process.env.ZEE_INVESTING_WATCHLIST_FILE,
+    JSON.stringify({
+      watchlist: [{ symbol: "MSFT" }],
+    }),
+  )
+
+  try {
+    return await fn()
+  } finally {
+    if (originalStateHome === undefined) {
+      delete process.env.XDG_STATE_HOME
+    } else {
+      process.env.XDG_STATE_HOME = originalStateHome
+    }
+    if (originalPortfolioFile === undefined) {
+      delete process.env.ZEE_INVESTING_PORTFOLIO_FILE
+    } else {
+      process.env.ZEE_INVESTING_PORTFOLIO_FILE = originalPortfolioFile
+    }
+    if (originalWatchlistFile === undefined) {
+      delete process.env.ZEE_INVESTING_WATCHLIST_FILE
+    } else {
+      process.env.ZEE_INVESTING_WATCHLIST_FILE = originalWatchlistFile
+    }
+  }
+}
+
+describe("investing portfolio briefings", () => {
+  test("builds and persists a daily holdings/watchlist briefing from research outputs", async () => {
+    await withPortfolioBriefingState(async () => {
+      const recordSpy = spyOn(FluxRecorder, "record")
+      seedThesis("NVDA", "NVDA remains a core AI holding.")
+      seedThesis("MSFT", "MSFT stays on the watchlist for cloud and AI follow-through.")
+      await seedEventDelta("NVDA", "NVDA raises guidance after a strong quarter")
+      await seedEventDelta("MSFT", "MSFT raises guidance after a strong quarter")
+
+      const briefing = await createInvestingPortfolioBriefing()
+
+      expect(briefing.kind).toBe("daily-portfolio-brief")
+      expect(briefing.coverage.holdingsCount).toBe(1)
+      expect(briefing.coverage.watchlistCount).toBe(1)
+      expect(briefing.coverage.thesisTrackedCount).toBe(2)
+      expect(briefing.coverage.eventDeltaCount).toBe(2)
+      expect(briefing.sections.map((section) => section.title)).toEqual(["Overview", "Holdings", "Watchlist"])
+      expect(renderInvestingPortfolioBriefing(briefing)).toContain("NVDA [holding]")
+      expect(renderInvestingPortfolioBriefing(briefing)).toContain("MSFT [watchlist]")
+      expect(getInvestingPortfolioBriefing(briefing.id)?.id).toBe(briefing.id)
+      expect(await Bun.file(getInvestingPortfolioBriefingStateFile()).exists()).toBe(true)
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.portfolio.briefing")).toBe(true)
+    })
+  })
+
+  test("tool surface can create, read, and list daily portfolio briefings", async () => {
+    await withPortfolioBriefingState(async () => {
+      seedThesis("NVDA", "NVDA remains a core AI holding.")
+      seedThesis("MSFT", "MSFT stays on the watchlist for cloud and AI follow-through.")
+      await seedEventDelta("NVDA", "NVDA raises guidance after a strong quarter")
+      await seedEventDelta("MSFT", "MSFT raises guidance after a strong quarter")
+
+      const runtime = await portfolioBriefingsTool.init()
+      const ctx = makeToolContext()
+
+      const createResult = await runtime.execute(
+        {
+          action: "create",
+          kind: "daily-portfolio-brief",
+        },
+        ctx,
+      )
+      const created = JSON.parse(createResult.output) as { id: string }
+      expect(created.id).toBeDefined()
+
+      const readResult = await runtime.execute(
+        {
+          action: "read",
+          briefingId: created.id,
+        },
+        ctx,
+      )
+      expect(JSON.parse(readResult.output)).toMatchObject({
+        id: created.id,
+      })
+
+      const listResult = await runtime.execute(
+        {
+          action: "list",
+          audience: "holding",
+          limit: 5,
+        },
+        ctx,
+      )
+      const listed = JSON.parse(listResult.output) as {
+        count: number
+        briefings: Array<{ id: string }>
+      }
+      expect(listed.count).toBeGreaterThan(0)
+      expect(listed.briefings.some((entry) => entry.id === created.id)).toBe(true)
+    })
+  })
+})

--- a/src/domain/investing/briefings.ts
+++ b/src/domain/investing/briefings.ts
@@ -1,0 +1,435 @@
+/**
+ * Investing Portfolio Briefings
+ *
+ * Builds and persists daily portfolio-ops briefings that summarize holdings
+ * and watchlist deltas from thesis state and event-intelligence outputs.
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { FluxRecorder } from "../../../packages/zee/src/flux";
+import {
+  buildInvestingEventDeltaBrief,
+  type InvestingEventDeltaBrief,
+  type InvestingEventDeltaItem,
+} from "../../../packages/zee/src/investing/briefing-deltas";
+import { Log } from "../../../packages/zee/src/util/log";
+import { Investing } from "../../paths";
+import {
+  getInvestingThesis,
+  thesisKeyForSymbol,
+  type InvestingThesisConfidenceAssessment,
+  type InvestingThesisConviction,
+  type InvestingThesisPosture,
+  type InvestingThesisValuationSnapshot,
+} from "./thesis";
+
+const log = Log.create({ service: "investing:portfolio-briefings" });
+
+export const INVESTING_PORTFOLIO_BRIEFING_KINDS = ["daily-portfolio-brief"] as const;
+export type InvestingPortfolioBriefingKind = (typeof INVESTING_PORTFOLIO_BRIEFING_KINDS)[number];
+
+export type InvestingPortfolioBriefingAudience = "holding" | "watchlist";
+
+export interface InvestingPortfolioBriefingSection {
+  id: string;
+  title: string;
+  body: string;
+}
+
+export interface InvestingPortfolioBriefingSymbol {
+  symbol: string;
+  audience: InvestingPortfolioBriefingAudience;
+  shares?: number;
+  averageCost?: number;
+  thesis: null | {
+    thesisKey: string;
+    summary: string;
+    conviction: InvestingThesisConviction;
+    posture: InvestingThesisPosture;
+    currentVersion: number;
+    confidence: InvestingThesisConfidenceAssessment | null;
+  };
+  valuation: InvestingThesisValuationSnapshot | null;
+  eventDeltas: InvestingEventDeltaItem[];
+}
+
+export interface InvestingPortfolioBriefing {
+  id: string;
+  schemaVersion: "portfolio-brief.v1";
+  kind: InvestingPortfolioBriefingKind;
+  createdAt: string;
+  summary: string;
+  coverage: {
+    holdingsCount: number;
+    watchlistCount: number;
+    thesisTrackedCount: number;
+    eventDeltaCount: number;
+  };
+  symbols: InvestingPortfolioBriefingSymbol[];
+  sections: InvestingPortfolioBriefingSection[];
+}
+
+type PortfolioBriefingState = {
+  version: 1;
+  briefings: InvestingPortfolioBriefing[];
+};
+
+type PortfolioPosition = {
+  symbol: string;
+  shares: number;
+  averageCost?: number;
+};
+
+type WatchlistEntry = {
+  symbol: string;
+};
+
+type BuildInvestingPortfolioBriefingInput = {
+  watchlistSymbols?: string[];
+  portfolioFile?: string;
+  watchlistFile?: string;
+  createdAt?: string;
+  id?: string;
+};
+
+function getBriefingStateDir(): string {
+  const stateDir = process.env.XDG_STATE_HOME
+    ? path.join(process.env.XDG_STATE_HOME, "zee")
+    : path.join(os.homedir(), ".local", "state", "zee");
+  return path.join(stateDir, "investing");
+}
+
+export function getInvestingPortfolioBriefingStateFile(): string {
+  return path.join(getBriefingStateDir(), "portfolio-briefings.json");
+}
+
+function ensureBriefingStateDir(): void {
+  mkdirSync(getBriefingStateDir(), { recursive: true });
+}
+
+function readBriefingState(): PortfolioBriefingState {
+  const filePath = getInvestingPortfolioBriefingStateFile();
+  if (!existsSync(filePath)) {
+    return { version: 1, briefings: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as Partial<PortfolioBriefingState>;
+    return {
+      version: 1,
+      briefings: Array.isArray(parsed.briefings) ? parsed.briefings : [],
+    };
+  } catch (error) {
+    log.warn("failed to read portfolio briefing state", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { version: 1, briefings: [] };
+  }
+}
+
+function writeBriefingState(state: PortfolioBriefingState): void {
+  ensureBriefingStateDir();
+  writeFileSync(getInvestingPortfolioBriefingStateFile(), JSON.stringify(state, null, 2) + "\n", "utf-8");
+}
+
+function defaultWatchlistFile(): string {
+  return process.env.ZEE_INVESTING_WATCHLIST_FILE || path.join(os.homedir(), ".zee", "investing", "watchlist.json");
+}
+
+function normalizeSymbol(symbol: string | undefined): string {
+  return symbol?.trim().toUpperCase() ?? "";
+}
+
+function parseNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function unique<T>(items: T[]): T[] {
+  return [...new Set(items)];
+}
+
+function readJsonFile(filePath: string): unknown {
+  if (!existsSync(filePath)) return undefined;
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+function loadPortfolioPositions(portfolioFile = Investing.portfolioFile()): PortfolioPosition[] {
+  const parsed = readJsonFile(portfolioFile);
+  const record = asRecord(parsed);
+  const positions = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(record?.positions)
+      ? record.positions
+      : Array.isArray(record?.holdings)
+        ? record.holdings
+        : [];
+
+  return positions
+    .map((entry): PortfolioPosition | null => {
+      const record = asRecord(entry);
+      if (!record) return null;
+      const symbol = normalizeSymbol(String(record.symbol ?? record.ticker ?? ""));
+      const shares = parseNumber(record.shares ?? record.quantity ?? record.position);
+      if (!symbol || !shares || shares <= 0) return null;
+      const averageCost = parseNumber(
+        record.averageCost ??
+          record.average_cost ??
+          record.avg_cost ??
+          record.entryPrice ??
+          record.entry_price ??
+          record.price,
+      );
+      return {
+        symbol,
+        shares,
+        averageCost,
+      };
+    })
+    .filter((entry): entry is PortfolioPosition => Boolean(entry));
+}
+
+function loadWatchlistEntries(input: { watchlistSymbols?: string[]; watchlistFile?: string }): WatchlistEntry[] {
+  const parsed = readJsonFile(input.watchlistFile ?? defaultWatchlistFile());
+  const record = asRecord(parsed);
+  const items = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(record?.items)
+      ? record.items
+      : Array.isArray(record?.watchlist)
+        ? record.watchlist
+        : Array.isArray(record?.symbols)
+          ? record.symbols
+          : [];
+
+  const symbols = [
+    ...items.map((item) => {
+      if (typeof item === "string") return normalizeSymbol(item);
+      const record = asRecord(item);
+      return normalizeSymbol(String(record?.symbol ?? record?.ticker ?? record?.code ?? ""));
+    }),
+    ...(input.watchlistSymbols ?? []).map((symbol) => normalizeSymbol(symbol)),
+  ];
+
+  return unique(symbols)
+    .filter(Boolean)
+    .map((symbol) => ({ symbol }));
+}
+
+function summarizeEventDelta(delta: InvestingEventDeltaItem): string {
+  return `${delta.materialityBand}/${delta.direction}: ${delta.headline}`;
+}
+
+function renderSymbol(entry: InvestingPortfolioBriefingSymbol): string {
+  const thesis = entry.thesis
+    ? `${entry.thesis.summary} (${entry.thesis.conviction}/${entry.thesis.posture}, v${entry.thesis.currentVersion})`
+    : "No thesis record yet.";
+  const valuation =
+    entry.valuation?.upsidePercent != null
+      ? `${entry.valuation.signal ?? "n/a"} @ ${entry.valuation.upsidePercent.toFixed(1)}%`
+      : entry.valuation?.signal ?? "n/a";
+  const deltas =
+    entry.eventDeltas.length > 0 ? entry.eventDeltas.map((item) => summarizeEventDelta(item)).join("; ") : "No high-signal deltas.";
+  const position =
+    entry.audience === "holding"
+      ? ` shares=${entry.shares ?? 0}${entry.averageCost != null ? ` avgCost=${entry.averageCost}` : ""}`
+      : "";
+  return `- ${entry.symbol} [${entry.audience}]${position}\n  thesis: ${thesis}\n  valuation: ${valuation}\n  deltas: ${deltas}`;
+}
+
+function buildSections(input: {
+  holdings: InvestingPortfolioBriefingSymbol[];
+  watchlist: InvestingPortfolioBriefingSymbol[];
+  eventDeltaBrief: InvestingEventDeltaBrief;
+}): InvestingPortfolioBriefingSection[] {
+  return [
+    {
+      id: "overview",
+      title: "Overview",
+      body: input.eventDeltaBrief.summary,
+    },
+    {
+      id: "holdings",
+      title: "Holdings",
+      body: input.holdings.length > 0 ? input.holdings.map((entry) => renderSymbol(entry)).join("\n") : "- none",
+    },
+    {
+      id: "watchlist",
+      title: "Watchlist",
+      body: input.watchlist.length > 0 ? input.watchlist.map((entry) => renderSymbol(entry)).join("\n") : "- none",
+    },
+  ];
+}
+
+export async function buildInvestingPortfolioBriefing(
+  input: BuildInvestingPortfolioBriefingInput = {},
+): Promise<InvestingPortfolioBriefing> {
+  const createdAt = input.createdAt ?? new Date().toISOString();
+  const holdings = loadPortfolioPositions(input.portfolioFile);
+  const watchlist = loadWatchlistEntries({
+    watchlistSymbols: input.watchlistSymbols,
+    watchlistFile: input.watchlistFile,
+  }).filter((entry) => !holdings.some((position) => position.symbol === entry.symbol));
+
+  const symbols = unique([...holdings.map((entry) => entry.symbol), ...watchlist.map((entry) => entry.symbol)]);
+  const eventDeltaBrief = await buildInvestingEventDeltaBrief({
+    mode: "daily",
+    symbols,
+  });
+  const deltasBySymbol = new Map<string, InvestingEventDeltaItem[]>();
+  for (const item of eventDeltaBrief.items) {
+    const symbol = normalizeSymbol(item.symbol);
+    if (!symbol) continue;
+    const items = deltasBySymbol.get(symbol) ?? [];
+    items.push(item);
+    deltasBySymbol.set(symbol, items);
+  }
+
+  const symbolEntries: InvestingPortfolioBriefingSymbol[] = [
+    ...holdings.map((position) => {
+      const thesis = getInvestingThesis(thesisKeyForSymbol(position.symbol));
+      return {
+        symbol: position.symbol,
+        audience: "holding" as const,
+        shares: position.shares,
+        averageCost: position.averageCost,
+        thesis: thesis
+          ? {
+              thesisKey: thesis.id,
+              summary: thesis.summary,
+              conviction: thesis.conviction,
+              posture: thesis.posture,
+              currentVersion: thesis.currentVersion,
+              confidence: thesis.confidence,
+            }
+          : null,
+        valuation: thesis?.valuation ?? null,
+        eventDeltas: deltasBySymbol.get(position.symbol) ?? [],
+      };
+    }),
+    ...watchlist.map((entry) => {
+      const thesis = getInvestingThesis(thesisKeyForSymbol(entry.symbol));
+      return {
+        symbol: entry.symbol,
+        audience: "watchlist" as const,
+        thesis: thesis
+          ? {
+              thesisKey: thesis.id,
+              summary: thesis.summary,
+              conviction: thesis.conviction,
+              posture: thesis.posture,
+              currentVersion: thesis.currentVersion,
+              confidence: thesis.confidence,
+            }
+          : null,
+        valuation: thesis?.valuation ?? null,
+        eventDeltas: deltasBySymbol.get(entry.symbol) ?? [],
+      };
+    }),
+  ].sort((left, right) => left.symbol.localeCompare(right.symbol));
+
+  const thesisTrackedCount = symbolEntries.filter((entry) => entry.thesis).length;
+  const holdingsEntries = symbolEntries.filter((entry) => entry.audience === "holding");
+  const watchlistEntries = symbolEntries.filter((entry) => entry.audience === "watchlist");
+  const summary = `Daily portfolio brief covers ${holdingsEntries.length} holding(s) and ${watchlistEntries.length} watchlist name(s), with ${eventDeltaBrief.items.length} high-signal event delta(s) and ${thesisTrackedCount} thesis-backed symbol(s).`;
+
+  return {
+    id: input.id ?? `portfolio-brief-${randomUUID().slice(0, 12)}`,
+    schemaVersion: "portfolio-brief.v1",
+    kind: "daily-portfolio-brief",
+    createdAt,
+    summary,
+    coverage: {
+      holdingsCount: holdingsEntries.length,
+      watchlistCount: watchlistEntries.length,
+      thesisTrackedCount,
+      eventDeltaCount: eventDeltaBrief.items.length,
+    },
+    symbols: symbolEntries,
+    sections: buildSections({
+      holdings: holdingsEntries,
+      watchlist: watchlistEntries,
+      eventDeltaBrief,
+    }),
+  };
+}
+
+export function renderInvestingPortfolioBriefing(briefing: InvestingPortfolioBriefing): string {
+  return [
+    "Portfolio Briefing:",
+    briefing.summary,
+    "",
+    ...briefing.sections.flatMap((section) => [section.title, section.body, ""]),
+  ]
+    .join("\n")
+    .trim();
+}
+
+export async function createInvestingPortfolioBriefing(
+  input: BuildInvestingPortfolioBriefingInput = {},
+): Promise<InvestingPortfolioBriefing> {
+  const briefing = await buildInvestingPortfolioBriefing(input);
+  const state = readBriefingState();
+  state.briefings = [briefing, ...state.briefings.filter((entry) => entry.id !== briefing.id)].slice(0, 300);
+  writeBriefingState(state);
+
+  FluxRecorder.record({
+    traceID: briefing.id,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.portfolio.briefing",
+    status: "ok",
+    method: "create",
+    path: briefing.kind,
+    route: briefing.id,
+    metadata: {
+      symbolCount: briefing.symbols.length,
+      holdingsCount: briefing.coverage.holdingsCount,
+      watchlistCount: briefing.coverage.watchlistCount,
+      thesisTrackedCount: briefing.coverage.thesisTrackedCount,
+      eventDeltaCount: briefing.coverage.eventDeltaCount,
+    },
+  });
+
+  return briefing;
+}
+
+export function getInvestingPortfolioBriefing(briefingId: string): InvestingPortfolioBriefing | null {
+  const state = readBriefingState();
+  return state.briefings.find((entry) => entry.id === briefingId) ?? null;
+}
+
+export function listInvestingPortfolioBriefings(options?: {
+  kind?: InvestingPortfolioBriefingKind;
+  symbol?: string;
+  audience?: InvestingPortfolioBriefingAudience;
+  limit?: number;
+}): InvestingPortfolioBriefing[] {
+  const normalizedSymbol = options?.symbol ? normalizeSymbol(options.symbol) : undefined;
+  const state = readBriefingState();
+  return state.briefings
+    .filter((entry) => (options?.kind ? entry.kind === options.kind : true))
+    .filter((entry) =>
+      normalizedSymbol ? entry.symbols.some((symbol) => symbol.symbol === normalizedSymbol) : true,
+    )
+    .filter((entry) =>
+      options?.audience ? entry.symbols.some((symbol) => symbol.audience === options.audience) : true,
+    )
+    .slice(0, options?.limit ?? 20);
+}

--- a/src/domain/investing/tools.ts
+++ b/src/domain/investing/tools.ts
@@ -45,6 +45,13 @@ import {
   listInvestingValuationPackets,
 } from "./valuation-packet";
 import {
+  INVESTING_PORTFOLIO_BRIEFING_KINDS,
+  createInvestingPortfolioBriefing,
+  getInvestingPortfolioBriefing,
+  getInvestingPortfolioBriefingStateFile,
+  listInvestingPortfolioBriefings,
+} from "./briefings";
+import {
   INVESTING_EVENT_CLASSIFICATIONS,
   INVESTING_EVENT_CONNECTORS,
   INVESTING_EVENT_DIRECTIONS,
@@ -1029,6 +1036,83 @@ export const valuationPacketTool: ToolDefinition = {
   }),
 };
 
+const PortfolioBriefingParams = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("create"),
+    kind: z.enum(INVESTING_PORTFOLIO_BRIEFING_KINDS).default("daily-portfolio-brief").describe("Briefing workflow kind"),
+    watchlistSymbols: z.array(z.string()).optional().describe("Optional explicit watchlist override"),
+  }),
+  z.object({
+    action: z.literal("read"),
+    briefingId: z.string().describe("Persisted portfolio briefing identifier"),
+  }),
+  z.object({
+    action: z.literal("list"),
+    kind: z.enum(INVESTING_PORTFOLIO_BRIEFING_KINDS).optional().describe("Optional briefing kind filter"),
+    symbol: z.string().optional().describe("Optional symbol filter"),
+    audience: z.enum(["holding", "watchlist"]).optional().describe("Optional audience filter"),
+    limit: z.number().min(1).max(100).default(10).describe("Maximum number of briefings to return"),
+  }),
+]);
+
+export const portfolioBriefingsTool: ToolDefinition = {
+  id: "zee:invest-briefings",
+  category: "domain",
+  init: async () => ({
+    description: `Create, read, and list daily portfolio briefings built from thesis state and event intelligence.`,
+    parameters: PortfolioBriefingParams,
+    execute: async (args, ctx): Promise<ToolExecutionResult> => {
+      switch (args.action) {
+        case "create": {
+          ctx.metadata({ title: `Creating ${args.kind}` });
+          const briefing = await createInvestingPortfolioBriefing({
+            watchlistSymbols: args.watchlistSymbols,
+          });
+          return {
+            title: "Investing Portfolio Briefings",
+            metadata: {
+              action: args.action,
+              briefingId: briefing.id,
+              kind: briefing.kind,
+              stateFile: getInvestingPortfolioBriefingStateFile(),
+            },
+            output: JSON.stringify(briefing, null, 2),
+          };
+        }
+        case "read": {
+          ctx.metadata({ title: `Loading portfolio briefing ${args.briefingId}` });
+          const briefing = getInvestingPortfolioBriefing(args.briefingId);
+          return {
+            title: "Investing Portfolio Briefings",
+            metadata: { action: args.action, briefingId: args.briefingId, found: Boolean(briefing) },
+            output: JSON.stringify(briefing ?? { error: `Portfolio briefing not found: ${args.briefingId}` }, null, 2),
+          };
+        }
+        case "list": {
+          ctx.metadata({ title: "Listing portfolio briefings" });
+          const briefings = listInvestingPortfolioBriefings({
+            kind: args.kind,
+            symbol: args.symbol,
+            audience: args.audience,
+            limit: args.limit,
+          });
+          return {
+            title: "Investing Portfolio Briefings",
+            metadata: {
+              action: args.action,
+              count: briefings.length,
+              kind: args.kind,
+              symbol: args.symbol,
+              audience: args.audience,
+            },
+            output: JSON.stringify({ briefings, count: briefings.length }, null, 2),
+          };
+        }
+      }
+    },
+  }),
+};
+
 // =============================================================================
 // Nautilus Trading Tool
 // =============================================================================
@@ -1202,6 +1286,7 @@ export const INVESTING_TOOLS = [
   researchTool,
   valuationKernelTool,
   valuationPacketTool,
+  portfolioBriefingsTool,
   researchPlannerTool,
   researchExecutorTool,
   researchArtifactsTool,


### PR DESCRIPTION
## Summary
- add a persisted portfolio briefing read model for holdings and watchlist workflows
- expose create/read/list surfaces in the investing CLI and 
- wire the morning investing brief to render the new portfolio briefing and document the contract

## Validation
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- bun test --cwd packages/zee test/investing/portfolio-briefings.test.ts test/investing/thesis-ledger.test.ts
- CI=true bun test --cwd packages/zee --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh
- zee investing briefing create --json

Closes #512