### PR TITLE
feat(#516): add investing eval scorers

### DIFF
--- a/docs/architecture/investing-eval-harness.md
+++ b/docs/architecture/investing-eval-harness.md
@@ -55,7 +55,21 @@ The current run contract includes:
 - `scores.consistency`
 - `scores.timeliness`
 
-Those three quality dimensions are intentionally `null` in this slice and become concrete in `#516`.
+Those three quality dimensions are now scored by the deterministic `research-leads.v1` profile:
+
+- `structural >= 100`
+- `factuality >= 85`
+- `consistency >= 85`
+- `timeliness >= 80`
+
+The current scorer rules are:
+
+- factuality
+  - weights citation coverage, diagnostic budget, summary alignment, and status alignment
+- consistency
+  - weights summary alignment, section-title stability, symbol coverage, and workflow alignment
+- timeliness
+  - scores the live source age against either `freshnessWithinHours` or a source-type default window
 
 ## Operator surfaces
 
@@ -106,5 +120,7 @@ This slice emits:
   - dataset creation and dataset read/list activity
 - `investing.eval.run`
   - harness execution totals, pass/fail/error counts, and structural score
+- `investing.eval.score`
+  - per-case and aggregate factuality, consistency, and timeliness scores plus threshold breaches
 
 That gives the evaluation epic a persisted baseline before the scorer and CI-gate slices land.

--- a/docs/architecture/investing-eval-scoring.md
+++ b/docs/architecture/investing-eval-scoring.md
@@ -1,0 +1,79 @@
+# Investing Eval Scoring
+
+This slice closes `#516`.
+
+The investing eval harness now computes deterministic `factuality`, `consistency`, and `timeliness` scores for every case and every run.
+
+## Threshold profile
+
+Score profile:
+
+- `research-leads.v1`
+
+Thresholds:
+
+- `structural >= 100`
+- `factuality >= 85`
+- `consistency >= 85`
+- `timeliness >= 80`
+
+The profile is persisted on every eval run so later CI gates can enforce the same standard without guessing which rubric was used.
+
+## Scorer rules
+
+### Factuality
+
+Inputs:
+
+- citation coverage against the dataset case minimum
+- diagnostic budget adherence
+- summary alignment with the golden snapshot
+- status alignment with the golden snapshot
+
+### Consistency
+
+Inputs:
+
+- summary alignment
+- section-title alignment
+- symbol coverage alignment
+- workflow alignment when the source exposes a workflow
+
+### Timeliness
+
+Inputs:
+
+- `freshnessWithinHours` from the dataset case when present
+- otherwise a source-type default window:
+  - `portfolio-briefing`: 24h
+  - `earnings-packet`: 48h
+  - `research-artifact`: 72h
+
+The score decays as the live source drifts outside that window.
+
+## Run contract additions
+
+Each eval run now includes:
+
+- `scoreProfile`
+- `thresholds`
+- `scores.factuality`
+- `scores.consistency`
+- `scores.timeliness`
+- `thresholdBreaches[]`
+
+Each case result now includes:
+
+- per-case `scores`
+- per-case `thresholdBreaches[]`
+- scorer `reasons` for factuality, consistency, and timeliness
+
+## Telemetry
+
+This slice emits:
+
+- `investing.eval.score`
+  - one event per case score
+  - one aggregate event per eval run
+
+That gives the next CI-gate slice enough signal to route regressions and fail builds on explicit score thresholds.

--- a/packages/zee/src/cli/cmd/investing.ts
+++ b/packages/zee/src/cli/cmd/investing.ts
@@ -571,7 +571,10 @@ const InvestingEvalRunCreateCommand = cmd({
     }
 
     console.log(`${run.id}`)
-    console.log(`- status=${run.status} passRate=${run.totals.passRate}% structural=${run.scores.structural}`)
+    console.log(
+      `- status=${run.status} passRate=${run.totals.passRate}% structural=${run.scores.structural} factuality=${run.scores.factuality} consistency=${run.scores.consistency} timeliness=${run.scores.timeliness}`,
+    )
+    console.log(`- thresholdBreaches=${run.thresholdBreaches.join(", ") || "none"} profile=${run.scoreProfile}`)
     console.log(`- summary=${run.summary}`)
   },
 })
