### PR TITLE
feat(#513): add earnings research packets

### DIFF
--- a/docs/architecture/investing-earnings-packets.md
+++ b/docs/architecture/investing-earnings-packets.md
@@ -1,0 +1,75 @@
+# Investing Earnings Packets
+
+This slice closes `#513`.
+
+## Implementation plan
+
+- reuse persisted research executions and artifacts as the packet source of truth
+- join those executions with event delta intelligence and thesis-linked valuation state
+- expose one operator surface for create/read/list/export instead of forcing manual assembly
+
+## Contract
+
+State file:
+
+- `~/.local/state/zee/investing/earnings-packets.json`
+
+Each packet stores:
+
+- `schemaVersion`
+  - current value: `earnings-packet.v1`
+- `workflow`
+  - `earnings-preview` or `earnings-review`
+- `status`
+  - `ready` or `degraded`
+- `summary`
+  - concise packet outcome across catalysts, risks, and valuation context
+- `catalysts[]`
+  - event delta records selected for the relevant earnings mode
+- `risks[]`
+  - thesis watchpoints, negative event deltas, and research diagnostics
+- `valuation`
+  - current thesis-linked valuation snapshot plus comparison against the most recent prior packet
+- `sections[]`
+  - operator sections for overview, synthesis, catalysts, risks, valuation change, evidence, and diagnostics
+
+## Inputs
+
+The packet is built from already-persisted workflow state:
+
+- research execution and artifact output for the chosen earnings execution
+- event delta intelligence in `pre-earnings` or `post-earnings` mode
+- thesis ledger state, including the latest linked valuation snapshot
+
+That keeps packet generation deterministic:
+
+- no new research run is required to create a packet
+- valuation change reporting is anchored to persisted thesis state instead of freeform notes
+
+## Tool surface
+
+The operator surface is `zee:invest-earnings-packets`.
+
+Supported actions:
+
+- `create`
+  - inputs: `executionId`, optional `overwrite`
+- `read`
+  - inputs: `packetId`
+- `list`
+  - inputs: optional `symbol`, `workflow`, `executionId`, `limit`
+- `export`
+  - inputs: `packetId`, `format`
+
+The CLI mirror is `zee investing earnings-packet ...`.
+
+## Telemetry
+
+This slice emits:
+
+- `investing.earnings.packet`
+  - one event per persisted earnings packet
+  - metadata includes symbol, workflow, packet status, catalyst count, risk count, and valuation linkage
+- `investing.earnings.packet.export`
+  - one event per operator export
+  - metadata includes workflow, symbol, format, and export count

--- a/packages/zee/src/cli/cmd/investing.ts
+++ b/packages/zee/src/cli/cmd/investing.ts
@@ -32,6 +32,16 @@ import {
   type InvestingPortfolioBriefingAudience,
   type InvestingPortfolioBriefingKind,
 } from "@root/domain/investing/briefings"
+import {
+  createInvestingEarningsPacket,
+  exportInvestingEarningsPacket,
+  getInvestingEarningsPacket,
+  INVESTING_EARNINGS_PACKET_WORKFLOWS,
+  listInvestingEarningsPackets,
+  type InvestingEarningsPacketWorkflow,
+} from "@root/domain/investing/earnings-packets"
+import { getInvestingResearchExecution } from "@root/domain/investing/executor"
+import { getInvestingResearchPlan } from "@root/domain/investing/planner"
 
 const InvestingIngestStatusCommand = cmd({
   command: "status",
@@ -355,6 +365,193 @@ const InvestingThesisCommand = cmd({
   async handler() {},
 })
 
+const InvestingEarningsPacketCreateCommand = cmd({
+  command: "create <executionId>",
+  describe: "create a persisted pre or post earnings packet from a research execution",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("executionId", {
+        type: "string",
+        demandOption: true,
+        describe: "persisted research execution identifier",
+      })
+      .option("overwrite", {
+        type: "boolean",
+        default: false,
+        describe: "regenerate the packet even if one already exists",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: { executionId?: string; overwrite?: boolean; json?: boolean }) => {
+    if (!args.executionId) {
+      throw new Error("executionId is required")
+    }
+    const execution = getInvestingResearchExecution(args.executionId)
+    if (!execution) {
+      console.log(JSON.stringify({ error: `Research execution not found: ${args.executionId}` }, null, 2))
+      return
+    }
+
+    const plan = getInvestingResearchPlan(execution.planId)
+    const task = plan?.tasks.find((entry) => entry.id === execution.taskId)
+    if (!plan || !task) {
+      console.log(JSON.stringify({ error: `Research plan context not found for execution: ${args.executionId}` }, null, 2))
+      return
+    }
+
+    const packet = await createInvestingEarningsPacket({
+      execution,
+      plan,
+      task,
+      overwrite: args.overwrite,
+    })
+    if (args.json) {
+      console.log(JSON.stringify(packet, null, 2))
+      return
+    }
+
+    console.log(`${packet.id}`)
+    console.log(`- workflow=${packet.workflow} symbol=${packet.symbol} status=${packet.status}`)
+    console.log(`- summary=${packet.summary}`)
+    console.log(
+      `- coverage catalysts=${packet.catalysts.length} risks=${packet.risks.length} citations=${packet.citations.length}`,
+    )
+  },
+})
+
+const InvestingEarningsPacketReadCommand = cmd({
+  command: "read <packetId>",
+  describe: "read one persisted earnings packet",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("packetId", {
+        type: "string",
+        demandOption: true,
+        describe: "persisted earnings packet identifier",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: { packetId?: string; json?: boolean }) => {
+    if (!args.packetId) {
+      throw new Error("packetId is required")
+    }
+    const packet = getInvestingEarningsPacket(args.packetId)
+    const payload = packet ?? { error: `Earnings packet not found: ${args.packetId}` }
+    if (args.json || !packet) {
+      console.log(JSON.stringify(payload, null, 2))
+      return
+    }
+
+    console.log(`${packet.id}`)
+    console.log(`- workflow=${packet.workflow} symbol=${packet.symbol} status=${packet.status}`)
+    console.log(`- summary=${packet.summary}`)
+    for (const section of packet.sections) {
+      console.log(`\n${section.title}`)
+      console.log(section.body)
+    }
+  },
+})
+
+const InvestingEarningsPacketListCommand = cmd({
+  command: "list",
+  describe: "list persisted earnings packets",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("symbol", {
+        type: "string",
+        describe: "optional symbol filter",
+      })
+      .option("workflow", {
+        type: "string",
+        choices: [...INVESTING_EARNINGS_PACKET_WORKFLOWS],
+        describe: "optional workflow filter",
+      })
+      .option("execution-id", {
+        type: "string",
+        describe: "optional execution filter",
+      })
+      .option("limit", {
+        type: "number",
+        default: 10,
+        describe: "maximum number of packets to return",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: {
+    symbol?: string
+    workflow?: string
+    executionId?: string
+    limit?: number
+    json?: boolean
+  }) => {
+    const packets = listInvestingEarningsPackets({
+      symbol: args.symbol,
+      workflow: args.workflow as InvestingEarningsPacketWorkflow | undefined,
+      executionId: args.executionId,
+      limit: args.limit,
+    })
+    if (args.json) {
+      console.log(JSON.stringify({ packets, count: packets.length }, null, 2))
+      return
+    }
+    for (const packet of packets) {
+      console.log(
+        `- ${packet.id}: workflow=${packet.workflow} symbol=${packet.symbol} status=${packet.status} catalysts=${packet.catalysts.length} risks=${packet.risks.length} summary=${packet.summary}`,
+      )
+    }
+  },
+})
+
+const InvestingEarningsPacketExportCommand = cmd({
+  command: "export <packetId>",
+  describe: "export one persisted earnings packet",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("packetId", {
+        type: "string",
+        demandOption: true,
+        describe: "persisted earnings packet identifier",
+      })
+      .option("format", {
+        type: "string",
+        choices: ["json", "markdown"],
+        default: "json",
+        describe: "export format",
+      }),
+  handler: async (args: { packetId?: string; format?: string }) => {
+    if (!args.packetId) {
+      throw new Error("packetId is required")
+    }
+    const exported = exportInvestingEarningsPacket({
+      packetId: args.packetId,
+      format: (args.format as "json" | "markdown" | undefined) ?? "json",
+    })
+    console.log(exported.content)
+  },
+})
+
+const InvestingEarningsPacketCommand = cmd({
+  command: "earnings-packet",
+  describe: "persisted pre and post earnings research packets",
+  builder: (yargs: Argv) =>
+    yargs
+      .command(InvestingEarningsPacketCreateCommand)
+      .command(InvestingEarningsPacketReadCommand)
+      .command(InvestingEarningsPacketListCommand)
+      .command(InvestingEarningsPacketExportCommand)
+      .demandCommand(),
+  async handler() {},
+})
+
 const InvestingBriefingCreateCommand = cmd({
   command: "create",
   describe: "create a persisted daily portfolio briefing",
@@ -533,6 +730,7 @@ export const InvestingCommand = cmd({
       .command(InvestingEntityCommand)
       .command(InvestingEventCommand)
       .command(InvestingThesisCommand)
+      .command(InvestingEarningsPacketCommand)
       .command(InvestingBriefingCommand)
       .demandCommand(),
   async handler() {},

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -66,6 +66,8 @@ export type FluxKind =
   | "investing.valuation.sensitivity"
   | "investing.valuation.packet"
   | "investing.valuation.packet.export"
+  | "investing.earnings.packet"
+  | "investing.earnings.packet.export"
   | "investing.thesis.record"
   | "investing.thesis.revision"
   | "investing.thesis.confidence"

--- a/packages/zee/test/investing/earnings-packets.test.ts
+++ b/packages/zee/test/investing/earnings-packets.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import { mkdirSync } from "node:fs"
+import path from "node:path"
+import { FluxRecorder } from "../../src/flux"
+import { normalizeInvestingConnectorEntities } from "../../src/investing/entities"
+import { classifyInvestingConnectorEvents, upsertInvestingEvents } from "../../src/investing/events"
+import { tmpdir } from "../fixture/fixture"
+import { createInvestingResearchArtifact } from "../../../../src/domain/investing/artifacts"
+import {
+  createInvestingEarningsPacket,
+  getInvestingEarningsPacket,
+  getInvestingEarningsPacketStateFile,
+} from "../../../../src/domain/investing/earnings-packets"
+import {
+  getInvestingResearchExecutionStateFile,
+  type InvestingResearchExecution,
+} from "../../../../src/domain/investing/executor"
+import { createInvestingResearchPlan } from "../../../../src/domain/investing/planner"
+import { earningsPacketTool } from "../../../../src/domain/investing/tools"
+import {
+  recordInvestingThesisRevision,
+  syncInvestingThesisContext,
+  thesisKeyForSymbol,
+} from "../../../../src/domain/investing/thesis"
+
+function makeToolContext() {
+  return {
+    sessionId: "session-1",
+    messageId: "message-1",
+    agent: "zee",
+    abort: new AbortController().signal,
+    metadata: () => {},
+  }
+}
+
+async function seedEventDelta(symbol: string, headline: string) {
+  const events = classifyInvestingConnectorEvents({
+    connector: "news",
+    entities: normalizeInvestingConnectorEntities({
+      connector: "news",
+      collectedAt: "2026-03-15T10:00:00.000Z",
+      data: [
+        {
+          symbol,
+          articleId: `${symbol.toLowerCase()}-${headline.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+          publishedAt: "2026-03-15T09:30:00.000Z",
+          title: headline,
+          summary: `${headline} for ${symbol}.`,
+          sector: "Technology",
+        },
+      ],
+    }),
+  })
+  await upsertInvestingEvents({ events })
+}
+
+function seedThesis(symbol: string, summary: string, signal: "balanced" | "re-rate-up", upsidePercent: number) {
+  const thesisKey = thesisKeyForSymbol(symbol)
+  syncInvestingThesisContext({
+    thesisKey,
+    symbol,
+    summary,
+    valuation: {
+      valuationCaseId: `valuation_case:equity:${symbol.toLowerCase()}:base`,
+      packetId: `valuation-packet-${symbol.toLowerCase()}-${signal}`,
+      runId: `valuation-run-${symbol.toLowerCase()}-${signal}`,
+      signal,
+      fairValue: 100 + upsidePercent,
+      currentPrice: 100,
+      upsidePercent,
+    },
+  })
+  recordInvestingThesisRevision({
+    thesisKey,
+    symbol,
+    changeType: "refresh",
+    summary,
+    thesis: `${summary} Thesis body for ${symbol}.`,
+    conviction: signal === "re-rate-up" ? "high" : "medium",
+    posture: signal === "re-rate-up" ? "bullish" : "neutral",
+    evidence: [
+      {
+        kind: "research-evidence",
+        id: `evidence-${symbol.toLowerCase()}-${signal}`,
+        label: `[E1] Research summary for ${symbol}`,
+        link: `evidence:research-${symbol}:E1`,
+        toolId: "zee:invest-research",
+      },
+      {
+        kind: "valuation-packet",
+        id: `valuation-packet-${symbol.toLowerCase()}-${signal}`,
+        label: `Valuation packet for ${symbol}`,
+        link: `valuation-packet:valuation-packet-${symbol.toLowerCase()}-${signal}`,
+        toolId: "zee:invest-valuation",
+      },
+    ],
+    valuation: {
+      valuationCaseId: `valuation_case:equity:${symbol.toLowerCase()}:base`,
+      packetId: `valuation-packet-${symbol.toLowerCase()}-${signal}`,
+      runId: `valuation-run-${symbol.toLowerCase()}-${signal}`,
+      signal,
+      fairValue: 100 + upsidePercent,
+      currentPrice: 100,
+      upsidePercent,
+    },
+  })
+}
+
+function makeExecution(input: {
+  id: string
+  planId: string
+  taskId: string
+  workflow: string
+  symbol: string
+  synthesis: string
+}): InvestingResearchExecution {
+  return {
+    id: input.id,
+    planId: input.planId,
+    taskId: input.taskId,
+    workflow: input.workflow,
+    status: "ok",
+    startedAt: "2026-03-15T10:00:00.000Z",
+    finishedAt: "2026-03-15T10:05:00.000Z",
+    synthesis: input.synthesis,
+    provenance: null,
+    evidence: [
+      {
+        id: `${input.id}:E1`,
+        citation: "E1",
+        link: `evidence:${input.id}:E1`,
+        toolId: "zee:invest-research",
+        sourceLabel: "Research endpoint",
+        args: { symbol: input.symbol },
+        collectedAt: "2026-03-15T10:01:00.000Z",
+        status: "completed",
+        summary: `${input.symbol} setup summary`,
+        data: { symbol: input.symbol, summary: `${input.symbol} research summary` },
+      },
+      {
+        id: `${input.id}:E2`,
+        citation: "E2",
+        link: `evidence:${input.id}:E2`,
+        toolId: "zee:invest-valuation",
+        sourceLabel: "Investing Valuation Kernel",
+        args: { symbol: input.symbol },
+        collectedAt: "2026-03-15T10:02:00.000Z",
+        status: "completed",
+        summary: `${input.symbol} valuation snapshot`,
+        data: {
+          id: `valuation-run-${input.symbol.toLowerCase()}`,
+          valuationCaseId: `valuation_case:equity:${input.symbol.toLowerCase()}:base`,
+          blendedFairValue: 125,
+          currentPrice: 100,
+          upsidePercent: 25,
+          thesisContext: {
+            signal: "re-rate-up",
+          },
+        },
+      },
+    ],
+  }
+}
+
+async function persistExecution(execution: InvestingResearchExecution): Promise<void> {
+  const stateFile = getInvestingResearchExecutionStateFile()
+  mkdirSync(path.dirname(stateFile), { recursive: true })
+  await Bun.write(
+    stateFile,
+    JSON.stringify({
+      version: 1,
+      executions: [execution],
+    }),
+  )
+}
+
+async function withEarningsPacketState<T>(fn: () => Promise<T>): Promise<T> {
+  await using dir = await tmpdir()
+  const originalStateHome = process.env.XDG_STATE_HOME
+  process.env.XDG_STATE_HOME = dir.path
+  try {
+    return await fn()
+  } finally {
+    if (originalStateHome === undefined) {
+      delete process.env.XDG_STATE_HOME
+    } else {
+      process.env.XDG_STATE_HOME = originalStateHome
+    }
+  }
+}
+
+describe("investing earnings packets", () => {
+  test("creates preview and review packets with catalyst, risk, and valuation-change context", async () => {
+    await withEarningsPacketState(async () => {
+      const recordSpy = spyOn(FluxRecorder, "record")
+
+      seedThesis("NVDA", "NVDA enters earnings with a balanced setup.", "balanced", 10)
+      await seedEventDelta("NVDA", "NVDA raises guidance ahead of earnings")
+
+      const previewPlan = createInvestingResearchPlan({
+        objective: "Prepare a pre-earnings preview for NVDA",
+      })
+      const previewTask = previewPlan.tasks.find((task) => task.id === "preview-brief")
+      if (!previewTask) throw new Error("preview task should exist")
+      const previewExecution = makeExecution({
+        id: "research-execution-preview",
+        planId: previewPlan.id,
+        taskId: previewTask.id,
+        workflow: previewPlan.workflow,
+        symbol: "NVDA",
+        synthesis: "Preview packet captures the setup, catalysts, and open questions for the call.",
+      })
+      const previewArtifact = createInvestingResearchArtifact({
+        execution: previewExecution,
+        plan: previewPlan,
+        task: previewTask,
+      })
+      previewExecution.artifactId = previewArtifact.id
+
+      const previewPacket = await createInvestingEarningsPacket({
+        execution: previewExecution,
+        plan: previewPlan,
+        task: previewTask,
+      })
+
+      expect(previewPacket.workflow).toBe("earnings-preview")
+      expect(previewPacket.catalysts.length).toBeGreaterThan(0)
+      expect(previewPacket.risks.length).toBeGreaterThan(0)
+      expect(previewPacket.sections.map((section) => section.title)).toEqual([
+        "Overview",
+        "Synthesis",
+        "Catalysts",
+        "Risks",
+        "Valuation Change",
+        "Evidence",
+      ])
+
+      seedThesis("NVDA", "NVDA exits earnings with a cleaner upside setup.", "re-rate-up", 25)
+      await seedEventDelta("NVDA", "NVDA posts a strong quarter and lifts guidance")
+
+      const reviewPlan = createInvestingResearchPlan({
+        objective: "Prepare a post earnings review for NVDA",
+      })
+      const reviewTask = reviewPlan.tasks.find((task) => task.id === "review-brief")
+      if (!reviewTask) throw new Error("review task should exist")
+      const reviewExecution = makeExecution({
+        id: "research-execution-review",
+        planId: reviewPlan.id,
+        taskId: reviewTask.id,
+        workflow: reviewPlan.workflow,
+        symbol: "NVDA",
+        synthesis: "Review packet captures the realized result, valuation change, and follow-up work.",
+      })
+      const reviewArtifact = createInvestingResearchArtifact({
+        execution: reviewExecution,
+        plan: reviewPlan,
+        task: reviewTask,
+      })
+      reviewExecution.artifactId = reviewArtifact.id
+
+      const reviewPacket = await createInvestingEarningsPacket({
+        execution: reviewExecution,
+        plan: reviewPlan,
+        task: reviewTask,
+      })
+
+      expect(reviewPacket.workflow).toBe("earnings-review")
+      expect(reviewPacket.valuation.previousPacketId).toBe(previewPacket.id)
+      expect(reviewPacket.valuation.upsidePercentDelta).toBe(15)
+      expect(reviewPacket.valuation.narrative).toContain("re-rate-up")
+      expect(getInvestingEarningsPacket(reviewPacket.id)?.id).toBe(reviewPacket.id)
+      expect(await Bun.file(getInvestingEarningsPacketStateFile()).exists()).toBe(true)
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.earnings.packet")).toBe(true)
+    })
+  })
+
+  test("tool surface can create, read, list, and export earnings packets", async () => {
+    await withEarningsPacketState(async () => {
+      const recordSpy = spyOn(FluxRecorder, "record")
+
+      seedThesis("NVDA", "NVDA enters earnings with an improving setup.", "re-rate-up", 25)
+      await seedEventDelta("NVDA", "NVDA raises guidance ahead of earnings")
+
+      const plan = createInvestingResearchPlan({
+        objective: "Prepare a pre-earnings preview for NVDA",
+      })
+      const task = plan.tasks.find((entry) => entry.id === "preview-brief")
+      if (!task) throw new Error("preview task should exist")
+
+      const execution = makeExecution({
+        id: "research-execution-tool",
+        planId: plan.id,
+        taskId: task.id,
+        workflow: plan.workflow,
+        symbol: "NVDA",
+        synthesis: "Tool packet captures the setup for delivery.",
+      })
+      const artifact = createInvestingResearchArtifact({
+        execution,
+        plan,
+        task,
+      })
+      execution.artifactId = artifact.id
+      await persistExecution(execution)
+
+      const runtime = await earningsPacketTool.init()
+      const ctx = makeToolContext()
+
+      const createResult = await runtime.execute(
+        {
+          action: "create",
+          executionId: execution.id,
+        },
+        ctx,
+      )
+      const created = JSON.parse(createResult.output) as { id: string; executionId: string }
+      expect(created.executionId).toBe(execution.id)
+
+      const readResult = await runtime.execute(
+        {
+          action: "read",
+          packetId: created.id,
+        },
+        ctx,
+      )
+      expect(JSON.parse(readResult.output)).toMatchObject({
+        id: created.id,
+      })
+
+      const listResult = await runtime.execute(
+        {
+          action: "list",
+          symbol: "NVDA",
+          workflow: "earnings-preview",
+          limit: 5,
+        },
+        ctx,
+      )
+      const listed = JSON.parse(listResult.output) as {
+        count: number
+        packets: Array<{ id: string }>
+      }
+      expect(listed.count).toBeGreaterThan(0)
+      expect(listed.packets.some((entry) => entry.id === created.id)).toBe(true)
+
+      const exportResult = await runtime.execute(
+        {
+          action: "export",
+          packetId: created.id,
+          format: "markdown",
+        },
+        ctx,
+      )
+      expect(exportResult.output).toContain("# Earnings Preview Packet: NVDA")
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.earnings.packet.export")).toBe(true)
+    })
+  })
+})

--- a/src/domain/investing/earnings-packets.ts
+++ b/src/domain/investing/earnings-packets.ts
@@ -1,0 +1,655 @@
+/**
+ * Investing Earnings Packets
+ *
+ * Persists pre and post earnings packets tied to catalysts, risks, and
+ * valuation changes so portfolio operators can review one stable artifact
+ * instead of stitching together event deltas, thesis state, and research
+ * outputs by hand.
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { FluxRecorder } from "../../../packages/zee/src/flux";
+import {
+  buildInvestingEventDeltaBrief,
+  type InvestingEventDeltaItem,
+} from "../../../packages/zee/src/investing/briefing-deltas";
+import { Log } from "../../../packages/zee/src/util/log";
+import {
+  getInvestingResearchArtifact,
+  type InvestingResearchArtifactDiagnostic,
+} from "./artifacts";
+import type { InvestingResearchExecution } from "./executor";
+import type { InvestingResearchPlan, InvestingResearchTask } from "./planner";
+import {
+  getInvestingThesis,
+  thesisKeyForSymbol,
+  type InvestingThesisValuationSnapshot,
+} from "./thesis";
+
+const log = Log.create({ service: "investing:earnings-packets" });
+
+export const INVESTING_EARNINGS_PACKET_WORKFLOWS = [
+  "earnings-preview",
+  "earnings-review",
+] as const;
+
+export type InvestingEarningsPacketWorkflow =
+  (typeof INVESTING_EARNINGS_PACKET_WORKFLOWS)[number];
+
+export const INVESTING_EARNINGS_PACKET_STATUSES = [
+  "ready",
+  "degraded",
+] as const;
+
+export type InvestingEarningsPacketStatus =
+  (typeof INVESTING_EARNINGS_PACKET_STATUSES)[number];
+
+type ExportFormat = "json" | "markdown";
+
+export interface InvestingEarningsPacketCatalyst {
+  eventId: string;
+  symbol: string;
+  asOf: string;
+  headline: string;
+  delta: string;
+  classification: InvestingEventDeltaItem["classification"];
+  direction: InvestingEventDeltaItem["direction"];
+  materialityBand: InvestingEventDeltaItem["materialityBand"];
+  materialityScore: number;
+  implications: string[];
+}
+
+export interface InvestingEarningsPacketRisk {
+  id: string;
+  source: "thesis-watchpoint" | "event-delta" | "diagnostic";
+  summary: string;
+  detail?: string;
+}
+
+export interface InvestingEarningsPacketCitation {
+  citation: string;
+  link: string;
+  toolId: string;
+  sourceLabel: string;
+  status: InvestingResearchExecution["status"] | "completed" | "error";
+}
+
+export interface InvestingEarningsPacketSection {
+  id: string;
+  title: string;
+  body: string;
+  citations: string[];
+}
+
+export interface InvestingEarningsPacketValuationChange {
+  basis: "thesis-ledger";
+  current: InvestingThesisValuationSnapshot | null;
+  previousPacketId?: string;
+  previousWorkflow?: InvestingEarningsPacketWorkflow;
+  previous: InvestingThesisValuationSnapshot | null;
+  signalChanged: boolean;
+  upsidePercentDelta: number | null;
+  narrative: string;
+}
+
+export interface InvestingEarningsPacket {
+  id: string;
+  schemaVersion: "earnings-packet.v1";
+  status: InvestingEarningsPacketStatus;
+  workflow: InvestingEarningsPacketWorkflow;
+  symbol: string;
+  planId: string;
+  taskId: string;
+  executionId: string;
+  artifactId?: string;
+  createdAt: string;
+  updatedAt: string;
+  title: string;
+  objective: string;
+  summary: string;
+  catalysts: InvestingEarningsPacketCatalyst[];
+  risks: InvestingEarningsPacketRisk[];
+  valuation: InvestingEarningsPacketValuationChange;
+  citations: InvestingEarningsPacketCitation[];
+  diagnostics: InvestingResearchArtifactDiagnostic[];
+  sections: InvestingEarningsPacketSection[];
+  audit: {
+    generatedAt: string;
+    lastExportedAt?: string;
+    exportCount: number;
+  };
+}
+
+type PacketState = {
+  version: 1;
+  packets: InvestingEarningsPacket[];
+};
+
+type CreateInvestingEarningsPacketInput = {
+  execution: InvestingResearchExecution;
+  plan: InvestingResearchPlan;
+  task: InvestingResearchTask;
+  overwrite?: boolean;
+};
+
+function getPacketStateDir(): string {
+  const stateDir = process.env.XDG_STATE_HOME
+    ? path.join(process.env.XDG_STATE_HOME, "zee")
+    : path.join(os.homedir(), ".local", "state", "zee");
+  return path.join(stateDir, "investing");
+}
+
+export function getInvestingEarningsPacketStateFile(): string {
+  return path.join(getPacketStateDir(), "earnings-packets.json");
+}
+
+function ensurePacketStateDir(): void {
+  mkdirSync(getPacketStateDir(), { recursive: true });
+}
+
+function readPacketState(): PacketState {
+  const filePath = getInvestingEarningsPacketStateFile();
+  if (!existsSync(filePath)) {
+    return { version: 1, packets: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as Partial<PacketState>;
+    return {
+      version: 1,
+      packets: Array.isArray(parsed.packets) ? parsed.packets : [],
+    };
+  } catch (error) {
+    log.warn("failed to read earnings packet state", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { version: 1, packets: [] };
+  }
+}
+
+function writePacketState(state: PacketState): void {
+  ensurePacketStateDir();
+  writeFileSync(getInvestingEarningsPacketStateFile(), JSON.stringify(state, null, 2) + "\n", "utf-8");
+}
+
+function normalizeSymbol(symbol: string): string {
+  return symbol.trim().toUpperCase();
+}
+
+function unique(items: string[]): string[] {
+  return [...new Set(items.filter(Boolean))];
+}
+
+function workflowLabel(workflow: InvestingEarningsPacketWorkflow): string {
+  return workflow === "earnings-preview" ? "Earnings Preview" : "Post-Earnings Review";
+}
+
+function eventDeltaModeForWorkflow(
+  workflow: InvestingEarningsPacketWorkflow,
+): "pre-earnings" | "post-earnings" {
+  return workflow === "earnings-preview" ? "pre-earnings" : "post-earnings";
+}
+
+function formatSignedDelta(value: number): string {
+  return `${value >= 0 ? "+" : ""}${value.toFixed(1)} pts`;
+}
+
+function citationsFromExecution(
+  execution: InvestingResearchExecution,
+): InvestingEarningsPacketCitation[] {
+  return execution.evidence.map((item) => ({
+    citation: item.citation,
+    link: item.link,
+    toolId: item.toolId,
+    sourceLabel: item.sourceLabel,
+    status: item.status,
+  }));
+}
+
+function buildValuationNarrative(input: {
+  current: InvestingThesisValuationSnapshot | null;
+  previous: InvestingThesisValuationSnapshot | null;
+}): {
+  signalChanged: boolean;
+  upsidePercentDelta: number | null;
+  narrative: string;
+} {
+  const signalChanged =
+    Boolean(input.current?.signal) &&
+    Boolean(input.previous?.signal) &&
+    input.current?.signal !== input.previous?.signal;
+  const upsidePercentDelta =
+    input.current?.upsidePercent != null && input.previous?.upsidePercent != null
+      ? input.current.upsidePercent - input.previous.upsidePercent
+      : null;
+
+  const parts: string[] = [];
+
+  if (input.current?.signal && input.previous?.signal) {
+    if (signalChanged) {
+      parts.push(
+        `Valuation signal moved from ${input.previous.signal} to ${input.current.signal}.`,
+      );
+    } else {
+      parts.push(`Valuation signal remains ${input.current.signal}.`);
+    }
+  } else if (input.current?.signal) {
+    parts.push(`Current valuation signal is ${input.current.signal}.`);
+  } else {
+    parts.push("No linked valuation signal is available for this packet.");
+  }
+
+  if (input.current?.upsidePercent != null && input.previous?.upsidePercent != null) {
+    parts.push(
+      `Upside moved ${formatSignedDelta(upsidePercentDelta ?? 0)} to ${input.current.upsidePercent.toFixed(1)}%.`,
+    );
+  } else if (input.current?.upsidePercent != null) {
+    parts.push(`Current valuation implies ${input.current.upsidePercent.toFixed(1)}% upside.`);
+  }
+
+  if (input.current?.valuationCaseId) {
+    parts.push(`Case: ${input.current.valuationCaseId}.`);
+  }
+
+  return {
+    signalChanged,
+    upsidePercentDelta,
+    narrative: parts.join(" "),
+  };
+}
+
+function buildCatalysts(
+  items: InvestingEventDeltaItem[],
+  symbol: string,
+): InvestingEarningsPacketCatalyst[] {
+  return items
+    .filter((item) => normalizeSymbol(item.symbol ?? symbol) === symbol)
+    .map((item) => ({
+      eventId: item.eventId,
+      symbol,
+      asOf: item.asOf,
+      headline: item.headline,
+      delta: item.delta,
+      classification: item.classification,
+      direction: item.direction,
+      materialityBand: item.materialityBand,
+      materialityScore: item.materialityScore,
+      implications: item.implications,
+    }));
+}
+
+function buildRisks(input: {
+  symbol: string;
+  watchpoints: string[];
+  catalysts: InvestingEarningsPacketCatalyst[];
+  diagnostics: InvestingResearchArtifactDiagnostic[];
+}): InvestingEarningsPacketRisk[] {
+  const risks: InvestingEarningsPacketRisk[] = [];
+
+  for (const watchpoint of input.watchpoints) {
+    risks.push({
+      id: `risk-watchpoint-${randomUUID().slice(0, 8)}`,
+      source: "thesis-watchpoint",
+      summary: watchpoint,
+    });
+  }
+
+  for (const catalyst of input.catalysts) {
+    if (catalyst.direction !== "negative" && catalyst.materialityBand !== "critical") continue;
+    risks.push({
+      id: `risk-event-${catalyst.eventId}`,
+      source: "event-delta",
+      summary: `${catalyst.headline} raises downside risk for ${input.symbol}.`,
+      detail: catalyst.implications.join(" "),
+    });
+  }
+
+  for (const diagnostic of input.diagnostics) {
+    risks.push({
+      id: `risk-diagnostic-${diagnostic.id}`,
+      source: "diagnostic",
+      summary: diagnostic.summary,
+      detail: diagnostic.operatorAction,
+    });
+  }
+
+  const deduped = new Map<string, InvestingEarningsPacketRisk>();
+  for (const risk of risks) {
+    deduped.set(`${risk.source}:${risk.summary}:${risk.detail ?? ""}`, risk);
+  }
+  return [...deduped.values()];
+}
+
+function buildSections(input: {
+  packet: Omit<InvestingEarningsPacket, "sections">;
+  synthesis: string;
+}): InvestingEarningsPacketSection[] {
+  const evidenceCitations = input.packet.citations.map((item) => item.citation);
+
+  const sections: InvestingEarningsPacketSection[] = [
+    {
+      id: "overview",
+      title: "Overview",
+      body: [
+        `Objective: ${input.packet.objective}`,
+        `Workflow: ${input.packet.workflow}`,
+        `Task: ${input.packet.taskId}`,
+        `Status: ${input.packet.status}`,
+        input.packet.summary,
+      ].join("\n"),
+      citations: [],
+    },
+    {
+      id: "synthesis",
+      title: "Synthesis",
+      body: input.synthesis,
+      citations: evidenceCitations,
+    },
+    {
+      id: "catalysts",
+      title: "Catalysts",
+      body:
+        input.packet.catalysts.length > 0
+          ? input.packet.catalysts
+              .map((catalyst) =>
+                [
+                  `- ${catalyst.headline}`,
+                  `  ${catalyst.classification} / ${catalyst.direction} / ${catalyst.materialityBand} ${catalyst.materialityScore}/100`,
+                  `  ${catalyst.delta}`,
+                  `  Implications: ${catalyst.implications.join(" | ") || "n/a"}`,
+                ].join("\n"),
+              )
+              .join("\n")
+          : "- No qualifying event deltas were available for this packet.",
+      citations: [],
+    },
+    {
+      id: "risks",
+      title: "Risks",
+      body:
+        input.packet.risks.length > 0
+          ? input.packet.risks
+              .map((risk) =>
+                [
+                  `- ${risk.summary}`,
+                  risk.detail ? `  Detail: ${risk.detail}` : null,
+                ]
+                  .filter(Boolean)
+                  .join("\n"),
+              )
+              .join("\n")
+          : "- No explicit risks were captured beyond the current packet evidence.",
+      citations: [],
+    },
+    {
+      id: "valuation",
+      title: "Valuation Change",
+      body: [
+        input.packet.valuation.narrative,
+        `Current fair value: ${input.packet.valuation.current?.fairValue ?? "n/a"}`,
+        `Current price: ${input.packet.valuation.current?.currentPrice ?? "n/a"}`,
+        `Previous packet: ${input.packet.valuation.previousPacketId ?? "none"}`,
+      ].join("\n"),
+      citations: evidenceCitations.filter((citation) =>
+        input.packet.citations.some(
+          (item) => item.citation === citation && item.toolId === "zee:invest-valuation",
+        ),
+      ),
+    },
+    {
+      id: "evidence",
+      title: "Evidence",
+      body:
+        input.packet.citations.length > 0
+          ? input.packet.citations
+              .map(
+                (citation) =>
+                  `- [${citation.citation}] ${citation.sourceLabel} (${citation.status}) via ${citation.toolId}`,
+              )
+              .join("\n")
+          : "- No evidence links were persisted.",
+      citations: evidenceCitations,
+    },
+  ];
+
+  if (input.packet.diagnostics.length > 0) {
+    sections.push({
+      id: "diagnostics",
+      title: "Diagnostics",
+      body: input.packet.diagnostics
+        .map((diagnostic) =>
+          [
+            `- ${diagnostic.summary}`,
+            `  Detail: ${diagnostic.detail}`,
+            `  Action: ${diagnostic.operatorAction}`,
+            diagnostic.command ? `  Command: ${diagnostic.command}` : null,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        )
+        .join("\n"),
+      citations: [],
+    });
+  }
+
+  return sections;
+}
+
+function renderPacketMarkdown(packet: InvestingEarningsPacket): string {
+  return [
+    `# ${packet.title}`,
+    "",
+    `- Symbol: ${packet.symbol}`,
+    `- Workflow: ${packet.workflow}`,
+    `- Status: ${packet.status}`,
+    `- Summary: ${packet.summary}`,
+    "",
+    ...packet.sections.flatMap((section) => [
+      `## ${section.title}`,
+      section.body,
+      "",
+    ]),
+  ]
+    .join("\n")
+    .trim();
+}
+
+function assertEarningsWorkflow(
+  workflow: string,
+): asserts workflow is InvestingEarningsPacketWorkflow {
+  if (
+    workflow !== "earnings-preview" &&
+    workflow !== "earnings-review"
+  ) {
+    throw new Error(`Unsupported earnings packet workflow: ${workflow}`);
+  }
+}
+
+export function findInvestingEarningsPacketByExecution(
+  executionId: string,
+): InvestingEarningsPacket | null {
+  const state = readPacketState();
+  return state.packets.find((packet) => packet.executionId === executionId) ?? null;
+}
+
+export async function createInvestingEarningsPacket(
+  input: CreateInvestingEarningsPacketInput,
+): Promise<InvestingEarningsPacket> {
+  assertEarningsWorkflow(input.plan.workflow);
+
+  const existing = findInvestingEarningsPacketByExecution(input.execution.id);
+  if (existing && !input.overwrite) {
+    return existing;
+  }
+
+  const symbol = normalizeSymbol(input.plan.symbols[0] ?? "");
+  if (!symbol) {
+    throw new Error("Earnings packets require a primary symbol.");
+  }
+
+  const state = readPacketState();
+  const artifact = input.execution.artifactId
+    ? getInvestingResearchArtifact(input.execution.artifactId)
+    : null;
+  const thesis = getInvestingThesis(thesisKeyForSymbol(symbol));
+  const eventDeltaBrief = await buildInvestingEventDeltaBrief({
+    mode: eventDeltaModeForWorkflow(input.plan.workflow),
+    symbols: [symbol],
+  });
+  const catalysts = buildCatalysts(eventDeltaBrief.items, symbol);
+  const diagnostics = artifact?.diagnostics ?? [];
+  const previousPacket =
+    state.packets.find(
+      (packet) =>
+        packet.symbol === symbol &&
+        packet.executionId !== input.execution.id,
+    ) ?? null;
+  const valuationSummary = buildValuationNarrative({
+    current: thesis?.valuation ?? null,
+    previous: previousPacket?.valuation.current ?? null,
+  });
+  const risks = buildRisks({
+    symbol,
+    watchpoints: thesis?.watchpoints ?? [],
+    catalysts,
+    diagnostics,
+  });
+  const createdAt = new Date().toISOString();
+  const status: InvestingEarningsPacketStatus =
+    input.execution.status === "ok" && diagnostics.length === 0 ? "ready" : "degraded";
+  const title = `${workflowLabel(input.plan.workflow)} Packet: ${symbol}`;
+  const summary = `${workflowLabel(input.plan.workflow)} packet for ${symbol} captured ${catalysts.length} catalyst(s), ${risks.length} risk item(s), and ${thesis?.valuation?.signal ?? "no linked"} valuation context.`;
+
+  const packetBase: Omit<InvestingEarningsPacket, "sections"> = {
+    id: existing?.id ?? `earnings-packet-${randomUUID().slice(0, 12)}`,
+    schemaVersion: "earnings-packet.v1",
+    status,
+    workflow: input.plan.workflow,
+    symbol,
+    planId: input.plan.id,
+    taskId: input.task.id,
+    executionId: input.execution.id,
+    artifactId: input.execution.artifactId,
+    createdAt: existing?.createdAt ?? createdAt,
+    updatedAt: createdAt,
+    title,
+    objective: input.plan.objective,
+    summary,
+    catalysts,
+    risks,
+    valuation: {
+      basis: "thesis-ledger",
+      current: thesis?.valuation ?? null,
+      previousPacketId: previousPacket?.id,
+      previousWorkflow: previousPacket?.workflow,
+      previous: previousPacket?.valuation.current ?? null,
+      signalChanged: valuationSummary.signalChanged,
+      upsidePercentDelta: valuationSummary.upsidePercentDelta,
+      narrative: valuationSummary.narrative,
+    },
+    citations: citationsFromExecution(input.execution),
+    diagnostics,
+    audit: {
+      generatedAt: existing?.audit.generatedAt ?? createdAt,
+      lastExportedAt: existing?.audit.lastExportedAt,
+      exportCount: existing?.audit.exportCount ?? 0,
+    },
+  };
+
+  const packet: InvestingEarningsPacket = {
+    ...packetBase,
+    sections: buildSections({
+      packet: packetBase,
+      synthesis: input.execution.synthesis,
+    }),
+  };
+
+  state.packets = [packet, ...state.packets.filter((entry) => entry.id !== packet.id)].slice(0, 300);
+  writePacketState(state);
+
+  FluxRecorder.record({
+    traceID: packet.id,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.earnings.packet",
+    status: packet.status === "ready" ? "ok" : "error",
+    method: existing ? "update" : "create",
+    path: packet.workflow,
+    route: packet.id,
+    metadata: {
+      symbol: packet.symbol,
+      planId: packet.planId,
+      taskId: packet.taskId,
+      executionId: packet.executionId,
+      status: packet.status,
+      schemaVersion: packet.schemaVersion,
+      catalystCount: packet.catalysts.length,
+      riskCount: packet.risks.length,
+      signal: packet.valuation.current?.signal,
+      previousPacketId: packet.valuation.previousPacketId,
+    },
+  });
+
+  return packet;
+}
+
+export function getInvestingEarningsPacket(
+  packetId: string,
+): InvestingEarningsPacket | null {
+  const state = readPacketState();
+  return state.packets.find((packet) => packet.id === packetId) ?? null;
+}
+
+export function listInvestingEarningsPackets(options?: {
+  symbol?: string;
+  workflow?: InvestingEarningsPacketWorkflow;
+  executionId?: string;
+  limit?: number;
+}): InvestingEarningsPacket[] {
+  const normalizedSymbol = options?.symbol ? normalizeSymbol(options.symbol) : undefined;
+  const state = readPacketState();
+  return state.packets
+    .filter((packet) => (normalizedSymbol ? packet.symbol === normalizedSymbol : true))
+    .filter((packet) => (options?.workflow ? packet.workflow === options.workflow : true))
+    .filter((packet) => (options?.executionId ? packet.executionId === options.executionId : true))
+    .slice(0, options?.limit ?? 20);
+}
+
+export function exportInvestingEarningsPacket(input: {
+  packetId: string;
+  format: ExportFormat;
+}): { packet: InvestingEarningsPacket; content: string } {
+  const state = readPacketState();
+  const packet = state.packets.find((entry) => entry.id === input.packetId);
+  if (!packet) {
+    throw new Error(`Earnings packet not found: ${input.packetId}`);
+  }
+
+  packet.audit.exportCount += 1;
+  packet.audit.lastExportedAt = new Date().toISOString();
+  writePacketState(state);
+
+  FluxRecorder.record({
+    traceID: packet.id,
+    direction: "internal",
+    domain: "investing",
+    kind: "investing.earnings.packet.export",
+    status: "ok",
+    method: "export",
+    path: input.format,
+    route: packet.id,
+    metadata: {
+      workflow: packet.workflow,
+      symbol: packet.symbol,
+      exportCount: packet.audit.exportCount,
+    },
+  });
+
+  return {
+    packet,
+    content: input.format === "markdown" ? renderPacketMarkdown(packet) : JSON.stringify(packet, null, 2),
+  };
+}

--- a/src/domain/investing/tools.ts
+++ b/src/domain/investing/tools.ts
@@ -45,6 +45,13 @@ import {
   listInvestingValuationPackets,
 } from "./valuation-packet";
 import {
+  createInvestingEarningsPacket,
+  exportInvestingEarningsPacket,
+  getInvestingEarningsPacket,
+  INVESTING_EARNINGS_PACKET_WORKFLOWS,
+  listInvestingEarningsPackets,
+} from "./earnings-packets";
+import {
   INVESTING_PORTFOLIO_BRIEFING_KINDS,
   createInvestingPortfolioBriefing,
   getInvestingPortfolioBriefing,
@@ -1036,6 +1043,132 @@ export const valuationPacketTool: ToolDefinition = {
   }),
 };
 
+const EarningsPacketParams = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("create"),
+    executionId: z.string().describe("Persisted research execution identifier"),
+    overwrite: z.boolean().optional().default(false).describe("Regenerate the packet even if one already exists"),
+  }),
+  z.object({
+    action: z.literal("read"),
+    packetId: z.string().describe("Persisted earnings packet identifier"),
+  }),
+  z.object({
+    action: z.literal("list"),
+    symbol: z.string().optional().describe("Optional symbol filter"),
+    workflow: z.enum(INVESTING_EARNINGS_PACKET_WORKFLOWS).optional().describe("Optional workflow filter"),
+    executionId: z.string().optional().describe("Optional execution filter"),
+    limit: z.number().min(1).max(100).default(10).describe("Maximum number of packets to return"),
+  }),
+  z.object({
+    action: z.literal("export"),
+    packetId: z.string().describe("Persisted earnings packet identifier"),
+    format: z.enum(["json", "markdown"]).default("json").describe("Export format"),
+  }),
+]);
+
+export const earningsPacketTool: ToolDefinition = {
+  id: "zee:invest-earnings-packets",
+  category: "domain",
+  init: async () => ({
+    description: `Create, inspect, list, and export pre and post earnings packets tied to catalysts, risks, and valuation changes.`,
+    parameters: EarningsPacketParams,
+    execute: async (args, ctx): Promise<ToolExecutionResult> => {
+      switch (args.action) {
+        case "create": {
+          ctx.metadata({ title: `Creating earnings packet for ${args.executionId}` });
+          const execution = getInvestingResearchExecution(args.executionId);
+          if (!execution) {
+            return {
+              title: "Investing Earnings Packets",
+              metadata: { action: args.action, executionId: args.executionId, found: false },
+              output: JSON.stringify({ error: `Research execution not found: ${args.executionId}` }, null, 2),
+            };
+          }
+
+          const plan = getInvestingResearchPlan(execution.planId);
+          const task = plan?.tasks.find((entry) => entry.id === execution.taskId);
+          if (!plan || !task) {
+            return {
+              title: "Investing Earnings Packets",
+              metadata: { action: args.action, executionId: args.executionId, found: false },
+              output: JSON.stringify(
+                { error: `Research plan context not found for execution: ${args.executionId}` },
+                null,
+                2,
+              ),
+            };
+          }
+
+          const packet = await createInvestingEarningsPacket({
+            execution,
+            plan,
+            task,
+            overwrite: args.overwrite,
+          });
+          return {
+            title: "Investing Earnings Packets",
+            metadata: {
+              action: args.action,
+              packetId: packet.id,
+              executionId: packet.executionId,
+              workflow: packet.workflow,
+              status: packet.status,
+            },
+            output: JSON.stringify(packet, null, 2),
+          };
+        }
+        case "read": {
+          ctx.metadata({ title: `Loading earnings packet ${args.packetId}` });
+          const packet = getInvestingEarningsPacket(args.packetId);
+          return {
+            title: "Investing Earnings Packets",
+            metadata: { action: args.action, packetId: args.packetId, found: Boolean(packet) },
+            output: JSON.stringify(packet ?? { error: `Earnings packet not found: ${args.packetId}` }, null, 2),
+          };
+        }
+        case "list": {
+          ctx.metadata({ title: "Listing earnings packets" });
+          const packets = listInvestingEarningsPackets({
+            symbol: args.symbol,
+            workflow: args.workflow,
+            executionId: args.executionId,
+            limit: args.limit,
+          });
+          return {
+            title: "Investing Earnings Packets",
+            metadata: {
+              action: args.action,
+              count: packets.length,
+              symbol: args.symbol,
+              workflow: args.workflow,
+              executionId: args.executionId,
+            },
+            output: JSON.stringify({ packets, count: packets.length }, null, 2),
+          };
+        }
+        case "export": {
+          ctx.metadata({ title: `Exporting earnings packet ${args.packetId}` });
+          const exported = exportInvestingEarningsPacket({
+            packetId: args.packetId,
+            format: args.format,
+          });
+          return {
+            title: "Investing Earnings Packets",
+            metadata: {
+              action: args.action,
+              packetId: args.packetId,
+              format: args.format,
+              exportCount: exported.packet.audit.exportCount,
+            },
+            output: exported.content,
+          };
+        }
+      }
+    },
+  }),
+};
+
 const PortfolioBriefingParams = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("create"),
@@ -1286,6 +1419,7 @@ export const INVESTING_TOOLS = [
   researchTool,
   valuationKernelTool,
   valuationPacketTool,
+  earningsPacketTool,
   portfolioBriefingsTool,
   researchPlannerTool,
   researchExecutorTool,


### PR DESCRIPTION
## Summary
- add persisted pre and post earnings packets built from research executions, event deltas, and thesis-linked valuation state
- expose create/read/list/export surfaces in the investing CLI and zee:invest-earnings-packets
- document the packet contract and add telemetry plus coverage for packet creation and export

## Validation
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- bun test --cwd packages/zee test/investing/earnings-packets.test.ts
- CI=true bun test --cwd packages/zee --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh
- XDG_STATE_HOME=/tmp/tmp.c5ICAhXkmj zee investing earnings-packet list --json

Closes #513