### PR TITLE
feat(#518): consolidate v3 release reporting

### DIFF
--- a/docs/architecture/v3-release-gate.md
+++ b/docs/architecture/v3-release-gate.md
@@ -1,0 +1,75 @@
+# V3 Release Gate
+
+This slice closes `#518`.
+
+Zee now exposes a single consolidated release gate report through `zee v3 status` and `zee v3 release`.
+
+## Report contract
+
+Report id:
+
+- `v3-release-gate`
+
+Categories:
+
+- `reliability`
+- `security`
+- `performance`
+- `docs`
+
+Current gates:
+
+- reliability
+  - AgentDB memory wiring
+  - hierarchical mesh capacity
+  - agentic-flow plan decomposition
+  - OpenCode runtime parity
+- security
+  - deep control-plane audit
+  - node-client policy exposure
+- performance
+  - day-window usage latency and error-rate budget
+- docs
+  - required operator docs presence
+
+## Operator usage
+
+```bash
+zee v3 status
+zee v3 release
+zee v3 release --strict
+zee v3 release --json
+```
+
+`--strict` exits non-zero when any category gate fails.
+
+## Performance budget
+
+The current report treats the performance gate as passing when either:
+
+- there is no recorded traffic in the trailing day window
+- or the trailing day window stays within:
+  - `avgLatencyMs <= 5000`
+  - `errorRate <= 5%`
+
+The report still prints request count, average latency, error rate, and cache-hit rate even when the gate is non-blocking because there is no traffic.
+
+## Documentation checks
+
+The consolidated report now verifies the presence of these operator-facing docs:
+
+- `docs/architecture/opencode-runtime-rollout.md`
+- `docs/architecture/v3-release-readiness.md`
+- `docs/architecture/investing-eval-gates.md`
+
+## Telemetry
+
+This slice emits:
+
+- `release.v3.report`
+  - gate count
+  - failure count
+  - missing-doc count
+  - trailing usage latency and error-rate metrics
+
+That gives the rollout and launch slices a single release report object to extend instead of reassembling independent checks in each command.

--- a/docs/architecture/v3-release-readiness.md
+++ b/docs/architecture/v3-release-readiness.md
@@ -1,6 +1,7 @@
 # V3 Release Readiness
 
 This document defines the executable v3 gate introduced by `zee v3`.
+The consolidated release report now closes `#518`.
 
 ## Implemented slices
 - Memory unification:
@@ -17,7 +18,7 @@ This document defines the executable v3 gate introduced by `zee v3`.
   - `zee v3 plan <objective> [--execute]`
   - `zee v3 release [--strict]`
 - Release gate:
-  - combines memory, swarm mesh, agentic-flow, OpenCode runtime parity, and deep security audit checks
+  - combines reliability, security, performance, and documentation checks into one report
 
 ## Operational usage
 - Inspect readiness:
@@ -26,6 +27,8 @@ This document defines the executable v3 gate introduced by `zee v3`.
   - `zee v3 plan "objective text" --steps 6 --execute`
 - Enforce CI-like strict gate:
   - `zee v3 release --strict`
+- Emit the full consolidated report:
+  - `zee v3 release --json`
 
 ## Runtime parity tie-in
 - `zee v3 status` and `zee v3 release` both embed the `inspect runtime-rollout` parity verdict.
@@ -39,3 +42,12 @@ This document defines the executable v3 gate introduced by `zee v3`.
 - v3 release gate consumes deep security audit output.
 - Node-client exposure is included in release readiness decisions.
 - `zee v3 release` emits the same `security.audit.checked` / `security.audit.finding` telemetry as the deep audit commands.
+
+## Consolidated Report Tie-in
+- `zee v3 status` and `zee v3 release` now render the same `v3-release-gate` report.
+- The report groups gates into:
+  - `reliability`
+  - `security`
+  - `performance`
+  - `docs`
+- `zee v3 release` emits `release.v3.report` telemetry with failure counts and performance/doc metrics.

--- a/packages/zee/src/cli/cmd/v3.ts
+++ b/packages/zee/src/cli/cmd/v3.ts
@@ -1,17 +1,11 @@
 import type { Argv } from "yargs"
 import { cmd } from "./cmd"
 import { bootstrap } from "../bootstrap"
-import { Config } from "../../config/config"
-import { auditControlUiSecurityDeep, emitSecurityAuditTelemetry } from "@/security"
-import { getAgentDbMemoryStats } from "@/memory/agentdb-service"
-import { getHierarchicalMeshCoordinator } from "@/coordination/hierarchical-mesh"
 import { AgenticFlowBridge } from "@/orchestration/agentic-flow-bridge"
-import { getNodeClientRegistry, resolveNodeClientPolicy } from "@/gateway/node-client-registry"
 import {
-  buildOpenCodeRuntimeReleaseGate,
-  buildOpenCodeRuntimeRolloutReport,
-  emitOpenCodeRuntimeRolloutTelemetry,
-} from "@/runtime/opencode-rollout"
+  collectV3ReleaseReport,
+  summarizeV3ReleaseReport,
+} from "@/runtime/v3-release"
 
 type V3StatusArgs = {
   json?: boolean
@@ -29,77 +23,9 @@ type V3ReleaseArgs = {
   strict?: boolean
 }
 
-async function collectV3Status(options: { emitSecurityTelemetry?: boolean } = {}) {
-  const [config, memoryStats] = await Promise.all([Config.get(), getAgentDbMemoryStats()])
-  const security = await auditControlUiSecurityDeep(config)
-  if (options.emitSecurityTelemetry) {
-    emitSecurityAuditTelemetry({
-      source: "v3.release",
-      deep: true,
-      report: security,
-    })
-  }
-  const mesh = getHierarchicalMeshCoordinator().snapshot()
-  const nodePolicy = resolveNodeClientPolicy(config)
-  const nodeStats = await getNodeClientRegistry().getStats()
-  const flowBridge = new AgenticFlowBridge()
-  const samplePlan = flowBridge.decomposeObjective("memory sync; swarm routing; release gate", { maxSteps: 3 })
-  const runtimeRollout = buildOpenCodeRuntimeRolloutReport()
-  if (options.emitSecurityTelemetry) {
-    await emitOpenCodeRuntimeRolloutTelemetry(runtimeRollout)
-  }
-  const runtimeGate = buildOpenCodeRuntimeReleaseGate(runtimeRollout)
-
-  const gates = [
-    { id: "memory.agentdb", ok: true, details: "Unified AgentDB memory service is wired through server routes." },
-    {
-      id: "swarm.hierarchical-mesh",
-      ok: mesh.withinCapacity && mesh.maxAgents >= 15,
-      details: `mesh agents=${mesh.totalAgents}/${mesh.maxAgents}, cross-domain-links=${mesh.crossDomainLinks}`,
-    },
-    {
-      id: "agentic-flow.bridge",
-      ok: samplePlan.steps.length > 0,
-      details: `decomposition steps=${samplePlan.steps.length}`,
-    },
-    {
-      id: "cli.modernization",
-      ok: true,
-      details: "v3 status/plan/release command surface available for operator workflows.",
-    },
-    runtimeGate,
-    {
-      id: "release.security",
-      ok: security.ok,
-      details: `security errors=${security.errors} warnings=${security.warnings}`,
-    },
-    {
-      id: "node-client.policy",
-      ok: !nodePolicy.enabled || nodePolicy.securityMode !== "full",
-      details: `enabled=${nodePolicy.enabled} mode=${nodePolicy.securityMode} paired=${nodeStats.active}`,
-    },
-  ]
-
-  return {
-    generatedAt: new Date().toISOString(),
-    memory: {
-      stats: memoryStats,
-    },
-    mesh,
-    nodeClient: {
-      policy: nodePolicy,
-      stats: nodeStats,
-    },
-    runtimeRollout,
-    security,
-    gates,
-    readyForRelease: gates.every((gate) => gate.ok),
-  }
-}
-
 const V3StatusCommand = cmd({
   command: "status",
-  describe: "show v3 readiness across memory, swarm, agentic-flow, and release security gates",
+  describe: "show the consolidated v3 readiness report across reliability, security, performance, and docs gates",
   builder: (yargs: Argv) =>
     yargs.option("json", {
       type: "boolean",
@@ -108,16 +34,12 @@ const V3StatusCommand = cmd({
     }),
   handler: async (args: V3StatusArgs) => {
     await bootstrap(process.cwd(), async () => {
-      const status = await collectV3Status()
+      const status = await collectV3ReleaseReport()
       if (args.json) {
         console.log(JSON.stringify(status, null, 2))
         return
       }
-
-      console.log(`v3 release readiness: ${status.readyForRelease ? "ready" : "blocked"}`)
-      for (const gate of status.gates) {
-        console.log(`- ${gate.ok ? "ok" : "fail"} ${gate.id}: ${gate.details}`)
-      }
+      console.log(summarizeV3ReleaseReport(status))
     })
   },
 })
@@ -171,7 +93,7 @@ const V3PlanCommand = cmd({
 
 const V3ReleaseCommand = cmd({
   command: "release",
-  describe: "run v3 release gate checks",
+  describe: "run the consolidated v3 release gate checks",
   builder: (yargs: Argv) =>
     yargs
       .option("json", {
@@ -186,14 +108,11 @@ const V3ReleaseCommand = cmd({
       }),
   handler: async (args: V3ReleaseArgs) => {
     await bootstrap(process.cwd(), async () => {
-      const status = await collectV3Status({ emitSecurityTelemetry: true })
+      const status = await collectV3ReleaseReport({ emitTelemetry: true })
       if (args.json) {
         console.log(JSON.stringify(status, null, 2))
       } else {
-        console.log(`v3 release gate: ${status.readyForRelease ? "PASS" : "FAIL"}`)
-        for (const gate of status.gates) {
-          console.log(`- ${gate.ok ? "ok" : "fail"} ${gate.id}: ${gate.details}`)
-        }
+        console.log(summarizeV3ReleaseReport(status))
       }
 
       if (args.strict && !status.readyForRelease) {

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -81,6 +81,7 @@ export type FluxKind =
   | "investing.eval.gate"
   | "investing.eval.alert"
   | "investing.portfolio.briefing"
+  | "release.v3.report"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"
   | "provider.fallback.used"

--- a/packages/zee/src/runtime/v3-release.ts
+++ b/packages/zee/src/runtime/v3-release.ts
@@ -1,0 +1,431 @@
+import { existsSync } from "node:fs"
+import path from "node:path"
+import { Config } from "@/config/config"
+import { getHierarchicalMeshCoordinator } from "@/coordination/hierarchical-mesh"
+import { FluxRecorder } from "@/flux"
+import { getNodeClientRegistry, resolveNodeClientPolicy } from "@/gateway/node-client-registry"
+import { getAgentDbMemoryStats } from "@/memory/agentdb-service"
+import { AgenticFlowBridge } from "@/orchestration/agentic-flow-bridge"
+import {
+  auditControlUiSecurityDeep,
+  emitSecurityAuditTelemetry,
+  type SecurityAuditReport,
+} from "@/security"
+import {
+  buildOpenCodeRuntimeReleaseGate,
+  buildOpenCodeRuntimeRolloutReport,
+  emitOpenCodeRuntimeRolloutTelemetry,
+  type OpenCodeRuntimeReleaseGate,
+  type OpenCodeRuntimeRolloutReport,
+} from "@/runtime/opencode-rollout"
+import * as Usage from "@/usage"
+import type { UsageSummary } from "@/usage/types"
+
+const PERFORMANCE_SLO = {
+  maxAvgLatencyMs: 5000,
+  maxErrorRate: 0.05,
+} as const
+
+const REQUIRED_V3_RELEASE_DOCS = [
+  {
+    id: "runtime-rollout",
+    path: "docs/architecture/opencode-runtime-rollout.md",
+    label: "OpenCode runtime rollout",
+  },
+  {
+    id: "v3-release-readiness",
+    path: "docs/architecture/v3-release-readiness.md",
+    label: "V3 release readiness",
+  },
+  {
+    id: "investing-eval-gates",
+    path: "docs/architecture/investing-eval-gates.md",
+    label: "Investing eval gates",
+  },
+] as const
+
+export type V3ReleaseCategory = "reliability" | "security" | "performance" | "docs"
+
+export interface V3ReleaseGate {
+  id: string
+  category: V3ReleaseCategory
+  ok: boolean
+  details: string
+}
+
+export interface V3ReleaseCategorySummary {
+  id: V3ReleaseCategory
+  ok: boolean
+  gateCount: number
+  failureCount: number
+}
+
+export interface V3ReleaseDocCheck {
+  id: string
+  label: string
+  path: string
+  exists: boolean
+}
+
+export interface V3ReleasePerformanceSnapshot {
+  totalRequests: number
+  avgLatencyMs: number
+  errorRate: number
+  cacheHitRate: number
+}
+
+export interface V3ReleaseReport {
+  reportId: "v3-release-gate"
+  reportVersion: 1
+  generatedAt: string
+  categories: V3ReleaseCategorySummary[]
+  gates: V3ReleaseGate[]
+  docs: {
+    required: V3ReleaseDocCheck[]
+    missingCount: number
+  }
+  performance: V3ReleasePerformanceSnapshot
+  memory: {
+    stats: unknown
+  }
+  mesh: {
+    totalAgents: number
+    maxAgents: number
+    crossDomainLinks: number
+    withinCapacity: boolean
+  }
+  nodeClient: {
+    policy: {
+      enabled: boolean
+      securityMode: "deny" | "allowlist" | "full"
+    }
+    stats: {
+      active: number
+      revoked: number
+      total: number
+    }
+  }
+  runtimeRollout: OpenCodeRuntimeRolloutReport
+  security: SecurityAuditReport
+  readyForRelease: boolean
+  telemetry: {
+    kind: "release.v3.report"
+    metrics: {
+      gateCount: number
+      failureCount: number
+      docMissingCount: number
+      avgLatencyMs: number
+      errorRate: number
+      requestCount: number
+    }
+  }
+}
+
+export interface BuildV3ReleaseReportInput {
+  generatedAt?: Date
+  memoryStats: unknown
+  mesh: {
+    totalAgents: number
+    maxAgents: number
+    crossDomainLinks: number
+    withinCapacity: boolean
+  }
+  samplePlanSteps: number
+  runtimeRollout: OpenCodeRuntimeRolloutReport
+  runtimeGate: OpenCodeRuntimeReleaseGate
+  security: SecurityAuditReport
+  nodePolicy: {
+    enabled: boolean
+    securityMode: "deny" | "allowlist" | "full"
+  }
+  nodeStats: {
+    active: number
+    revoked: number
+    total: number
+  }
+  usageSummary: UsageSummary
+  docs: V3ReleaseDocCheck[]
+}
+
+function resolveRepoRoot(): string {
+  return path.resolve(import.meta.dir, "../../../../")
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`
+}
+
+function buildDocsGate(docs: V3ReleaseDocCheck[]): V3ReleaseGate {
+  const missing = docs.filter((doc) => !doc.exists)
+  return {
+    id: "docs.architecture.required",
+    category: "docs",
+    ok: missing.length === 0,
+    details:
+      missing.length === 0
+        ? `required=${docs.length} missing=0`
+        : `required=${docs.length} missing=${missing.map((doc) => doc.path).join(", ")}`,
+  }
+}
+
+function buildPerformanceGate(summary: UsageSummary): V3ReleaseGate {
+  const latencyOk = summary.totalRequests === 0 || summary.avgLatencyMs <= PERFORMANCE_SLO.maxAvgLatencyMs
+  const errorOk = summary.totalRequests === 0 || summary.errorRate <= PERFORMANCE_SLO.maxErrorRate
+
+  return {
+    id: "performance.usage-latency",
+    category: "performance",
+    ok: latencyOk && errorOk,
+    details:
+      `requests=${summary.totalRequests} avgLatency=${Math.round(summary.avgLatencyMs)}ms ` +
+      `errorRate=${formatPercent(summary.errorRate)} cacheHit=${formatPercent(summary.cacheHitRate)}`,
+  }
+}
+
+export function collectRequiredV3ReleaseDocs(repoRoot: string = resolveRepoRoot()): V3ReleaseDocCheck[] {
+  return REQUIRED_V3_RELEASE_DOCS.map((doc) => ({
+    ...doc,
+    exists: existsSync(path.join(repoRoot, doc.path)),
+  }))
+}
+
+export function buildV3ReleaseReport(input: BuildV3ReleaseReportInput): V3ReleaseReport {
+  const generatedAt = (input.generatedAt ?? new Date()).toISOString()
+  const docsGate = buildDocsGate(input.docs)
+  const performanceGate = buildPerformanceGate(input.usageSummary)
+  const gates: V3ReleaseGate[] = [
+    {
+      id: "memory.agentdb",
+      category: "reliability",
+      ok: true,
+      details: "Unified AgentDB memory service is wired through server routes.",
+    },
+    {
+      id: "swarm.hierarchical-mesh",
+      category: "reliability",
+      ok: input.mesh.withinCapacity && input.mesh.maxAgents >= 15,
+      details: `mesh agents=${input.mesh.totalAgents}/${input.mesh.maxAgents} cross-domain-links=${input.mesh.crossDomainLinks}`,
+    },
+    {
+      id: "agentic-flow.bridge",
+      category: "reliability",
+      ok: input.samplePlanSteps > 0,
+      details: `decomposition steps=${input.samplePlanSteps}`,
+    },
+    {
+      id: input.runtimeGate.id,
+      category: "reliability",
+      ok: input.runtimeGate.ok,
+      details: input.runtimeGate.details,
+    },
+    {
+      id: "release.security",
+      category: "security",
+      ok: input.security.ok,
+      details: `security errors=${input.security.errors} warnings=${input.security.warnings}`,
+    },
+    {
+      id: "node-client.policy",
+      category: "security",
+      ok: !input.nodePolicy.enabled || input.nodePolicy.securityMode !== "full",
+      details: `enabled=${input.nodePolicy.enabled} mode=${input.nodePolicy.securityMode} paired=${input.nodeStats.active}`,
+    },
+    performanceGate,
+    docsGate,
+  ]
+
+  const categories = (["reliability", "security", "performance", "docs"] as const).map((category) => {
+    const categoryGates = gates.filter((gate) => gate.category === category)
+    const failureCount = categoryGates.filter((gate) => !gate.ok).length
+    return {
+      id: category,
+      ok: failureCount === 0,
+      gateCount: categoryGates.length,
+      failureCount,
+    }
+  })
+
+  const failureCount = gates.filter((gate) => !gate.ok).length
+
+  return {
+    reportId: "v3-release-gate",
+    reportVersion: 1,
+    generatedAt,
+    categories,
+    gates,
+    docs: {
+      required: input.docs,
+      missingCount: input.docs.filter((doc) => !doc.exists).length,
+    },
+    performance: {
+      totalRequests: input.usageSummary.totalRequests,
+      avgLatencyMs: input.usageSummary.avgLatencyMs,
+      errorRate: input.usageSummary.errorRate,
+      cacheHitRate: input.usageSummary.cacheHitRate,
+    },
+    memory: {
+      stats: input.memoryStats,
+    },
+    mesh: input.mesh,
+    nodeClient: {
+      policy: input.nodePolicy,
+      stats: input.nodeStats,
+    },
+    runtimeRollout: input.runtimeRollout,
+    security: input.security,
+    readyForRelease: failureCount === 0,
+    telemetry: {
+      kind: "release.v3.report",
+      metrics: {
+        gateCount: gates.length,
+        failureCount,
+        docMissingCount: input.docs.filter((doc) => !doc.exists).length,
+        avgLatencyMs: input.usageSummary.avgLatencyMs,
+        errorRate: input.usageSummary.errorRate,
+        requestCount: input.usageSummary.totalRequests,
+      },
+    },
+  }
+}
+
+function emptyUsageSummary(now: Date = new Date()): UsageSummary {
+  const endTime = now.getTime()
+  return {
+    period: "day",
+    startTime: endTime - 24 * 60 * 60 * 1000,
+    endTime,
+    totalRequests: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCost: 0,
+    byProvider: {},
+    byModel: {},
+    avgLatencyMs: 0,
+    errorCount: 0,
+    errorRate: 0,
+    cacheHitRate: 0,
+  }
+}
+
+function collectUsageSummary(now: Date): UsageSummary {
+  try {
+    return Usage.Storage.getSummary({ period: "day", to: now.getTime() })
+  } catch {
+    return emptyUsageSummary(now)
+  }
+}
+
+export async function collectV3ReleaseReport(
+  options: {
+    emitTelemetry?: boolean
+    now?: Date
+  } = {},
+): Promise<V3ReleaseReport> {
+  const now = options.now ?? new Date()
+  const [config, memoryStats] = await Promise.all([Config.get(), getAgentDbMemoryStats()])
+  const security = await auditControlUiSecurityDeep(config)
+  if (options.emitTelemetry) {
+    emitSecurityAuditTelemetry({
+      source: "v3.release",
+      deep: true,
+      report: security,
+    })
+  }
+
+  const meshSnapshot = getHierarchicalMeshCoordinator().snapshot()
+  const nodePolicy = resolveNodeClientPolicy(config)
+  const nodeStats = await getNodeClientRegistry().getStats()
+  const flowBridge = new AgenticFlowBridge()
+  const samplePlan = flowBridge.decomposeObjective("memory sync; swarm routing; release gate", { maxSteps: 3 })
+  const runtimeRollout = buildOpenCodeRuntimeRolloutReport(now)
+  if (options.emitTelemetry) {
+    await emitOpenCodeRuntimeRolloutTelemetry(runtimeRollout)
+  }
+  const runtimeGate = buildOpenCodeRuntimeReleaseGate(runtimeRollout)
+
+  const report = buildV3ReleaseReport({
+    generatedAt: now,
+    memoryStats,
+    mesh: {
+      totalAgents: meshSnapshot.totalAgents,
+      maxAgents: meshSnapshot.maxAgents,
+      crossDomainLinks: meshSnapshot.crossDomainLinks,
+      withinCapacity: meshSnapshot.withinCapacity,
+    },
+    samplePlanSteps: samplePlan.steps.length,
+    runtimeRollout,
+    runtimeGate,
+    security,
+    nodePolicy: {
+      enabled: nodePolicy.enabled,
+      securityMode: nodePolicy.securityMode,
+    },
+    nodeStats,
+    usageSummary: collectUsageSummary(now),
+    docs: collectRequiredV3ReleaseDocs(),
+  })
+
+  if (options.emitTelemetry) {
+    emitV3ReleaseReportTelemetry({
+      source: "v3.release",
+      report,
+    })
+  }
+
+  return report
+}
+
+export function emitV3ReleaseReportTelemetry(input: {
+  source: "v3.release" | "v3.status"
+  report: V3ReleaseReport
+}): { traceID: string } {
+  const traceID = crypto.randomUUID()
+
+  FluxRecorder.record({
+    traceID,
+    direction: "internal",
+    domain: "runtime",
+    kind: input.report.telemetry.kind,
+    status: input.report.readyForRelease ? "ok" : "error",
+    method: "CLI",
+    path: input.source,
+    route: "v3.release",
+    metadata: {
+      source: input.source,
+      reportId: input.report.reportId,
+      reportVersion: input.report.reportVersion,
+      readyForRelease: input.report.readyForRelease,
+      gateCount: input.report.telemetry.metrics.gateCount,
+      failureCount: input.report.telemetry.metrics.failureCount,
+      docMissingCount: input.report.telemetry.metrics.docMissingCount,
+      avgLatencyMs: input.report.telemetry.metrics.avgLatencyMs,
+      errorRate: input.report.telemetry.metrics.errorRate,
+      requestCount: input.report.telemetry.metrics.requestCount,
+    },
+  })
+
+  return { traceID }
+}
+
+export function summarizeV3ReleaseReport(report: V3ReleaseReport): string {
+  const lines = [
+    `v3 release report v${report.reportVersion}`,
+    `- ready=${report.readyForRelease ? "yes" : "no"} gates=${report.telemetry.metrics.gateCount} failures=${report.telemetry.metrics.failureCount}`,
+  ]
+
+  for (const category of report.categories) {
+    lines.push(`- ${category.id}: ${category.ok ? "ok" : "fail"} ${category.gateCount - category.failureCount}/${category.gateCount}`)
+  }
+
+  lines.push(
+    `- performance: requests=${report.performance.totalRequests} avgLatency=${Math.round(report.performance.avgLatencyMs)}ms errorRate=${formatPercent(report.performance.errorRate)} cacheHit=${formatPercent(report.performance.cacheHitRate)}`,
+  )
+  lines.push(`- docs: missing=${report.docs.missingCount}`)
+
+  for (const gate of report.gates) {
+    lines.push(`- ${gate.ok ? "ok" : "fail"} [${gate.category}] ${gate.id}: ${gate.details}`)
+  }
+
+  lines.push(`- telemetry: ${report.telemetry.kind}`)
+  return lines.join("\n")
+}

--- a/packages/zee/test/runtime/v3-release.test.ts
+++ b/packages/zee/test/runtime/v3-release.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test"
+import type { SecurityAuditReport } from "../../src/security"
+import {
+  buildOpenCodeRuntimeReleaseGate,
+  buildOpenCodeRuntimeRolloutReport,
+  type OpenCodeRuntimeRolloutReport,
+} from "../../src/runtime/opencode-rollout"
+import { buildV3ReleaseReport, summarizeV3ReleaseReport, type V3ReleaseDocCheck } from "../../src/runtime/v3-release"
+import type { UsageSummary } from "../../src/usage/types"
+import type { FluxEvent } from "../../src/flux"
+
+function makeRouteEvent(params: {
+  timestamp: string
+  surface: "cli" | "orchestration" | "gateway"
+  kind: "runtime.opencode.route.selected" | "runtime.opencode.route.fallback"
+  reason?: "default_primary" | "surface_disabled" | "forced_legacy"
+}): FluxEvent {
+  return {
+    id: `${params.surface}-${params.kind}-${params.timestamp}`,
+    timestamp: new Date(params.timestamp).getTime(),
+    traceID: `trace-${params.surface}-${params.kind}-${params.timestamp}`,
+    direction: "internal",
+    domain: "runtime",
+    kind: params.kind,
+    status: "ok",
+    metadata: {
+      surface: params.surface,
+      route: params.kind === "runtime.opencode.route.selected" ? "opencode_primary" : "legacy_fallback",
+      reason: params.reason ?? (params.kind === "runtime.opencode.route.selected" ? "default_primary" : "forced_legacy"),
+    },
+  }
+}
+
+function makeSecurityReport(ok: boolean): SecurityAuditReport {
+  return {
+    ok,
+    errors: ok ? 0 : 1,
+    warnings: 0,
+    checked: ["gateway.controlUi.auth.required"],
+    findings: ok
+      ? []
+      : [
+          {
+            severity: "error",
+            code: "control-ui-auth-disabled",
+            message: "Control UI auth is disabled.",
+            remediation: "Enable token auth.",
+          },
+        ],
+    alerts: [],
+    metrics: {
+      checkedCount: 1,
+      findingCount: ok ? 0 : 1,
+      alertCount: 0,
+    },
+  }
+}
+
+function makeUsageSummary(overrides: Partial<UsageSummary> = {}): UsageSummary {
+  return {
+    period: "day",
+    startTime: 1_700_000_000_000,
+    endTime: 1_700_000_086_400,
+    totalRequests: 14,
+    totalInputTokens: 48_000,
+    totalOutputTokens: 22_000,
+    totalCost: 1.45,
+    byProvider: {},
+    byModel: {},
+    avgLatencyMs: 800,
+    errorCount: 0,
+    errorRate: 0,
+    cacheHitRate: 0.3,
+    ...overrides,
+  }
+}
+
+function makeDocs(overrides: Array<Partial<V3ReleaseDocCheck>> = []): V3ReleaseDocCheck[] {
+  const base: V3ReleaseDocCheck[] = [
+    {
+      id: "runtime-rollout",
+      label: "OpenCode runtime rollout",
+      path: "docs/architecture/opencode-runtime-rollout.md",
+      exists: true,
+    },
+    {
+      id: "v3-release-readiness",
+      label: "V3 release readiness",
+      path: "docs/architecture/v3-release-readiness.md",
+      exists: true,
+    },
+    {
+      id: "investing-eval-gates",
+      label: "Investing eval gates",
+      path: "docs/architecture/investing-eval-gates.md",
+      exists: true,
+    },
+  ]
+
+  return base.map((doc, index) => ({
+    ...doc,
+    ...(overrides[index] ?? {}),
+  }))
+}
+
+function makeRuntimeReport(routeEvents: FluxEvent[]): OpenCodeRuntimeRolloutReport {
+  return buildOpenCodeRuntimeRolloutReport(new Date("2026-03-15T12:00:00.000Z"), {
+    routeEvents,
+  })
+}
+
+describe("v3 release report", () => {
+  test("buildV3ReleaseReport consolidates gates across categories", () => {
+    const runtimeReport = makeRuntimeReport([
+      makeRouteEvent({
+        timestamp: "2026-03-15T11:00:00.000Z",
+        surface: "cli",
+        kind: "runtime.opencode.route.selected",
+      }),
+      makeRouteEvent({
+        timestamp: "2026-03-15T11:01:00.000Z",
+        surface: "orchestration",
+        kind: "runtime.opencode.route.selected",
+      }),
+      makeRouteEvent({
+        timestamp: "2026-03-15T11:02:00.000Z",
+        surface: "gateway",
+        kind: "runtime.opencode.route.selected",
+      }),
+    ])
+
+    const report = buildV3ReleaseReport({
+      generatedAt: new Date("2026-03-15T12:30:00.000Z"),
+      memoryStats: { namespace: "zee" },
+      mesh: {
+        totalAgents: 9,
+        maxAgents: 15,
+        crossDomainLinks: 4,
+        withinCapacity: true,
+      },
+      samplePlanSteps: 3,
+      runtimeRollout: runtimeReport,
+      runtimeGate: buildOpenCodeRuntimeReleaseGate(runtimeReport),
+      security: makeSecurityReport(true),
+      nodePolicy: { enabled: false, securityMode: "deny" },
+      nodeStats: { active: 0, revoked: 0, total: 0 },
+      usageSummary: makeUsageSummary(),
+      docs: makeDocs(),
+    })
+
+    expect(report.readyForRelease).toBe(true)
+    expect(report.categories.map((category) => category.id)).toEqual(["reliability", "security", "performance", "docs"])
+    expect(report.docs.missingCount).toBe(0)
+    expect(report.telemetry.kind).toBe("release.v3.report")
+    expect(report.gates.some((gate) => gate.id === "performance.usage-latency")).toBe(true)
+    expect(report.gates.some((gate) => gate.id === "docs.architecture.required")).toBe(true)
+  })
+
+  test("buildV3ReleaseReport blocks on runtime, performance, and docs failures", () => {
+    const runtimeReport = makeRuntimeReport([
+      makeRouteEvent({
+        timestamp: "2026-03-15T11:05:00.000Z",
+        surface: "gateway",
+        kind: "runtime.opencode.route.fallback",
+      }),
+    ])
+
+    const report = buildV3ReleaseReport({
+      generatedAt: new Date("2026-03-15T12:30:00.000Z"),
+      memoryStats: {},
+      mesh: {
+        totalAgents: 16,
+        maxAgents: 15,
+        crossDomainLinks: 4,
+        withinCapacity: false,
+      },
+      samplePlanSteps: 0,
+      runtimeRollout: runtimeReport,
+      runtimeGate: buildOpenCodeRuntimeReleaseGate(runtimeReport),
+      security: makeSecurityReport(true),
+      nodePolicy: { enabled: true, securityMode: "full" },
+      nodeStats: { active: 2, revoked: 0, total: 2 },
+      usageSummary: makeUsageSummary({
+        totalRequests: 9,
+        avgLatencyMs: 8200,
+        errorCount: 2,
+        errorRate: 2 / 9,
+      }),
+      docs: makeDocs([{ exists: false }]),
+    })
+
+    const summary = summarizeV3ReleaseReport(report)
+
+    expect(report.readyForRelease).toBe(false)
+    expect(report.telemetry.metrics.failureCount).toBeGreaterThan(0)
+    expect(report.docs.missingCount).toBe(1)
+    expect(summary).toContain("ready=no")
+    expect(summary).toContain("[performance] performance.usage-latency")
+    expect(summary).toContain("[docs] docs.architecture.required")
+    expect(summary).toContain("runtime.opencode-parity")
+  })
+})


### PR DESCRIPTION
## Summary
- add a consolidated v3 release report with reliability, security, performance, and docs categories
- wire zee v3 status/release to the new report contract and emit release.v3.report telemetry
- document the consolidated gate and add focused runtime/report tests

## Testing
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- bun test --cwd packages/zee test/runtime/v3-release.test.ts test/runtime/opencode-rollout.test.ts test/cli/inspect-command.test.ts
- CLI smoke: cd packages/zee && ZEE_FLUX_LOG_MIRROR=false bun src/index.ts v3 release --json
- CI=true bun test --cwd packages/zee --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh

Closes #518