@@ -603,7 +606,10 @@ const InvestingEvalRunReadCommand = cmd({
     }
 
     console.log(`${run.id}`)
-    console.log(`- datasetId=${run.datasetId} status=${run.status} passRate=${run.totals.passRate}%`)
+    console.log(
+      `- datasetId=${run.datasetId} status=${run.status} passRate=${run.totals.passRate}% structural=${run.scores.structural} factuality=${run.scores.factuality} consistency=${run.scores.consistency} timeliness=${run.scores.timeliness}`,
+    )
+    console.log(`- thresholdBreaches=${run.thresholdBreaches.join(", ") || "none"} profile=${run.scoreProfile}`)
     console.log(`- summary=${run.summary}`)
   },
 })
@@ -644,7 +650,7 @@ const InvestingEvalRunListCommand = cmd({
     }
     for (const run of runs) {
       console.log(
-        `- ${run.id}: datasetId=${run.datasetId} status=${run.status} passRate=${run.totals.passRate}% summary=${run.summary}`,
+        `- ${run.id}: datasetId=${run.datasetId} status=${run.status} passRate=${run.totals.passRate}% factuality=${run.scores.factuality} consistency=${run.scores.consistency} timeliness=${run.scores.timeliness} thresholdBreaches=${run.thresholdBreaches.join(", ") || "none"} summary=${run.summary}`,
       )
     }
   },

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -77,6 +77,7 @@ export type FluxKind =
   | "investing.thesis.rollup"
   | "investing.eval.dataset"
   | "investing.eval.run"
+  | "investing.eval.score"
   | "investing.portfolio.briefing"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"

--- a/packages/zee/test/investing/evals.test.ts
+++ b/packages/zee/test/investing/evals.test.ts
@@ -212,6 +212,10 @@ describe("investing eval harness", () => {
       expect(run.status).toBe("pass")
       expect(run.totals.passCount).toBe(2)
       expect(run.scores.structural).toBe(100)
+      expect(run.scores.factuality).toBeGreaterThanOrEqual(85)
+      expect(run.scores.consistency).toBeGreaterThanOrEqual(85)
+      expect(run.scores.timeliness).toBeGreaterThanOrEqual(80)
+      expect(run.thresholdBreaches).toEqual([])
 
       const tool = await evalsTool.init()
       const result = await tool.execute(
@@ -228,6 +232,7 @@ describe("investing eval harness", () => {
 
       expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.eval.dataset")).toBe(true)
       expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.eval.run")).toBe(true)
+      expect(recordSpy.mock.calls.some((call) => call[0]?.kind === "investing.eval.score")).toBe(true)
     })
   })
 
@@ -271,6 +276,8 @@ describe("investing eval harness", () => {
         false,
       )
       expect(payload.scores.structural).toBe(0)
+      expect(payload.scores.consistency).toBeLessThan(85)
+      expect(payload.thresholdBreaches).toContain("structural")
     })
   })
 })

