### PR TITLE
feat(#515): add investing eval harness

### DIFF
--- a/docs/architecture/investing-eval-harness.md
+++ b/docs/architecture/investing-eval-harness.md
@@ -1,0 +1,110 @@
+# Investing Eval Harness
+
+This slice closes `#515`.
+
+Zee now ships a persisted golden-set evaluation harness for investing research outputs. Operators can capture datasets from stable outputs, rerun the harness later, and detect drift without rebuilding the source workflows by hand.
+
+## State contract
+
+State file:
+
+- `~/.local/state/zee/investing/evals.json`
+
+The file stores:
+
+- `datasets[]`
+  - golden-set definitions with owner, description, cases, capture audit, and last run metadata
+- `runs[]`
+  - replay results with structural pass/fail totals and per-case checks
+
+## Supported source kinds
+
+Datasets can capture golden snapshots from:
+
+- `research-artifact`
+- `earnings-packet`
+- `portfolio-briefing`
+
+Each captured case stores a golden snapshot with:
+
+- `summary`
+- `sectionTitles[]`
+- `citationCount`
+- `diagnosticCount`
+- `updatedAt`
+- source metadata such as `workflow`, `status`, `kind`, and `symbols[]`
+
+## Harness checks
+
+Each eval run replays the current live source against the stored golden snapshot and emits per-case checks for:
+
+- summary equality
+- section-title equality
+- minimum citation count
+- maximum diagnostic count
+- status equality
+- symbol coverage equality
+- workflow equality when the source exposes one
+- freshness window when the dataset case configures `freshnessWithinHours`
+
+The current run contract includes:
+
+- `scores.structural`
+  - percent of cases that passed the golden-set replay
+- `scores.factuality`
+- `scores.consistency`
+- `scores.timeliness`
+
+Those three quality dimensions are intentionally `null` in this slice and become concrete in `#516`.
+
+## Operator surfaces
+
+Tool:
+
+- `zee:invest-evals`
+
+Actions:
+
+- `create-dataset`
+- `read-dataset`
+- `list-datasets`
+- `run-dataset`
+- `read-run`
+- `list-runs`
+
+CLI:
+
+```bash
+zee investing eval dataset create --name daily-goldens --description "Daily research goldens" --owner research-qa --case-file ./cases.json
+zee investing eval dataset list
+zee investing eval dataset read <datasetId>
+zee investing eval run create <datasetId>
+zee investing eval run read <runId>
+zee investing eval run list --dataset-id <datasetId>
+```
+
+`--case-file` must point to a JSON array shaped like:
+
+```json
+[
+  {
+    "label": "NVDA preview artifact",
+    "sourceKind": "research-artifact",
+    "sourceId": "research-artifact-123",
+    "expectations": {
+      "freshnessWithinHours": 48
+    }
+  }
+]
+```
+
+## Telemetry
+
+This slice emits:
+
+- `investing.eval.dataset`
+  - dataset creation and dataset read/list activity
+- `investing.eval.run`
+  - harness execution totals, pass/fail/error counts, and structural score
+
+That gives the evaluation epic a persisted baseline before the scorer and CI-gate slices land.

--- a/packages/zee/src/cli/cmd/investing.ts
+++ b/packages/zee/src/cli/cmd/investing.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs"
 import type { Argv } from "yargs"
 import { cmd } from "./cmd"
 import { getInvestingEntityCatalogStatus } from "@/investing/entities"
@@ -41,6 +42,17 @@ import {
   queryInvestingTheses,
   type InvestingThesisPortfolioRollupAudience,
 } from "@root/domain/investing/thesis-queries"
+import {
+  createInvestingEvalDataset,
+  getInvestingEvalDataset,
+  getInvestingEvalRun,
+  INVESTING_EVAL_RUN_STATUSES,
+  listInvestingEvalDatasets,
+  listInvestingEvalRuns,
+  runInvestingEvalDataset,
+  type InvestingEvalRunStatus,
+  type InvestingEvalSourceKind,
+} from "@root/domain/investing/evals"
 import {
   INVESTING_PORTFOLIO_BRIEFING_KINDS,
   createInvestingPortfolioBriefing,
@@ -370,9 +382,292 @@ const InvestingEventCommand = cmd({
   async handler() {},
 })
 
+function readEvalCasesFile(filePath: string): Array<{
+  label: string
+  sourceKind: InvestingEvalSourceKind
+  sourceId: string
+  expectations?: {
+    requiredSectionTitles?: string[]
+    minCitationCount?: number
+    maxDiagnosticCount?: number
+    freshnessWithinHours?: number
+  }
+}> {
+  const parsed = JSON.parse(readFileSync(filePath, "utf8")) as unknown
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Eval case file must contain a JSON array: ${filePath}`)
+  }
+  return parsed as Array<{
+    label: string
+    sourceKind: InvestingEvalSourceKind
+    sourceId: string
+    expectations?: {
+      requiredSectionTitles?: string[]
+      minCitationCount?: number
+      maxDiagnosticCount?: number
+      freshnessWithinHours?: number
+    }
+  }>
+}
+
 function thesisLookup(value: string): string {
   return value.startsWith("thesis:") ? value : value.toUpperCase()
 }
+
+const InvestingEvalDatasetCreateCommand = cmd({
+  command: "create",
+  describe: "create a golden-set eval dataset from persisted investing outputs",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("name", {
+        type: "string",
+        demandOption: true,
+        describe: "dataset name",
+      })
+      .option("description", {
+        type: "string",
+        demandOption: true,
+        describe: "dataset description",
+      })
+      .option("owner", {
+        type: "string",
+        demandOption: true,
+        describe: "owning team or operator",
+      })
+      .option("case-file", {
+        type: "string",
+        demandOption: true,
+        describe: "path to a JSON array of eval case definitions",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: { name?: string; description?: string; owner?: string; caseFile?: string; json?: boolean }) => {
+    if (!args.name || !args.description || !args.owner || !args.caseFile) {
+      throw new Error("name, description, owner, and case-file are required")
+    }
+    const dataset = createInvestingEvalDataset({
+      name: args.name,
+      description: args.description,
+      owner: args.owner,
+      cases: readEvalCasesFile(args.caseFile),
+    })
+    if (args.json) {
+      console.log(JSON.stringify(dataset, null, 2))
+      return
+    }
+
+    console.log(`${dataset.id}`)
+    console.log(`- owner=${dataset.owner} cases=${dataset.cases.length} runCount=${dataset.audit.runCount}`)
+    console.log(`- description=${dataset.description}`)
+  },
+})
+
+const InvestingEvalDatasetReadCommand = cmd({
+  command: "read <datasetId>",
+  describe: "read one persisted eval dataset",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("datasetId", {
+        type: "string",
+        demandOption: true,
+        describe: "eval dataset identifier",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: { datasetId?: string; json?: boolean }) => {
+    if (!args.datasetId) {
+      throw new Error("datasetId is required")
+    }
+    const dataset = getInvestingEvalDataset(args.datasetId)
+    const payload = dataset ?? { error: `Eval dataset not found: ${args.datasetId}` }
+    if (args.json || !dataset) {
+      console.log(JSON.stringify(payload, null, 2))
+      return
+    }
+
+    console.log(`${dataset.id}`)
+    console.log(`- owner=${dataset.owner} cases=${dataset.cases.length} lastRunId=${dataset.audit.lastRunId ?? "n/a"}`)
+    console.log(`- description=${dataset.description}`)
+  },
+})
+
+const InvestingEvalDatasetListCommand = cmd({
+  command: "list",
+  describe: "list persisted eval datasets",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("owner", {
+        type: "string",
+        describe: "optional owner filter",
+      })
+      .option("limit", {
+        type: "number",
+        default: 20,
+        describe: "maximum number of datasets to return",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: { owner?: string; limit?: number; json?: boolean }) => {
+    const datasets = listInvestingEvalDatasets({
+      owner: args.owner,
+      limit: args.limit,
+    })
+    if (args.json) {
+      console.log(JSON.stringify({ datasets, count: datasets.length }, null, 2))
+      return
+    }
+    for (const dataset of datasets) {
+      console.log(
+        `- ${dataset.id}: owner=${dataset.owner} cases=${dataset.cases.length} runCount=${dataset.audit.runCount} description=${dataset.description}`,
+      )
+    }
+  },
+})
+
+const InvestingEvalDatasetCommand = cmd({
+  command: "dataset",
+  describe: "golden-set eval datasets",
+  builder: (yargs: Argv) =>
+    yargs
+      .command(InvestingEvalDatasetCreateCommand)
+      .command(InvestingEvalDatasetReadCommand)
+      .command(InvestingEvalDatasetListCommand)
+      .demandCommand(),
+  async handler() {},
+})
+
+const InvestingEvalRunCreateCommand = cmd({
+  command: "create <datasetId>",
+  describe: "run the persisted eval harness for one dataset",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("datasetId", {
+        type: "string",
+        demandOption: true,
+        describe: "eval dataset identifier",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: { datasetId?: string; json?: boolean }) => {
+    if (!args.datasetId) {
+      throw new Error("datasetId is required")
+    }
+    const run = runInvestingEvalDataset({ datasetId: args.datasetId })
+    if (args.json) {
+      console.log(JSON.stringify(run, null, 2))
+      return
+    }
+
+    console.log(`${run.id}`)
+    console.log(`- status=${run.status} passRate=${run.totals.passRate}% structural=${run.scores.structural}`)
+    console.log(`- summary=${run.summary}`)
+  },
+})
+
+const InvestingEvalRunReadCommand = cmd({
+  command: "read <runId>",
+  describe: "read one persisted eval run",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("runId", {
+        type: "string",
+        demandOption: true,
+        describe: "eval run identifier",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: { runId?: string; json?: boolean }) => {
+    if (!args.runId) {
+      throw new Error("runId is required")
+    }
+    const run = getInvestingEvalRun(args.runId)
+    const payload = run ?? { error: `Eval run not found: ${args.runId}` }
+    if (args.json || !run) {
+      console.log(JSON.stringify(payload, null, 2))
+      return
+    }
+
+    console.log(`${run.id}`)
+    console.log(`- datasetId=${run.datasetId} status=${run.status} passRate=${run.totals.passRate}%`)
+    console.log(`- summary=${run.summary}`)
+  },
+})
+
+const InvestingEvalRunListCommand = cmd({
+  command: "list",
+  describe: "list persisted eval runs",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("dataset-id", {
+        type: "string",
+        describe: "optional dataset filter",
+      })
+      .option("status", {
+        type: "string",
+        choices: [...INVESTING_EVAL_RUN_STATUSES],
+        describe: "optional run-status filter",
+      })
+      .option("limit", {
+        type: "number",
+        default: 20,
+        describe: "maximum number of eval runs to return",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output as JSON",
+      }),
+  handler: async (args: { datasetId?: string; status?: string; limit?: number; json?: boolean }) => {
+    const runs = listInvestingEvalRuns({
+      datasetId: args.datasetId,
+      status: args.status as InvestingEvalRunStatus | undefined,
+      limit: args.limit,
+    })
+    if (args.json) {
+      console.log(JSON.stringify({ runs, count: runs.length }, null, 2))
+      return
+    }
+    for (const run of runs) {
+      console.log(
+        `- ${run.id}: datasetId=${run.datasetId} status=${run.status} passRate=${run.totals.passRate}% summary=${run.summary}`,
+      )
+    }
+  },
+})
+
+const InvestingEvalRunCommand = cmd({
+  command: "run",
+  describe: "golden-set eval runs",
+  builder: (yargs: Argv) =>
+    yargs
+      .command(InvestingEvalRunCreateCommand)
+      .command(InvestingEvalRunReadCommand)
+      .command(InvestingEvalRunListCommand)
+      .demandCommand(),
+  async handler() {},
+})
+
+const InvestingEvalCommand = cmd({
+  command: "eval",
+  describe: "research-output evaluation datasets and harness runs",
+  builder: (yargs: Argv) => yargs.command(InvestingEvalDatasetCommand).command(InvestingEvalRunCommand).demandCommand(),
+  async handler() {},
+})
 
 const InvestingThesisStatusCommand = cmd({
   command: "status",
@@ -1449,6 +1744,7 @@ export const InvestingCommand = cmd({
       .command(InvestingIngestCommand)
       .command(InvestingEntityCommand)
       .command(InvestingEventCommand)
+      .command(InvestingEvalCommand)
       .command(InvestingThesisCommand)
       .command(InvestingEarningsPacketCommand)
       .command(InvestingOpsCommand)

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -75,6 +75,8 @@ export type FluxKind =
   | "investing.thesis.confidence"
   | "investing.thesis.query"
   | "investing.thesis.rollup"
+  | "investing.eval.dataset"
+  | "investing.eval.run"
   | "investing.portfolio.briefing"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"

--- a/packages/zee/test/investing/evals.test.ts
+++ b/packages/zee/test/investing/evals.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import { readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { FluxRecorder } from "../../src/flux"
+import { tmpdir } from "../fixture/fixture"
+import {
+  createInvestingResearchArtifact,
+  getInvestingResearchArtifactStateFile,
+} from "../../../../src/domain/investing/artifacts"
+import { createInvestingPortfolioBriefing } from "../../../../src/domain/investing/briefings"
+import { createInvestingEvalDataset, runInvestingEvalDataset } from "../../../../src/domain/investing/evals"
+import { evalsTool } from "../../../../src/domain/investing/tools"
+import {
+  recordInvestingThesisRevision,
+  syncInvestingThesisContext,
+  thesisKeyForSymbol,
+} from "../../../../src/domain/investing/thesis"
+import type { InvestingResearchExecution } from "../../../../src/domain/investing/executor"
+import type { InvestingResearchPlan, InvestingResearchTask } from "../../../../src/domain/investing/planner"
+
+function makeToolContext() {
+  return {
+    sessionId: "session-1",
+    messageId: "message-1",
+    agent: "zee",
+    abort: new AbortController().signal,
+    metadata: () => {},
+  }
+}
+
+async function withEvalState<T>(fn: (root: string) => Promise<T>): Promise<T> {
+  await using dir = await tmpdir()
+  const originalStateHome = process.env.XDG_STATE_HOME
+  const originalPortfolioFile = process.env.ZEE_INVESTING_PORTFOLIO_FILE
+  const originalWatchlistFile = process.env.ZEE_INVESTING_WATCHLIST_FILE
+
+  process.env.XDG_STATE_HOME = dir.path
+  process.env.ZEE_INVESTING_PORTFOLIO_FILE = path.join(dir.path, "portfolio.json")
+  process.env.ZEE_INVESTING_WATCHLIST_FILE = path.join(dir.path, "watchlist.json")
+
+  try {
+    return await fn(dir.path)
+  } finally {
+    if (originalStateHome === undefined) delete process.env.XDG_STATE_HOME
+    else process.env.XDG_STATE_HOME = originalStateHome
+
+    if (originalPortfolioFile === undefined) delete process.env.ZEE_INVESTING_PORTFOLIO_FILE
+    else process.env.ZEE_INVESTING_PORTFOLIO_FILE = originalPortfolioFile
+
+    if (originalWatchlistFile === undefined) delete process.env.ZEE_INVESTING_WATCHLIST_FILE
+    else process.env.ZEE_INVESTING_WATCHLIST_FILE = originalWatchlistFile
+  }
+}
+
+function seedThesis(symbol: string) {
+  const thesisKey = thesisKeyForSymbol(symbol)
+  syncInvestingThesisContext({
+    thesisKey,
+    symbol,
+    summary: `${symbol} thesis context.`,
+    valuation: {
+      valuationCaseId: `valuation_case:equity:${symbol.toLowerCase()}:base`,
+      packetId: `valuation-packet-${symbol.toLowerCase()}`,
+      runId: `valuation-run-${symbol.toLowerCase()}`,
+      signal: "re-rate-up",
+      fairValue: 140,
+      currentPrice: 100,
+      upsidePercent: 40,
+    },
+  })
+  recordInvestingThesisRevision({
+    thesisKey,
+    symbol,
+    changeType: "initialize",
+    summary: `${symbol} thesis initialized.`,
+    thesis: `${symbol} thesis body.`,
+    conviction: "high",
+    posture: "bullish",
+    watchpoints: [`Track ${symbol} demand`],
+    valuation: {
+      valuationCaseId: `valuation_case:equity:${symbol.toLowerCase()}:base`,
+      packetId: `valuation-packet-${symbol.toLowerCase()}`,
+      runId: `valuation-run-${symbol.toLowerCase()}`,
+      signal: "re-rate-up",
+      fairValue: 140,
+      currentPrice: 100,
+      upsidePercent: 40,
+    },
+    evidence: [
+      {
+        kind: "research-evidence",
+        id: `evidence-${symbol.toLowerCase()}`,
+        label: `[E1] Research summary for ${symbol}`,
+        link: `evidence:${symbol}:E1`,
+        toolId: "zee:invest-research",
+      },
+      {
+        kind: "valuation-packet",
+        id: `valuation-packet-${symbol.toLowerCase()}`,
+        label: `Valuation packet for ${symbol}`,
+        link: `valuation-packet:valuation-packet-${symbol.toLowerCase()}`,
+        toolId: "zee:invest-valuation",
+      },
+    ],
+  })
+}
+
+function makeResearchArtifact(symbol: string) {
+  const timestamp = "2026-03-15T10:00:00.000Z"
+  const task: InvestingResearchTask = {
+    id: "brief-synthesis",
+    phase: "synthesis",
+    title: "Write preview brief",
+    description: `Synthesize the current preview view for ${symbol}.`,
+    toolIds: ["zee:invest-research", "zee:invest-market-data"],
+    dependsOn: [],
+    deliverable: "Preview synthesis with citations.",
+    status: "completed",
+  }
+  const plan: InvestingResearchPlan = {
+    id: `plan-${symbol.toLowerCase()}`,
+    objective: `Prepare the preview view for ${symbol}`,
+    workflow: "earnings-preview",
+    symbols: [symbol],
+    status: "active",
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    tasks: [task],
+  }
+  const execution: InvestingResearchExecution = {
+    id: `execution-${symbol.toLowerCase()}`,
+    planId: plan.id,
+    taskId: task.id,
+    workflow: plan.workflow,
+    status: "ok",
+    startedAt: timestamp,
+    finishedAt: timestamp,
+    synthesis: `${symbol} preview synthesis captures the setup, catalysts, and open questions.`,
+    provenance: null,
+    evidence: [
+      {
+        id: `evidence-${symbol.toLowerCase()}-research`,
+        citation: "E1",
+        link: `evidence:${symbol}:E1`,
+        toolId: "zee:invest-research",
+        sourceLabel: `${symbol} research endpoint`,
+        args: { symbol },
+        collectedAt: timestamp,
+        status: "completed",
+        summary: `${symbol} research summary`,
+        data: { symbol, summary: `${symbol} research summary` },
+      },
+      {
+        id: `evidence-${symbol.toLowerCase()}-market`,
+        citation: "E2",
+        link: `evidence:${symbol}:E2`,
+        toolId: "zee:invest-market-data",
+        sourceLabel: `${symbol} market data`,
+        args: { symbol },
+        collectedAt: timestamp,
+        status: "completed",
+        summary: `${symbol} market snapshot`,
+        data: { symbol, price: 100 },
+      },
+    ],
+  }
+
+  return createInvestingResearchArtifact({
+    execution,
+    plan,
+    task,
+  })
+}
+
+describe("investing eval harness", () => {
+  test("captures a golden-set dataset and runs the harness across persisted outputs", async () => {
+    await withEvalState(async (root) => {
+      const recordSpy = spyOn(FluxRecorder, "record")
+      writeFileSync(
+        path.join(root, "portfolio.json"),
+        JSON.stringify({ positions: [{ symbol: "NVDA", shares: 10, averageCost: 90 }] }, null, 2),
+      )
+      writeFileSync(path.join(root, "watchlist.json"), JSON.stringify({ symbols: ["AAPL"] }, null, 2))
+
+      seedThesis("NVDA")
+      const artifact = makeResearchArtifact("NVDA")
+      const briefing = await createInvestingPortfolioBriefing()
+
+      const dataset = createInvestingEvalDataset({
+        name: "daily-research-goldens",
+        description: "Golden-set coverage for daily research outputs.",
+        owner: "research-qa",
+        cases: [
+          {
+            label: "NVDA preview artifact",
+            sourceKind: "research-artifact",
+            sourceId: artifact.id,
+            expectations: { freshnessWithinHours: 48 },
+          },
+          {
+            label: "Daily portfolio briefing",
+            sourceKind: "portfolio-briefing",
+            sourceId: briefing.id,
+          },
+        ],
+      })
+      expect(dataset.cases).toHaveLength(2)
+      expect(dataset.audit.captureCount).toBe(2)
+      expect(dataset.cases[0]?.golden.sectionTitles).toContain("Synthesis")
+
+      const run = runInvestingEvalDataset({ datasetId: dataset.id })
+      expect(run.status).toBe("pass")
+      expect(run.totals.passCount).toBe(2)
+      expect(run.scores.structural).toBe(100)
+
+      const tool = await evalsTool.init()
+      const result = await tool.execute(
+        {
+          action: "list-runs",
+          datasetId: dataset.id,
+          limit: 10,
+        },
+        makeToolContext() as never,
+      )
+      const payload = JSON.parse(result.output)
+      expect(payload.count).toBe(1)
+      expect(payload.runs[0].status).toBe("pass")
+
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.eval.dataset")).toBe(true)
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.eval.run")).toBe(true)
+    })
+  })
+
+  test("flags drift when a golden-set source changes after capture", async () => {
+    await withEvalState(async () => {
+      const artifact = makeResearchArtifact("NVDA")
+      const dataset = createInvestingEvalDataset({
+        name: "artifact-drift",
+        description: "Detect summary drift in the research artifact golden set.",
+        owner: "research-qa",
+        cases: [
+          {
+            label: "NVDA preview artifact",
+            sourceKind: "research-artifact",
+            sourceId: artifact.id,
+          },
+        ],
+      })
+
+      const state = JSON.parse(readFileSync(getInvestingResearchArtifactStateFile(), "utf8")) as {
+        version: number
+        artifacts: Array<Record<string, unknown>>
+      }
+      state.artifacts[0] = {
+        ...state.artifacts[0],
+        summary: "Mutated summary that should fail the golden snapshot comparison.",
+      }
+      writeFileSync(getInvestingResearchArtifactStateFile(), JSON.stringify(state, null, 2) + "\n", "utf8")
+
+      const tool = await evalsTool.init()
+      const result = await tool.execute(
+        {
+          action: "run-dataset",
+          datasetId: dataset.id,
+        },
+        makeToolContext() as never,
+      )
+      const payload = JSON.parse(result.output)
+      expect(payload.status).toBe("fail")
+      expect(payload.results[0].checks.find((check: { id: string }) => check.id === "summary-match")?.passed).toBe(
+        false,
+      )
+      expect(payload.scores.structural).toBe(0)
+    })
+  })
+})

--- a/src/domain/investing/evals.ts
+++ b/src/domain/investing/evals.ts
@@ -1,0 +1,596 @@
+/**
+ * Investing Evaluation Datasets And Golden-Set Harness
+ *
+ * Persists reusable evaluation datasets tied to stable research outputs and
+ * runs a repeatable golden-set harness across those outputs without requiring
+ * downstream scorers yet.
+ */
+
+import { randomUUID } from "node:crypto"
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { FluxRecorder } from "../../../packages/zee/src/flux"
+import { Log } from "../../../packages/zee/src/util/log"
+import { getInvestingResearchArtifact, type InvestingResearchArtifact } from "./artifacts"
+import { getInvestingPortfolioBriefing, type InvestingPortfolioBriefing } from "./briefings"
+import { getInvestingEarningsPacket, type InvestingEarningsPacket } from "./earnings-packets"
+
+const log = Log.create({ service: "investing:evals" })
+
+export const INVESTING_EVAL_SOURCE_KINDS = ["research-artifact", "earnings-packet", "portfolio-briefing"] as const
+export type InvestingEvalSourceKind = (typeof INVESTING_EVAL_SOURCE_KINDS)[number]
+
+export const INVESTING_EVAL_RUN_STATUSES = ["pass", "fail", "error"] as const
+export type InvestingEvalRunStatus = (typeof INVESTING_EVAL_RUN_STATUSES)[number]
+
+export interface InvestingEvalGoldenSnapshot {
+  sourceKind: InvestingEvalSourceKind
+  sourceId: string
+  capturedAt: string
+  title: string
+  summary: string
+  sectionTitles: string[]
+  citationCount: number
+  diagnosticCount: number
+  updatedAt: string
+  metadata: {
+    schemaVersion?: string
+    status?: string
+    workflow?: string
+    kind?: string
+    symbols: string[]
+  }
+}
+
+export interface InvestingEvalCaseExpectations {
+  requiredSectionTitles: string[]
+  minCitationCount: number
+  maxDiagnosticCount: number
+  freshnessWithinHours?: number
+}
+
+export interface InvestingEvalDatasetCase {
+  id: string
+  label: string
+  sourceKind: InvestingEvalSourceKind
+  sourceId: string
+  golden: InvestingEvalGoldenSnapshot
+  expectations: InvestingEvalCaseExpectations
+}
+
+export interface InvestingEvalDataset {
+  id: string
+  schemaVersion: "investing-eval-dataset.v1"
+  name: string
+  description: string
+  owner: string
+  createdAt: string
+  updatedAt: string
+  cases: InvestingEvalDatasetCase[]
+  audit: {
+    captureCount: number
+    lastRunId?: string
+    runCount: number
+  }
+}
+
+export interface InvestingEvalCaseCheck {
+  id: string
+  label: string
+  passed: boolean
+  expected: string
+  actual: string
+}
+
+export interface InvestingEvalCaseResult {
+  caseId: string
+  label: string
+  sourceKind: InvestingEvalSourceKind
+  sourceId: string
+  status: InvestingEvalRunStatus
+  summary: string
+  checks: InvestingEvalCaseCheck[]
+  live: InvestingEvalGoldenSnapshot | null
+  passCount: number
+  failCount: number
+}
+
+export interface InvestingEvalRunScores {
+  structural: number
+  factuality: number | null
+  consistency: number | null
+  timeliness: number | null
+}
+
+export interface InvestingEvalRun {
+  id: string
+  schemaVersion: "investing-eval-run.v1"
+  datasetId: string
+  createdAt: string
+  status: InvestingEvalRunStatus
+  summary: string
+  scores: InvestingEvalRunScores
+  totals: {
+    totalCases: number
+    passCount: number
+    failCount: number
+    errorCount: number
+    passRate: number
+  }
+  results: InvestingEvalCaseResult[]
+}
+
+type EvalState = {
+  version: 1
+  datasets: InvestingEvalDataset[]
+  runs: InvestingEvalRun[]
+}
+
+export type CreateInvestingEvalDatasetInput = {
+  name: string
+  description: string
+  owner: string
+  cases: Array<{
+    label: string
+    sourceKind: InvestingEvalSourceKind
+    sourceId: string
+    expectations?: Partial<InvestingEvalCaseExpectations>
+  }>
+}
+
+function getEvalStateDir(): string {
+  const stateDir = process.env.XDG_STATE_HOME
+    ? path.join(process.env.XDG_STATE_HOME, "zee")
+    : path.join(os.homedir(), ".local", "state", "zee")
+  return path.join(stateDir, "investing")
+}
+
+export function getInvestingEvalStateFile(): string {
+  return path.join(getEvalStateDir(), "evals.json")
+}
+
+function ensureEvalStateDir(): void {
+  mkdirSync(getEvalStateDir(), { recursive: true })
+}
+
+function readEvalState(): EvalState {
+  const filePath = getInvestingEvalStateFile()
+  if (!existsSync(filePath)) {
+    return { version: 1, datasets: [], runs: [] }
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as Partial<EvalState>
+    return {
+      version: 1,
+      datasets: Array.isArray(parsed.datasets) ? parsed.datasets : [],
+      runs: Array.isArray(parsed.runs) ? parsed.runs : [],
+    }
+  } catch (error) {
+    log.warn("failed to read investing eval state", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return { version: 1, datasets: [], runs: [] }
+  }
+}
+
+function writeEvalState(state: EvalState): void {
+  ensureEvalStateDir()
+  writeFileSync(getInvestingEvalStateFile(), JSON.stringify(state, null, 2) + "\n", "utf-8")
+}
+
+function round(value: number, places = 2): number {
+  const factor = 10 ** places
+  return Math.round(value * factor) / factor
+}
+
+function unique(items: string[]): string[] {
+  return [...new Set(items.filter(Boolean))]
+}
+
+function equalStringArrays(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((item, index) => item === right[index])
+}
+
+function stringList(items: string[]): string {
+  return items.length > 0 ? items.join(", ") : "none"
+}
+
+function telemetry(input: {
+  kind: "investing.eval.dataset" | "investing.eval.run"
+  traceID: string
+  method: string
+  path?: string
+  route?: string
+  status?: "ok" | "error"
+  metadata?: Record<string, unknown>
+}): void {
+  FluxRecorder.record({
+    traceID: input.traceID,
+    direction: "internal",
+    domain: "investing",
+    kind: input.kind,
+    status: input.status ?? "ok",
+    method: input.method,
+    path: input.path,
+    route: input.route,
+    metadata: input.metadata,
+  })
+}
+
+function snapshotFromResearchArtifact(artifact: InvestingResearchArtifact): InvestingEvalGoldenSnapshot {
+  return {
+    sourceKind: "research-artifact",
+    sourceId: artifact.id,
+    capturedAt: new Date().toISOString(),
+    title: artifact.title,
+    summary: artifact.summary,
+    sectionTitles: artifact.sections.map((section) => section.title),
+    citationCount: artifact.citations.length,
+    diagnosticCount: artifact.diagnostics.length,
+    updatedAt: artifact.updatedAt,
+    metadata: {
+      schemaVersion: "research-artifact.v1",
+      status: artifact.status,
+      workflow: artifact.workflow,
+      kind: artifact.kind,
+      symbols: artifact.symbols,
+    },
+  }
+}
+
+function snapshotFromEarningsPacket(packet: InvestingEarningsPacket): InvestingEvalGoldenSnapshot {
+  return {
+    sourceKind: "earnings-packet",
+    sourceId: packet.id,
+    capturedAt: new Date().toISOString(),
+    title: packet.title,
+    summary: packet.summary,
+    sectionTitles: packet.sections.map((section) => section.title),
+    citationCount: packet.citations.length,
+    diagnosticCount: packet.diagnostics.length,
+    updatedAt: packet.updatedAt,
+    metadata: {
+      schemaVersion: packet.schemaVersion,
+      status: packet.status,
+      workflow: packet.workflow,
+      symbols: [packet.symbol],
+    },
+  }
+}
+
+function snapshotFromPortfolioBriefing(briefing: InvestingPortfolioBriefing): InvestingEvalGoldenSnapshot {
+  return {
+    sourceKind: "portfolio-briefing",
+    sourceId: briefing.id,
+    capturedAt: new Date().toISOString(),
+    title: briefing.kind,
+    summary: briefing.summary,
+    sectionTitles: briefing.sections.map((section) => section.title),
+    citationCount: 0,
+    diagnosticCount: 0,
+    updatedAt: briefing.createdAt,
+    metadata: {
+      schemaVersion: briefing.schemaVersion,
+      kind: briefing.kind,
+      symbols: unique(briefing.symbols.map((entry) => entry.symbol)),
+    },
+  }
+}
+
+export function captureInvestingEvalSnapshot(input: {
+  sourceKind: InvestingEvalSourceKind
+  sourceId: string
+}): InvestingEvalGoldenSnapshot | null {
+  switch (input.sourceKind) {
+    case "research-artifact": {
+      const artifact = getInvestingResearchArtifact(input.sourceId)
+      return artifact ? snapshotFromResearchArtifact(artifact) : null
+    }
+    case "earnings-packet": {
+      const packet = getInvestingEarningsPacket(input.sourceId)
+      return packet ? snapshotFromEarningsPacket(packet) : null
+    }
+    case "portfolio-briefing": {
+      const briefing = getInvestingPortfolioBriefing(input.sourceId)
+      return briefing ? snapshotFromPortfolioBriefing(briefing) : null
+    }
+  }
+}
+
+function materializeEvalCase(input: CreateInvestingEvalDatasetInput["cases"][number]): InvestingEvalDatasetCase {
+  const golden = captureInvestingEvalSnapshot({
+    sourceKind: input.sourceKind,
+    sourceId: input.sourceId,
+  })
+  if (!golden) {
+    throw new Error(`Eval source not found: ${input.sourceKind}:${input.sourceId}`)
+  }
+
+  return {
+    id: `eval-case-${randomUUID().slice(0, 12)}`,
+    label: input.label,
+    sourceKind: input.sourceKind,
+    sourceId: input.sourceId,
+    golden,
+    expectations: {
+      requiredSectionTitles: input.expectations?.requiredSectionTitles ?? golden.sectionTitles,
+      minCitationCount: input.expectations?.minCitationCount ?? golden.citationCount,
+      maxDiagnosticCount: input.expectations?.maxDiagnosticCount ?? golden.diagnosticCount,
+      freshnessWithinHours: input.expectations?.freshnessWithinHours,
+    },
+  }
+}
+
+function persistDataset(state: EvalState, dataset: InvestingEvalDataset): InvestingEvalDataset {
+  dataset.updatedAt = new Date().toISOString()
+  state.datasets = [dataset, ...state.datasets.filter((entry) => entry.id !== dataset.id)].sort((a, b) =>
+    b.updatedAt.localeCompare(a.updatedAt),
+  )
+  writeEvalState(state)
+  return dataset
+}
+
+function checkEvalCase(dataset: InvestingEvalDataset, evalCase: InvestingEvalDatasetCase): InvestingEvalCaseResult {
+  const live = captureInvestingEvalSnapshot({
+    sourceKind: evalCase.sourceKind,
+    sourceId: evalCase.sourceId,
+  })
+
+  if (!live) {
+    return {
+      caseId: evalCase.id,
+      label: evalCase.label,
+      sourceKind: evalCase.sourceKind,
+      sourceId: evalCase.sourceId,
+      status: "error",
+      summary: `${evalCase.label} could not load live source ${evalCase.sourceKind}:${evalCase.sourceId}.`,
+      live: null,
+      checks: [
+        {
+          id: "source-available",
+          label: "live source available",
+          passed: false,
+          expected: `${evalCase.sourceKind}:${evalCase.sourceId}`,
+          actual: "missing",
+        },
+      ],
+      passCount: 0,
+      failCount: 1,
+    }
+  }
+
+  const checks: InvestingEvalCaseCheck[] = [
+    {
+      id: "summary-match",
+      label: "summary matches golden snapshot",
+      passed: live.summary === evalCase.golden.summary,
+      expected: evalCase.golden.summary,
+      actual: live.summary,
+    },
+    {
+      id: "section-titles",
+      label: "section titles match expected set",
+      passed: equalStringArrays(live.sectionTitles, evalCase.expectations.requiredSectionTitles),
+      expected: stringList(evalCase.expectations.requiredSectionTitles),
+      actual: stringList(live.sectionTitles),
+    },
+    {
+      id: "citation-count",
+      label: "citation count meets minimum",
+      passed: live.citationCount >= evalCase.expectations.minCitationCount,
+      expected: `>= ${evalCase.expectations.minCitationCount}`,
+      actual: String(live.citationCount),
+    },
+    {
+      id: "diagnostic-count",
+      label: "diagnostic count stays within budget",
+      passed: live.diagnosticCount <= evalCase.expectations.maxDiagnosticCount,
+      expected: `<= ${evalCase.expectations.maxDiagnosticCount}`,
+      actual: String(live.diagnosticCount),
+    },
+    {
+      id: "status-match",
+      label: "status matches golden snapshot",
+      passed: live.metadata.status === evalCase.golden.metadata.status,
+      expected: evalCase.golden.metadata.status ?? "n/a",
+      actual: live.metadata.status ?? "n/a",
+    },
+    {
+      id: "symbols-match",
+      label: "symbol coverage matches golden snapshot",
+      passed: equalStringArrays(live.metadata.symbols, evalCase.golden.metadata.symbols),
+      expected: stringList(evalCase.golden.metadata.symbols),
+      actual: stringList(live.metadata.symbols),
+    },
+  ]
+
+  if (evalCase.golden.metadata.workflow || live.metadata.workflow) {
+    checks.push({
+      id: "workflow-match",
+      label: "workflow matches golden snapshot",
+      passed: live.metadata.workflow === evalCase.golden.metadata.workflow,
+      expected: evalCase.golden.metadata.workflow ?? "n/a",
+      actual: live.metadata.workflow ?? "n/a",
+    })
+  }
+
+  if (evalCase.expectations.freshnessWithinHours != null) {
+    const ageMs = Date.now() - Date.parse(live.updatedAt)
+    const ageHours = ageMs / (60 * 60 * 1000)
+    checks.push({
+      id: "freshness-window",
+      label: "source falls within freshness window",
+      passed: ageHours <= evalCase.expectations.freshnessWithinHours,
+      expected: `<= ${evalCase.expectations.freshnessWithinHours}h`,
+      actual: `${round(ageHours, 2)}h`,
+    })
+  }
+
+  const failCount = checks.filter((check) => !check.passed).length
+  const passCount = checks.length - failCount
+  return {
+    caseId: evalCase.id,
+    label: evalCase.label,
+    sourceKind: evalCase.sourceKind,
+    sourceId: evalCase.sourceId,
+    status: failCount === 0 ? "pass" : "fail",
+    summary:
+      failCount === 0
+        ? `${evalCase.label} matched the golden snapshot for dataset ${dataset.name}.`
+        : `${evalCase.label} drifted from the golden snapshot for dataset ${dataset.name}.`,
+    checks,
+    live,
+    passCount,
+    failCount,
+  }
+}
+
+export function createInvestingEvalDataset(input: CreateInvestingEvalDatasetInput): InvestingEvalDataset {
+  if (input.cases.length === 0) {
+    throw new Error("Eval datasets require at least one case.")
+  }
+
+  const state = readEvalState()
+  const createdAt = new Date().toISOString()
+  const dataset: InvestingEvalDataset = {
+    id: `investing-eval-dataset-${randomUUID().slice(0, 12)}`,
+    schemaVersion: "investing-eval-dataset.v1",
+    name: input.name.trim(),
+    description: input.description.trim(),
+    owner: input.owner.trim(),
+    createdAt,
+    updatedAt: createdAt,
+    cases: input.cases.map((evalCase) => materializeEvalCase(evalCase)),
+    audit: {
+      captureCount: input.cases.length,
+      runCount: 0,
+    },
+  }
+
+  persistDataset(state, dataset)
+  telemetry({
+    kind: "investing.eval.dataset",
+    traceID: dataset.id,
+    method: "create",
+    path: dataset.name,
+    route: dataset.id,
+    metadata: {
+      owner: dataset.owner,
+      caseCount: dataset.cases.length,
+      captureCount: dataset.audit.captureCount,
+    },
+  })
+
+  return dataset
+}
+
+export function getInvestingEvalDataset(datasetId: string): InvestingEvalDataset | null {
+  const state = readEvalState()
+  const dataset = state.datasets.find((entry) => entry.id === datasetId) ?? null
+  telemetry({
+    kind: "investing.eval.dataset",
+    traceID: datasetId,
+    method: "read",
+    path: dataset?.name,
+    route: datasetId,
+    metadata: { found: Boolean(dataset) },
+  })
+  return dataset
+}
+
+export function listInvestingEvalDatasets(options?: { owner?: string; limit?: number }): InvestingEvalDataset[] {
+  const datasets = readEvalState()
+    .datasets.filter((dataset) => (options?.owner ? dataset.owner === options.owner : true))
+    .slice(0, options?.limit ?? 20)
+
+  telemetry({
+    kind: "investing.eval.dataset",
+    traceID: options?.owner ? `eval-datasets:${options.owner}` : "eval-datasets:list",
+    method: "list",
+    path: options?.owner,
+    route: "investing:eval:datasets",
+    metadata: { owner: options?.owner, count: datasets.length, limit: options?.limit ?? 20 },
+  })
+
+  return datasets
+}
+
+export function runInvestingEvalDataset(input: { datasetId: string }): InvestingEvalRun {
+  const state = readEvalState()
+  const dataset = state.datasets.find((entry) => entry.id === input.datasetId)
+  if (!dataset) {
+    throw new Error(`Eval dataset not found: ${input.datasetId}`)
+  }
+
+  const results = dataset.cases.map((evalCase) => checkEvalCase(dataset, evalCase))
+  const passCount = results.filter((result) => result.status === "pass").length
+  const failCount = results.filter((result) => result.status === "fail").length
+  const errorCount = results.filter((result) => result.status === "error").length
+  const totalCases = results.length
+  const passRate = totalCases > 0 ? round((passCount / totalCases) * 100) : 0
+  const run: InvestingEvalRun = {
+    id: `investing-eval-run-${randomUUID().slice(0, 12)}`,
+    schemaVersion: "investing-eval-run.v1",
+    datasetId: dataset.id,
+    createdAt: new Date().toISOString(),
+    status: errorCount > 0 ? "error" : failCount > 0 ? "fail" : "pass",
+    summary: `Eval dataset ${dataset.name} finished with ${passCount}/${totalCases} passing case(s), ${failCount} failing case(s), and ${errorCount} error case(s).`,
+    scores: {
+      structural: passRate,
+      factuality: null,
+      consistency: null,
+      timeliness: null,
+    },
+    totals: {
+      totalCases,
+      passCount,
+      failCount,
+      errorCount,
+      passRate,
+    },
+    results,
+  }
+
+  dataset.audit.lastRunId = run.id
+  dataset.audit.runCount += 1
+  persistDataset(state, dataset)
+  state.runs = [run, ...state.runs.filter((entry) => entry.id !== run.id)].slice(0, 500)
+  writeEvalState(state)
+
+  telemetry({
+    kind: "investing.eval.run",
+    traceID: run.id,
+    method: "execute",
+    path: dataset.name,
+    route: dataset.id,
+    status: run.status === "error" ? "error" : "ok",
+    metadata: {
+      datasetId: dataset.id,
+      totalCases,
+      passCount,
+      failCount,
+      errorCount,
+      structural: run.scores.structural,
+    },
+  })
+
+  return run
+}
+
+export function getInvestingEvalRun(runId: string): InvestingEvalRun | null {
+  const state = readEvalState()
+  return state.runs.find((entry) => entry.id === runId) ?? null
+}
+
+export function listInvestingEvalRuns(options?: {
+  datasetId?: string
+  status?: InvestingEvalRunStatus
+  limit?: number
+}): InvestingEvalRun[] {
+  return readEvalState()
+    .runs.filter((run) => (options?.datasetId ? run.datasetId === options.datasetId : true))
+    .filter((run) => (options?.status ? run.status === options.status : true))
+    .slice(0, options?.limit ?? 20)
+}

--- a/src/domain/investing/tools.ts
+++ b/src/domain/investing/tools.ts
@@ -48,6 +48,16 @@ import {
   listInvestingEarningsPackets,
 } from "./earnings-packets"
 import {
+  createInvestingEvalDataset,
+  getInvestingEvalDataset,
+  getInvestingEvalRun,
+  INVESTING_EVAL_RUN_STATUSES,
+  INVESTING_EVAL_SOURCE_KINDS,
+  listInvestingEvalDatasets,
+  listInvestingEvalRuns,
+  runInvestingEvalDataset,
+} from "./evals"
+import {
   INVESTING_PORTFOLIO_BRIEFING_KINDS,
   createInvestingPortfolioBriefing,
   getInvestingPortfolioBriefing,
@@ -1164,6 +1174,159 @@ export const earningsPacketTool: ToolDefinition = {
   }),
 }
 
+const EvalCaseParams = z.object({
+  label: z.string().describe("Operator-facing case label"),
+  sourceKind: z.enum(INVESTING_EVAL_SOURCE_KINDS).describe("Persisted source type to capture as a golden snapshot"),
+  sourceId: z.string().describe("Persisted source identifier"),
+  expectations: z
+    .object({
+      requiredSectionTitles: z.array(z.string()).optional().describe("Override the required section-title list"),
+      minCitationCount: z.number().min(0).optional().describe("Minimum citation count expected at run time"),
+      maxDiagnosticCount: z.number().min(0).optional().describe("Maximum diagnostic count allowed at run time"),
+      freshnessWithinHours: z.number().min(0).optional().describe("Optional freshness window for the live source"),
+    })
+    .optional(),
+})
+
+const EvalParams = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("create-dataset"),
+    name: z.string().describe("Dataset name"),
+    description: z.string().describe("Dataset description"),
+    owner: z.string().describe("Owning team or operator"),
+    cases: z.array(EvalCaseParams).min(1).describe("Cases to capture into the golden-set dataset"),
+  }),
+  z.object({
+    action: z.literal("read-dataset"),
+    datasetId: z.string().describe("Persisted eval dataset identifier"),
+  }),
+  z.object({
+    action: z.literal("list-datasets"),
+    owner: z.string().optional().describe("Optional owner filter"),
+    limit: z.number().min(1).max(100).default(20).describe("Maximum number of datasets to return"),
+  }),
+  z.object({
+    action: z.literal("run-dataset"),
+    datasetId: z.string().describe("Persisted eval dataset identifier"),
+  }),
+  z.object({
+    action: z.literal("read-run"),
+    runId: z.string().describe("Persisted eval run identifier"),
+  }),
+  z.object({
+    action: z.literal("list-runs"),
+    datasetId: z.string().optional().describe("Optional dataset filter"),
+    status: z.enum(INVESTING_EVAL_RUN_STATUSES).optional().describe("Optional run-status filter"),
+    limit: z.number().min(1).max(100).default(20).describe("Maximum number of eval runs to return"),
+  }),
+])
+
+export const evalsTool: ToolDefinition = {
+  id: "zee:invest-evals",
+  category: "domain",
+  init: async () => ({
+    description: `Create investing evaluation datasets from golden snapshots, inspect them, and run the repeatable harness against current research outputs.`,
+    parameters: EvalParams,
+    execute: async (args, ctx): Promise<ToolExecutionResult> => {
+      switch (args.action) {
+        case "create-dataset": {
+          ctx.metadata({ title: `Creating eval dataset ${args.name}` })
+          const dataset = createInvestingEvalDataset({
+            name: args.name,
+            description: args.description,
+            owner: args.owner,
+            cases: args.cases,
+          })
+          return {
+            title: "Investing Evals",
+            metadata: {
+              action: args.action,
+              datasetId: dataset.id,
+              owner: dataset.owner,
+              caseCount: dataset.cases.length,
+            },
+            output: JSON.stringify(dataset, null, 2),
+          }
+        }
+        case "read-dataset": {
+          ctx.metadata({ title: `Loading eval dataset ${args.datasetId}` })
+          const dataset = getInvestingEvalDataset(args.datasetId)
+          return {
+            title: "Investing Evals",
+            metadata: { action: args.action, datasetId: args.datasetId, found: Boolean(dataset) },
+            output: JSON.stringify(dataset ?? { error: `Eval dataset not found: ${args.datasetId}` }, null, 2),
+          }
+        }
+        case "list-datasets": {
+          ctx.metadata({ title: "Listing eval datasets" })
+          const datasets = listInvestingEvalDatasets({
+            owner: args.owner,
+            limit: args.limit,
+          })
+          return {
+            title: "Investing Evals",
+            metadata: {
+              action: args.action,
+              owner: args.owner,
+              count: datasets.length,
+            },
+            output: JSON.stringify({ datasets, count: datasets.length }, null, 2),
+          }
+        }
+        case "run-dataset": {
+          ctx.metadata({ title: `Running eval dataset ${args.datasetId}` })
+          try {
+            const run = runInvestingEvalDataset({ datasetId: args.datasetId })
+            return {
+              title: "Investing Evals",
+              metadata: {
+                action: args.action,
+                datasetId: args.datasetId,
+                runId: run.id,
+                status: run.status,
+              },
+              output: JSON.stringify(run, null, 2),
+            }
+          } catch (error) {
+            return {
+              title: "Investing Evals",
+              metadata: { action: args.action, datasetId: args.datasetId, found: false },
+              output: JSON.stringify({ error: error instanceof Error ? error.message : String(error) }, null, 2),
+            }
+          }
+        }
+        case "read-run": {
+          ctx.metadata({ title: `Loading eval run ${args.runId}` })
+          const run = getInvestingEvalRun(args.runId)
+          return {
+            title: "Investing Evals",
+            metadata: { action: args.action, runId: args.runId, found: Boolean(run) },
+            output: JSON.stringify(run ?? { error: `Eval run not found: ${args.runId}` }, null, 2),
+          }
+        }
+        case "list-runs": {
+          ctx.metadata({ title: "Listing eval runs" })
+          const runs = listInvestingEvalRuns({
+            datasetId: args.datasetId,
+            status: args.status,
+            limit: args.limit,
+          })
+          return {
+            title: "Investing Evals",
+            metadata: {
+              action: args.action,
+              datasetId: args.datasetId,
+              status: args.status,
+              count: runs.length,
+            },
+            output: JSON.stringify({ runs, count: runs.length }, null, 2),
+          }
+        }
+      }
+    },
+  }),
+}
+
 const ThesisQueryParams = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("read"),
@@ -1746,6 +1909,7 @@ export const INVESTING_TOOLS = [
   valuationKernelTool,
   valuationPacketTool,
   earningsPacketTool,
+  evalsTool,
   thesisTool,
   portfolioBriefingsTool,
   opsAutomationTool,


### PR DESCRIPTION
## Summary
- add persisted investing eval datasets, golden snapshots, and replay runs for research artifacts, earnings packets, and portfolio briefings
- expose the harness through `zee:invest-evals` plus `zee investing eval dataset ...` and `zee investing eval run ...`
- document the eval state contract and add regression coverage plus telemetry for dataset and run activity

## Validation
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- bun test --cwd packages/zee test/investing/evals.test.ts test/investing/thesis-queries.test.ts test/investing/portfolio-briefings.test.ts
- CI=true bun test --cwd packages/zee --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh
- exercised `zee investing eval dataset create --json` and `zee investing eval run create --json` against the built binary

Closes #515