--- a/src/domain/investing/eval-scoring.ts
+++ b/src/domain/investing/eval-scoring.ts
@@ -1,0 +1,156 @@
+/**
+ * Investing Evaluation Scorers
+ *
+ * Deterministic factuality, consistency, and timeliness scorers layered on top
+ * of the golden-set harness results from investing eval datasets.
+ */
+
+import type { InvestingEvalCaseResult, InvestingEvalDatasetCase, InvestingEvalSourceKind } from "./evals"
+
+export const INVESTING_EVAL_SCORE_PROFILE = "research-leads.v1" as const
+
+export interface InvestingEvalThresholdProfile {
+  profile: typeof INVESTING_EVAL_SCORE_PROFILE
+  structural: number
+  factuality: number
+  consistency: number
+  timeliness: number
+}
+
+export interface InvestingEvalCaseScores {
+  structural: number
+  factuality: number
+  consistency: number
+  timeliness: number
+}
+
+export interface InvestingEvalCaseScoring {
+  scores: InvestingEvalCaseScores
+  thresholdBreaches: Array<keyof InvestingEvalCaseScores>
+  reasons: {
+    factuality: string[]
+    consistency: string[]
+    timeliness: string[]
+  }
+}
+
+export const INVESTING_EVAL_THRESHOLDS: InvestingEvalThresholdProfile = {
+  profile: INVESTING_EVAL_SCORE_PROFILE,
+  structural: 100,
+  factuality: 85,
+  consistency: 85,
+  timeliness: 80,
+}
+
+function round(value: number, places = 2): number {
+  const factor = 10 ** places
+  return Math.round(value * factor) / factor
+}
+
+function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, round(value)))
+}
+
+function defaultTimelinessWindowForSourceKind(sourceKind: InvestingEvalSourceKind): number {
+  switch (sourceKind) {
+    case "portfolio-briefing":
+      return 24
+    case "earnings-packet":
+      return 48
+    case "research-artifact":
+    default:
+      return 72
+  }
+}
+
+function checkPassed(result: InvestingEvalCaseResult, checkId: string): boolean {
+  return result.checks.find((check) => check.id === checkId)?.passed ?? false
+}
+
+export function scoreInvestingEvalCase(input: {
+  evalCase: InvestingEvalDatasetCase
+  result: InvestingEvalCaseResult
+}): InvestingEvalCaseScoring {
+  const structural =
+    input.result.checks.length > 0 ? clampPercent((input.result.passCount / input.result.checks.length) * 100) : 0
+
+  if (!input.result.live) {
+    return {
+      scores: {
+        structural,
+        factuality: 0,
+        consistency: 0,
+        timeliness: 0,
+      },
+      thresholdBreaches: ["structural", "factuality", "consistency", "timeliness"],
+      reasons: {
+        factuality: ["Live source could not be loaded, so factuality is 0."],
+        consistency: ["Live source could not be loaded, so consistency is 0."],
+        timeliness: ["Live source could not be loaded, so timeliness is 0."],
+      },
+    }
+  }
+
+  const live = input.result.live
+  const citationTarget = input.evalCase.expectations.minCitationCount
+  const citationCoverage = citationTarget > 0 ? Math.min(live.citationCount / citationTarget, 1) : 1
+  const diagnosticBudget = Math.max(1, input.evalCase.expectations.maxDiagnosticCount + 1)
+  const diagnosticHealth = Math.max(
+    0,
+    1 - Math.max(0, live.diagnosticCount - input.evalCase.expectations.maxDiagnosticCount) / diagnosticBudget,
+  )
+  const summaryMatch = checkPassed(input.result, "summary-match") ? 1 : 0.45
+  const statusMatch = checkPassed(input.result, "status-match") ? 1 : 0.6
+  const factuality = clampPercent(
+    (citationCoverage * 0.45 + diagnosticHealth * 0.25 + summaryMatch * 0.2 + statusMatch * 0.1) * 100,
+  )
+
+  const sectionMatch = checkPassed(input.result, "section-titles") ? 1 : 0.4
+  const symbolMatch = checkPassed(input.result, "symbols-match") ? 1 : 0.5
+  const workflowMatch = input.result.checks.some((check) => check.id === "workflow-match")
+    ? checkPassed(input.result, "workflow-match")
+      ? 1
+      : 0.5
+    : 1
+  const consistency = clampPercent(
+    (summaryMatch * 0.35 + sectionMatch * 0.35 + symbolMatch * 0.15 + workflowMatch * 0.15) * 100,
+  )
+
+  const timelinessWindow =
+    input.evalCase.expectations.freshnessWithinHours ?? defaultTimelinessWindowForSourceKind(input.evalCase.sourceKind)
+  const ageHours = (Date.now() - Date.parse(live.updatedAt)) / (60 * 60 * 1000)
+  const timelinessRatio = timelinessWindow > 0 ? ageHours / timelinessWindow : 0
+  const timeliness = clampPercent(
+    timelinessRatio <= 1 ? 100 : timelinessRatio <= 3 ? 100 - (timelinessRatio - 1) * 50 : 0,
+  )
+
+  const scores: InvestingEvalCaseScores = {
+    structural,
+    factuality,
+    consistency,
+    timeliness,
+  }
+  const thresholdBreaches = (Object.keys(scores) as Array<keyof InvestingEvalCaseScores>).filter(
+    (dimension) => scores[dimension] < INVESTING_EVAL_THRESHOLDS[dimension],
+  )
+
+  return {
+    scores,
+    thresholdBreaches,
+    reasons: {
+      factuality: [
+        citationTarget > 0
+          ? `Citation coverage ${live.citationCount}/${citationTarget} contributed ${(citationCoverage * 45).toFixed(1)} points.`
+          : "Citation coverage was not required for this case and contributed 45.0 points.",
+        `Diagnostic health contributed ${(diagnosticHealth * 25).toFixed(1)} points with ${live.diagnosticCount} diagnostic(s).`,
+        `Summary and status alignment contributed ${((summaryMatch * 0.2 + statusMatch * 0.1) * 100).toFixed(1)} points.`,
+      ],
+      consistency: [
+        `Summary alignment contributed ${(summaryMatch * 35).toFixed(1)} points.`,
+        `Section-title alignment contributed ${(sectionMatch * 35).toFixed(1)} points.`,
+        `Symbol/workflow coverage contributed ${((symbolMatch * 0.15 + workflowMatch * 0.15) * 100).toFixed(1)} points.`,
+      ],
+      timeliness: [`Age ${round(ageHours)}h was scored against a ${timelinessWindow}h freshness window.`],
+    },
+  }
+}

--- a/src/domain/investing/evals.ts
+++ b/src/domain/investing/evals.ts
@@ -14,6 +14,13 @@ import { FluxRecorder } from "../../../packages/zee/src/flux"
 import { Log } from "../../../packages/zee/src/util/log"
 import { getInvestingResearchArtifact, type InvestingResearchArtifact } from "./artifacts"
 import { getInvestingPortfolioBriefing, type InvestingPortfolioBriefing } from "./briefings"
+import {
+  INVESTING_EVAL_SCORE_PROFILE,
+  INVESTING_EVAL_THRESHOLDS,
+  scoreInvestingEvalCase,
+  type InvestingEvalCaseScores,
+  type InvestingEvalThresholdProfile,
+} from "./eval-scoring"
 import { getInvestingEarningsPacket, type InvestingEarningsPacket } from "./earnings-packets"
 
 const log = Log.create({ service: "investing:evals" })
@@ -94,6 +101,13 @@ export interface InvestingEvalCaseResult {
   live: InvestingEvalGoldenSnapshot | null
   passCount: number
   failCount: number
+  scores: InvestingEvalCaseScores
+  thresholdBreaches: Array<keyof InvestingEvalCaseScores>
+  reasons: {
+    factuality: string[]
+    consistency: string[]
+    timeliness: string[]
+  }
 }
 
 export interface InvestingEvalRunScores {
@@ -110,7 +124,10 @@ export interface InvestingEvalRun {
   createdAt: string
   status: InvestingEvalRunStatus
   summary: string
+  scoreProfile: typeof INVESTING_EVAL_SCORE_PROFILE
+  thresholds: InvestingEvalThresholdProfile
   scores: InvestingEvalRunScores
+  thresholdBreaches: Array<keyof InvestingEvalRunScores>
   totals: {
     totalCases: number
     passCount: number
@@ -198,7 +215,7 @@ function stringList(items: string[]): string {
 }
 
 function telemetry(input: {
-  kind: "investing.eval.dataset" | "investing.eval.run"
+  kind: "investing.eval.dataset" | "investing.eval.run" | "investing.eval.score"
   traceID: string
   method: string
   path?: string
@@ -358,6 +375,18 @@ function checkEvalCase(dataset: InvestingEvalDataset, evalCase: InvestingEvalDat
       ],
       passCount: 0,
       failCount: 1,
+      scores: {
+        structural: 0,
+        factuality: 0,
+        consistency: 0,
+        timeliness: 0,
+      },
+      thresholdBreaches: ["structural", "factuality", "consistency", "timeliness"],
+      reasons: {
+        factuality: ["Live source could not be loaded."],
+        consistency: ["Live source could not be loaded."],
+        timeliness: ["Live source could not be loaded."],
+      },
     }
   }
 
@@ -430,6 +459,34 @@ function checkEvalCase(dataset: InvestingEvalDataset, evalCase: InvestingEvalDat
 
   const failCount = checks.filter((check) => !check.passed).length
   const passCount = checks.length - failCount
+  const scoring = scoreInvestingEvalCase({
+    evalCase,
+    result: {
+      caseId: evalCase.id,
+      label: evalCase.label,
+      sourceKind: evalCase.sourceKind,
+      sourceId: evalCase.sourceId,
+      status: failCount === 0 ? "pass" : "fail",
+      summary: "",
+      checks,
+      live,
+      passCount,
+      failCount,
+      scores: {
+        structural: 0,
+        factuality: 0,
+        consistency: 0,
+        timeliness: 0,
+      },
+      thresholdBreaches: [],
+      reasons: {
+        factuality: [],
+        consistency: [],
+        timeliness: [],
+      },
+    },
+  })
+
   return {
     caseId: evalCase.id,
     label: evalCase.label,
@@ -444,6 +501,9 @@ function checkEvalCase(dataset: InvestingEvalDataset, evalCase: InvestingEvalDat
     live,
     passCount,
     failCount,
+    scores: scoring.scores,
+    thresholdBreaches: scoring.thresholdBreaches,
+    reasons: scoring.reasons,
   }
 }
 
@@ -530,19 +590,29 @@ export function runInvestingEvalDataset(input: { datasetId: string }): Investing
   const errorCount = results.filter((result) => result.status === "error").length
   const totalCases = results.length
   const passRate = totalCases > 0 ? round((passCount / totalCases) * 100) : 0
+  const averageScore = (dimension: keyof InvestingEvalCaseScores): number =>
+    totalCases > 0 ? round(results.reduce((sum, result) => sum + result.scores[dimension], 0) / totalCases) : 0
+
+  const scores: InvestingEvalRunScores = {
+    structural: passRate,
+    factuality: averageScore("factuality"),
+    consistency: averageScore("consistency"),
+    timeliness: averageScore("timeliness"),
+  }
+  const thresholdBreaches = (Object.keys(scores) as Array<keyof InvestingEvalRunScores>).filter(
+    (dimension) => (scores[dimension] ?? 0) < INVESTING_EVAL_THRESHOLDS[dimension],
+  )
   const run: InvestingEvalRun = {
     id: `investing-eval-run-${randomUUID().slice(0, 12)}`,
     schemaVersion: "investing-eval-run.v1",
     datasetId: dataset.id,
     createdAt: new Date().toISOString(),
     status: errorCount > 0 ? "error" : failCount > 0 ? "fail" : "pass",
-    summary: `Eval dataset ${dataset.name} finished with ${passCount}/${totalCases} passing case(s), ${failCount} failing case(s), and ${errorCount} error case(s).`,
-    scores: {
-      structural: passRate,
-      factuality: null,
-      consistency: null,
-      timeliness: null,
-    },
+    summary: `Eval dataset ${dataset.name} finished with ${passCount}/${totalCases} passing case(s), ${failCount} failing case(s), and ${errorCount} error case(s). Threshold breaches: ${thresholdBreaches.join(", ") || "none"}.`,
+    scoreProfile: INVESTING_EVAL_SCORE_PROFILE,
+    thresholds: INVESTING_EVAL_THRESHOLDS,
+    scores,
+    thresholdBreaches,
     totals: {
       totalCases,
       passCount,
@@ -573,6 +643,47 @@ export function runInvestingEvalDataset(input: { datasetId: string }): Investing
       failCount,
       errorCount,
       structural: run.scores.structural,
+      factuality: run.scores.factuality,
+      consistency: run.scores.consistency,
+      timeliness: run.scores.timeliness,
+      thresholdBreaches: run.thresholdBreaches,
+    },
+  })
+
+  for (const result of results) {
+    telemetry({
+      kind: "investing.eval.score",
+      traceID: `${run.id}:${result.caseId}`,
+      method: "case",
+      path: result.sourceId,
+      route: dataset.id,
+      status: result.thresholdBreaches.length > 0 ? "error" : "ok",
+      metadata: {
+        caseId: result.caseId,
+        sourceKind: result.sourceKind,
+        structural: result.scores.structural,
+        factuality: result.scores.factuality,
+        consistency: result.scores.consistency,
+        timeliness: result.scores.timeliness,
+        thresholdBreaches: result.thresholdBreaches,
+      },
+    })
+  }
+
+  telemetry({
+    kind: "investing.eval.score",
+    traceID: run.id,
+    method: "aggregate",
+    path: dataset.name,
+    route: dataset.id,
+    status: run.thresholdBreaches.length > 0 ? "error" : "ok",
+    metadata: {
+      scoreProfile: run.scoreProfile,
+      structural: run.scores.structural,
+      factuality: run.scores.factuality,
+      consistency: run.scores.consistency,
+      timeliness: run.scores.timeliness,
+      thresholdBreaches: run.thresholdBreaches,
     },
   })
 

--- a/src/domain/investing/tools.ts
+++ b/src/domain/investing/tools.ts
@@ -1284,6 +1284,11 @@ export const evalsTool: ToolDefinition = {
                 datasetId: args.datasetId,
                 runId: run.id,
                 status: run.status,
+                structural: run.scores.structural,
+                factuality: run.scores.factuality,
+                consistency: run.scores.consistency,
+                timeliness: run.scores.timeliness,
+                thresholdBreaches: run.thresholdBreaches,
               },
               output: JSON.stringify(run, null, 2),
             }


### PR DESCRIPTION
## Summary
- add deterministic factuality, consistency, and timeliness scorers for investing eval datasets
- persist score profiles, thresholds, breaches, and per-case reasons in eval runs, CLI output, and tool responses
- emit investing.eval.score telemetry and document the research-leads.v1 rubric

## Testing
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- bun test --cwd packages/zee test/investing/evals.test.ts test/investing/thesis-queries.test.ts test/investing/portfolio-briefings.test.ts
- CI=true bun test --cwd packages/zee --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh
- CLI smoke: zee investing eval dataset create/run create --json

Closes #516