### PR TITLE
feat(#519): add staged v3 rollout automation

### DIFF
--- a/docs/architecture/opencode-runtime-rollout.md
+++ b/docs/architecture/opencode-runtime-rollout.md
@@ -18,6 +18,12 @@ cd packages/zee
 bun run --conditions=browser ./src/index.ts inspect runtime-rollout --no-json
 ```
 
+The staged rollout controller now lives in:
+
+```bash
+zee v3 rollout status
+```
+
 ## Control Flags
 
 - `ZEE_RUNTIME_OPENCODE_SURFACES`
@@ -59,6 +65,12 @@ To stage only CLI on the OpenCode primary route while keeping other surfaces on 
 ```bash
 export ZEE_RUNTIME_OPENCODE_SURFACES=cli
 export ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES=orchestration,gateway
+```
+
+The same flag transitions can now be written automatically through:
+
+```bash
+zee v3 rollout apply canary --actor release-manager --reason "Start CLI canary"
 ```
 
 Recommended rollback runbook when `inspect runtime-rollout` reports a breach:

--- a/docs/architecture/v3-release-gate.md
+++ b/docs/architecture/v3-release-gate.md
@@ -61,6 +61,7 @@ The consolidated report now verifies the presence of these operator-facing docs:
 - `docs/architecture/opencode-runtime-rollout.md`
 - `docs/architecture/v3-release-readiness.md`
 - `docs/architecture/investing-eval-gates.md`
+- `docs/architecture/v3-rollout-plan.md`
 
 ## Telemetry
 

--- a/docs/architecture/v3-rollout-plan.md
+++ b/docs/architecture/v3-rollout-plan.md
@@ -1,0 +1,63 @@
+# V3 Rollout Plan
+
+This slice closes `#519`.
+
+Zee now ships an executable staged rollout plan for v3 with managed daemon-env automation and a first-class rollback path.
+
+## Rollout stages
+
+- `paused`
+  - all tracked surfaces pinned to legacy
+- `canary`
+  - CLI primary, orchestration and gateway pinned to legacy
+- `internal`
+  - CLI and orchestration primary, gateway pinned to legacy
+- `broad`
+  - all tracked surfaces primary, legacy fallback still allowed
+- `general`
+  - all tracked surfaces primary, legacy fallback disabled
+
+Stage promotions can only move forward one step at a time.
+
+## Operator usage
+
+```bash
+zee v3 rollout status
+zee v3 rollout apply canary --actor release-manager --reason "Start CLI canary"
+zee v3 rollout apply internal --actor release-manager --reason "Promote daemon traffic"
+zee v3 rollout rollback --actor sre-owner --reason "Rollback after parity breach"
+```
+
+## Automation contract
+
+The rollout command manages these runtime flags inside `~/.config/zee/daemon.env`:
+
+- `ZEE_RUNTIME_OPENCODE_SURFACES`
+- `ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES`
+- `ZEE_RUNTIME_OPENCODE_ALLOW_LEGACY_FALLBACK`
+
+After applying or rolling back a stage, operators should restart the user service:
+
+```bash
+systemctl --user restart zee
+```
+
+## Promotion gate
+
+Forward promotion is blocked unless the consolidated `v3-release-gate` report is already passing.
+
+Rollback to `paused` is always allowed.
+
+## Telemetry
+
+This slice emits:
+
+- `release.v3.rollout`
+  - stage
+  - history count
+  - forced-legacy surface count
+  - fallback flag state
+  - release-gate readiness
+  - restart-required status
+
+That gives SRE and release operators a concrete rollout state machine instead of a prose-only rollout plan.

--- a/packages/zee/src/cli/cmd/v3.ts
+++ b/packages/zee/src/cli/cmd/v3.ts
@@ -6,6 +6,14 @@ import {
   collectV3ReleaseReport,
   summarizeV3ReleaseReport,
 } from "@/runtime/v3-release"
+import {
+  applyV3RolloutStage,
+  getV3RolloutReport,
+  rollbackV3Rollout,
+  summarizeV3RolloutReport,
+  V3_ROLLOUT_STAGES,
+  type V3RolloutStage,
+} from "@/runtime/v3-rollout"
 
 type V3StatusArgs = {
   json?: boolean
@@ -21,6 +29,23 @@ type V3PlanArgs = {
 type V3ReleaseArgs = {
   json?: boolean
   strict?: boolean
+}
+
+type V3RolloutStatusArgs = {
+  json?: boolean
+}
+
+type V3RolloutApplyArgs = {
+  stage?: V3RolloutStage
+  actor?: string
+  reason?: string
+  json?: boolean
+}
+
+type V3RolloutRollbackArgs = {
+  actor?: string
+  reason?: string
+  json?: boolean
 }
 
 const V3StatusCommand = cmd({
@@ -122,9 +147,127 @@ const V3ReleaseCommand = cmd({
   },
 })
 
+const V3RolloutStatusCommand = cmd({
+  command: "status",
+  describe: "show the current staged rollout plan and managed daemon env settings",
+  builder: (yargs: Argv) =>
+    yargs.option("json", {
+      type: "boolean",
+      default: false,
+      describe: "output JSON",
+    }),
+  handler: async (args: V3RolloutStatusArgs) => {
+    await bootstrap(process.cwd(), async () => {
+      const report = await getV3RolloutReport({ emitTelemetry: true })
+      if (args.json) {
+        console.log(JSON.stringify(report, null, 2))
+        return
+      }
+      console.log(summarizeV3RolloutReport(report))
+    })
+  },
+})
+
+const V3RolloutApplyCommand = cmd({
+  command: "apply <stage>",
+  describe: "apply the next rollout stage and write managed runtime flags into daemon.env",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("stage", {
+        type: "string",
+        demandOption: true,
+        choices: [...V3_ROLLOUT_STAGES],
+        describe: "rollout stage to apply",
+      })
+      .option("actor", {
+        type: "string",
+        demandOption: true,
+        describe: "operator or owner applying the stage",
+      })
+      .option("reason", {
+        type: "string",
+        demandOption: true,
+        describe: "reason for the rollout change",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output JSON",
+      }),
+  handler: async (args: V3RolloutApplyArgs) => {
+    if (!args.stage || !args.actor || !args.reason) {
+      throw new Error("stage, actor, and reason are required")
+    }
+    const stage = args.stage
+    const actor = args.actor
+    const reason = args.reason
+    await bootstrap(process.cwd(), async () => {
+      const report = await applyV3RolloutStage({
+        stage,
+        actor,
+        reason,
+      })
+      if (args.json) {
+        console.log(JSON.stringify(report, null, 2))
+        return
+      }
+      console.log(summarizeV3RolloutReport(report))
+    })
+  },
+})
+
+const V3RolloutRollbackCommand = cmd({
+  command: "rollback",
+  describe: "roll back to the paused stage and pin all tracked surfaces to legacy",
+  builder: (yargs: Argv) =>
+    yargs
+      .option("actor", {
+        type: "string",
+        demandOption: true,
+        describe: "operator or owner triggering rollback",
+      })
+      .option("reason", {
+        type: "string",
+        demandOption: true,
+        describe: "reason for the rollback",
+      })
+      .option("json", {
+        type: "boolean",
+        default: false,
+        describe: "output JSON",
+      }),
+  handler: async (args: V3RolloutRollbackArgs) => {
+    if (!args.actor || !args.reason) {
+      throw new Error("actor and reason are required")
+    }
+    const actor = args.actor
+    const reason = args.reason
+    await bootstrap(process.cwd(), async () => {
+      const report = await rollbackV3Rollout({
+        actor,
+        reason,
+      })
+      if (args.json) {
+        console.log(JSON.stringify(report, null, 2))
+        return
+      }
+      console.log(summarizeV3RolloutReport(report))
+    })
+  },
+})
+
+const V3RolloutCommand = cmd({
+  command: "rollout",
+  describe: "manage staged rollout progression and rollback automation for v3 launch",
+  builder: (yargs: Argv) =>
+    yargs.command(V3RolloutStatusCommand).command(V3RolloutApplyCommand).command(V3RolloutRollbackCommand).demandCommand(),
+  async handler() {},
+})
+
 export const V3Command = cmd({
   command: "v3",
   describe: "v3 modernization and release workflows",
-  builder: (yargs: Argv) => yargs.command(V3StatusCommand).command(V3PlanCommand).command(V3ReleaseCommand).demandCommand(),
+  builder: (yargs: Argv) =>
+    yargs.command(V3StatusCommand).command(V3PlanCommand).command(V3ReleaseCommand).command(V3RolloutCommand).demandCommand(),
   async handler() {},
 })

--- a/packages/zee/src/flux/types.ts
+++ b/packages/zee/src/flux/types.ts
@@ -82,6 +82,7 @@ export type FluxKind =
   | "investing.eval.alert"
   | "investing.portfolio.briefing"
   | "release.v3.report"
+  | "release.v3.rollout"
   | "agent.legacy_tools_alias.used"
   | "gateway.fallback.invoked"
   | "provider.fallback.used"

--- a/packages/zee/src/runtime/v3-release.ts
+++ b/packages/zee/src/runtime/v3-release.ts
@@ -42,6 +42,11 @@ const REQUIRED_V3_RELEASE_DOCS = [
     path: "docs/architecture/investing-eval-gates.md",
     label: "Investing eval gates",
   },
+  {
+    id: "v3-rollout-plan",
+    path: "docs/architecture/v3-rollout-plan.md",
+    label: "V3 rollout plan",
+  },
 ] as const
 
 export type V3ReleaseCategory = "reliability" | "security" | "performance" | "docs"

--- a/packages/zee/src/runtime/v3-rollout.ts
+++ b/packages/zee/src/runtime/v3-rollout.ts
@@ -1,0 +1,383 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { FluxRecorder } from "@/flux"
+import { resolveConfigDir, resolveStateDir } from "@/global/dirs"
+import { collectV3ReleaseReport, type V3ReleaseReport } from "@/runtime/v3-release"
+import type { RuntimeContractSurface } from "./opencode-contract"
+
+export const V3_ROLLOUT_STAGES = ["paused", "canary", "internal", "broad", "general"] as const
+export type V3RolloutStage = (typeof V3_ROLLOUT_STAGES)[number]
+
+type V3RolloutHistoryAction = "apply" | "rollback"
+
+export interface V3RolloutStageSpec {
+  stage: V3RolloutStage
+  description: string
+  enabledSurfaces: RuntimeContractSurface[]
+  forcedLegacySurfaces: RuntimeContractSurface[]
+  allowLegacyFallback: boolean
+  exitCriteria: string[]
+}
+
+export interface V3RolloutHistoryEntry {
+  action: V3RolloutHistoryAction
+  stage: V3RolloutStage
+  actor: string
+  reason: string
+  timestamp: string
+  releaseReady: boolean
+}
+
+export interface V3RolloutState {
+  schemaVersion: "v3-rollout.v1"
+  currentStage: V3RolloutStage
+  stageSpec: V3RolloutStageSpec
+  updatedAt: string
+  daemonEnvFile: string
+  restartRequired: boolean
+  history: V3RolloutHistoryEntry[]
+}
+
+export interface V3RolloutReport {
+  reportId: "v3-rollout-plan"
+  reportVersion: 1
+  generatedAt: string
+  state: V3RolloutState
+  releaseReady: boolean
+  releaseFailureCount: number
+  nextRecommendedStage: V3RolloutStage | null
+  restartCommand: string
+  managedEnv: Record<string, string>
+  runtimeParityReady: boolean
+  telemetry: {
+    kind: "release.v3.rollout"
+    metrics: {
+      historyCount: number
+      stage: V3RolloutStage
+      forcedLegacyCount: number
+      allowLegacyFallback: boolean
+      releaseReady: boolean
+      releaseFailureCount: number
+      restartRequired: boolean
+    }
+  }
+}
+
+const MANAGED_KEYS = [
+  "ZEE_RUNTIME_OPENCODE_SURFACES",
+  "ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES",
+  "ZEE_RUNTIME_OPENCODE_ALLOW_LEGACY_FALLBACK",
+] as const
+
+const STAGE_ORDER: V3RolloutStage[] = ["paused", "canary", "internal", "broad", "general"]
+
+const STAGE_SPECS: Record<V3RolloutStage, V3RolloutStageSpec> = {
+  paused: {
+    stage: "paused",
+    description: "All tracked surfaces are pinned to legacy while rollout is paused or rolled back.",
+    enabledSurfaces: ["cli", "orchestration", "gateway"],
+    forcedLegacySurfaces: ["cli", "orchestration", "gateway"],
+    allowLegacyFallback: true,
+    exitCriteria: ["Release report is green again.", "Rollback incident is documented and acknowledged."],
+  },
+  canary: {
+    stage: "canary",
+    description: "CLI is primary; orchestration and gateway remain pinned to legacy.",
+    enabledSurfaces: ["cli", "orchestration", "gateway"],
+    forcedLegacySurfaces: ["orchestration", "gateway"],
+    allowLegacyFallback: true,
+    exitCriteria: ["CLI parity remains clean.", "Operator can complete the release report in strict mode."],
+  },
+  internal: {
+    stage: "internal",
+    description: "CLI and orchestration are primary; gateway remains pinned to legacy.",
+    enabledSurfaces: ["cli", "orchestration", "gateway"],
+    forcedLegacySurfaces: ["gateway"],
+    allowLegacyFallback: true,
+    exitCriteria: ["Daemon/orchestration traffic remains clean.", "Gateway is the only remaining forced-legacy surface."],
+  },
+  broad: {
+    stage: "broad",
+    description: "All tracked surfaces are primary, but legacy fallback stays enabled during broad rollout.",
+    enabledSurfaces: ["cli", "orchestration", "gateway"],
+    forcedLegacySurfaces: [],
+    allowLegacyFallback: true,
+    exitCriteria: ["All tracked surfaces stay primary.", "No parity breaches appear in the trailing rollout window."],
+  },
+  general: {
+    stage: "general",
+    description: "All tracked surfaces are primary and legacy fallback is disabled for GA.",
+    enabledSurfaces: ["cli", "orchestration", "gateway"],
+    forcedLegacySurfaces: [],
+    allowLegacyFallback: false,
+    exitCriteria: ["Broad rollout remained stable.", "Legacy fallback can be disabled without new breaches."],
+  },
+}
+
+function resolveRolloutStateFile(): string {
+  return process.env.ZEE_V3_ROLLOUT_STATE_FILE?.trim() || path.join(resolveStateDir(), "v3-rollout.json")
+}
+
+function resolveRolloutEnvFile(): string {
+  return process.env.ZEE_V3_ROLLOUT_ENV_FILE?.trim() || path.join(resolveConfigDir(), "daemon.env")
+}
+
+function ensureParentDir(filePath: string): void {
+  mkdirSync(path.dirname(filePath), { recursive: true })
+}
+
+function currentManagedEnv(spec: V3RolloutStageSpec): Record<string, string> {
+  return {
+    ZEE_RUNTIME_OPENCODE_SURFACES: spec.enabledSurfaces.join(","),
+    ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES: spec.forcedLegacySurfaces.join(","),
+    ZEE_RUNTIME_OPENCODE_ALLOW_LEGACY_FALLBACK: String(spec.allowLegacyFallback),
+  }
+}
+
+function parseEnvKey(line: string): string | null {
+  let normalized = line.trim()
+  if (!normalized || normalized.startsWith("#")) return null
+  if (normalized.startsWith("export ")) {
+    normalized = normalized.slice("export ".length).trim()
+  }
+  const eqIndex = normalized.indexOf("=")
+  if (eqIndex <= 0) return null
+  return normalized.slice(0, eqIndex).trim() || null
+}
+
+function writeManagedDaemonEnv(filePath: string, spec: V3RolloutStageSpec): Record<string, string> {
+  ensureParentDir(filePath)
+  const existingLines = existsSync(filePath) ? readFileSync(filePath, "utf-8").split(/\r?\n/) : []
+  const preserved = existingLines.filter((line) => {
+    const key = parseEnvKey(line)
+    return !key || !MANAGED_KEYS.includes(key as (typeof MANAGED_KEYS)[number])
+  })
+  const managedEnv = currentManagedEnv(spec)
+  const managedLines = [
+    "# Managed by zee v3 rollout",
+    `export ZEE_RUNTIME_OPENCODE_SURFACES=${managedEnv.ZEE_RUNTIME_OPENCODE_SURFACES}`,
+    `export ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES=${managedEnv.ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES}`,
+    `export ZEE_RUNTIME_OPENCODE_ALLOW_LEGACY_FALLBACK=${managedEnv.ZEE_RUNTIME_OPENCODE_ALLOW_LEGACY_FALLBACK}`,
+  ]
+  const body = [...preserved.filter((line, index, lines) => !(index === lines.length - 1 && line.trim() === ""))]
+  if (body.length > 0) body.push("")
+  body.push(...managedLines)
+  writeFileSync(filePath, body.join("\n") + "\n", "utf-8")
+  return managedEnv
+}
+
+function defaultState(now: Date, envFile: string): V3RolloutState {
+  return {
+    schemaVersion: "v3-rollout.v1",
+    currentStage: "paused",
+    stageSpec: STAGE_SPECS.paused,
+    updatedAt: now.toISOString(),
+    daemonEnvFile: envFile,
+    restartRequired: false,
+    history: [],
+  }
+}
+
+function readRolloutState(now: Date, envFile: string): V3RolloutState {
+  const filePath = resolveRolloutStateFile()
+  if (!existsSync(filePath)) {
+    return defaultState(now, envFile)
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as Partial<V3RolloutState>
+    const currentStage = STAGE_SPECS[parsed.currentStage as V3RolloutStage] ? (parsed.currentStage as V3RolloutStage) : "paused"
+    return {
+      schemaVersion: "v3-rollout.v1",
+      currentStage,
+      stageSpec: STAGE_SPECS[currentStage],
+      updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : now.toISOString(),
+      daemonEnvFile: typeof parsed.daemonEnvFile === "string" && parsed.daemonEnvFile ? parsed.daemonEnvFile : envFile,
+      restartRequired: parsed.restartRequired === true,
+      history: Array.isArray(parsed.history) ? parsed.history : [],
+    }
+  } catch {
+    return defaultState(now, envFile)
+  }
+}
+
+function writeRolloutState(state: V3RolloutState): void {
+  const filePath = resolveRolloutStateFile()
+  ensureParentDir(filePath)
+  writeFileSync(filePath, JSON.stringify(state, null, 2) + "\n", "utf-8")
+}
+
+function nextStage(stage: V3RolloutStage): V3RolloutStage | null {
+  const index = STAGE_ORDER.indexOf(stage)
+  return index >= 0 && index < STAGE_ORDER.length - 1 ? STAGE_ORDER[index + 1] : null
+}
+
+function assertForwardTransition(current: V3RolloutStage, target: V3RolloutStage): void {
+  if (target === "paused") return
+  const currentIndex = STAGE_ORDER.indexOf(current)
+  const targetIndex = STAGE_ORDER.indexOf(target)
+  if (targetIndex === currentIndex) return
+  if (targetIndex !== currentIndex + 1) {
+    throw new Error(`Rollout stages must advance one step at a time (${current} -> ${nextStage(current) ?? "done"}).`)
+  }
+}
+
+function buildRolloutReport(input: {
+  now: Date
+  state: V3RolloutState
+  releaseReport: V3ReleaseReport
+  managedEnv: Record<string, string>
+}): V3RolloutReport {
+  return {
+    reportId: "v3-rollout-plan",
+    reportVersion: 1,
+    generatedAt: input.now.toISOString(),
+    state: input.state,
+    releaseReady: input.releaseReport.readyForRelease,
+    releaseFailureCount: input.releaseReport.telemetry.metrics.failureCount,
+    nextRecommendedStage: input.releaseReport.readyForRelease ? nextStage(input.state.currentStage) : null,
+    restartCommand: "systemctl --user restart zee",
+    managedEnv: input.managedEnv,
+    runtimeParityReady: input.releaseReport.runtimeRollout.parity.releaseReady,
+    telemetry: {
+      kind: "release.v3.rollout",
+      metrics: {
+        historyCount: input.state.history.length,
+        stage: input.state.currentStage,
+        forcedLegacyCount: input.state.stageSpec.forcedLegacySurfaces.length,
+        allowLegacyFallback: input.state.stageSpec.allowLegacyFallback,
+        releaseReady: input.releaseReport.readyForRelease,
+        releaseFailureCount: input.releaseReport.telemetry.metrics.failureCount,
+        restartRequired: input.state.restartRequired,
+      },
+    },
+  }
+}
+
+function emitV3RolloutTelemetry(method: "status" | "apply" | "rollback", report: V3RolloutReport): void {
+  FluxRecorder.record({
+    traceID: crypto.randomUUID(),
+    direction: "internal",
+    domain: "runtime",
+    kind: report.telemetry.kind,
+    status: report.releaseReady || report.state.currentStage === "paused" ? "ok" : "error",
+    method: method.toUpperCase(),
+    path: report.state.currentStage,
+    route: "v3.rollout",
+    metadata: {
+      stage: report.state.currentStage,
+      historyCount: report.telemetry.metrics.historyCount,
+      forcedLegacyCount: report.telemetry.metrics.forcedLegacyCount,
+      allowLegacyFallback: report.telemetry.metrics.allowLegacyFallback,
+      releaseReady: report.releaseReady,
+      releaseFailureCount: report.releaseFailureCount,
+      restartRequired: report.state.restartRequired,
+    },
+  })
+}
+
+export function summarizeV3RolloutReport(report: V3RolloutReport): string {
+  const lines = [
+    `v3 rollout plan v${report.reportVersion}`,
+    `- stage=${report.state.currentStage} release=${report.releaseReady ? "ready" : "blocked"} runtimeParity=${report.runtimeParityReady ? "ready" : "blocked"} restartRequired=${report.state.restartRequired ? "yes" : "no"}`,
+    `- next=${report.nextRecommendedStage ?? "none"} restart=${report.restartCommand}`,
+    `- env: ZEE_RUNTIME_OPENCODE_SURFACES=${report.managedEnv.ZEE_RUNTIME_OPENCODE_SURFACES}`,
+    `- env: ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES=${report.managedEnv.ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES || "none"}`,
+    `- env: ZEE_RUNTIME_OPENCODE_ALLOW_LEGACY_FALLBACK=${report.managedEnv.ZEE_RUNTIME_OPENCODE_ALLOW_LEGACY_FALLBACK}`,
+    `- telemetry: ${report.telemetry.kind}`,
+  ]
+
+  for (const criterion of report.state.stageSpec.exitCriteria) {
+    lines.push(`- exit: ${criterion}`)
+  }
+
+  return lines.join("\n")
+}
+
+export async function getV3RolloutReport(options: { emitTelemetry?: boolean; now?: Date } = {}): Promise<V3RolloutReport> {
+  const now = options.now ?? new Date()
+  const envFile = resolveRolloutEnvFile()
+  const state = readRolloutState(now, envFile)
+  const releaseReport = await collectV3ReleaseReport()
+  const managedEnv = currentManagedEnv(state.stageSpec)
+  const report = buildRolloutReport({
+    now,
+    state,
+    releaseReport,
+    managedEnv,
+  })
+
+  if (options.emitTelemetry) {
+    emitV3RolloutTelemetry("status", report)
+  }
+
+  return report
+}
+
+export async function applyV3RolloutStage(input: {
+  stage: V3RolloutStage
+  actor: string
+  reason: string
+  now?: Date
+  releaseReport?: V3ReleaseReport
+}): Promise<V3RolloutReport> {
+  const now = input.now ?? new Date()
+  const envFile = resolveRolloutEnvFile()
+  const currentState = readRolloutState(now, envFile)
+  const releaseReport = input.releaseReport ?? (await collectV3ReleaseReport())
+
+  if (input.stage !== "paused") {
+    if (!releaseReport.readyForRelease) {
+      throw new Error("V3 release report is blocked; rollout cannot advance.")
+    }
+    assertForwardTransition(currentState.currentStage, input.stage)
+  }
+
+  const action: V3RolloutHistoryAction = input.stage === "paused" ? "rollback" : "apply"
+  const stageSpec = STAGE_SPECS[input.stage]
+  const managedEnv = writeManagedDaemonEnv(envFile, stageSpec)
+  const state: V3RolloutState = {
+    schemaVersion: "v3-rollout.v1",
+    currentStage: input.stage,
+    stageSpec,
+    updatedAt: now.toISOString(),
+    daemonEnvFile: envFile,
+    restartRequired: true,
+    history: [
+      {
+        action,
+        stage: input.stage,
+        actor: input.actor,
+        reason: input.reason,
+        timestamp: now.toISOString(),
+        releaseReady: releaseReport.readyForRelease,
+      },
+      ...currentState.history,
+    ].slice(0, 50),
+  }
+  writeRolloutState(state)
+
+  const report = buildRolloutReport({
+    now,
+    state,
+    releaseReport,
+    managedEnv,
+  })
+  emitV3RolloutTelemetry(action, report)
+  return report
+}
+
+export async function rollbackV3Rollout(input: {
+  actor: string
+  reason: string
+  now?: Date
+  releaseReport?: V3ReleaseReport
+}): Promise<V3RolloutReport> {
+  return applyV3RolloutStage({
+    stage: "paused",
+    actor: input.actor,
+    reason: input.reason,
+    now: input.now,
+    releaseReport: input.releaseReport,
+  })
+}

--- a/packages/zee/test/runtime/v3-release.test.ts
+++ b/packages/zee/test/runtime/v3-release.test.ts
@@ -95,6 +95,12 @@ function makeDocs(overrides: Array<Partial<V3ReleaseDocCheck>> = []): V3ReleaseD
       path: "docs/architecture/investing-eval-gates.md",
       exists: true,
     },
+    {
+      id: "v3-rollout-plan",
+      label: "V3 rollout plan",
+      path: "docs/architecture/v3-rollout-plan.md",
+      exists: true,
+    },
   ]
 
   return base.map((doc, index) => ({

--- a/packages/zee/test/runtime/v3-rollout.test.ts
+++ b/packages/zee/test/runtime/v3-rollout.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { tmpdir } from "../fixture/fixture"
+import { buildOpenCodeRuntimeReleaseGate, buildOpenCodeRuntimeRolloutReport } from "../../src/runtime/opencode-rollout"
+import { applyV3RolloutStage, rollbackV3Rollout } from "../../src/runtime/v3-rollout"
+import { buildV3ReleaseReport, type V3ReleaseDocCheck } from "../../src/runtime/v3-release"
+import type { SecurityAuditReport } from "../../src/security"
+import type { UsageSummary } from "../../src/usage/types"
+import type { FluxEvent } from "../../src/flux"
+
+function makeRouteEvent(params: {
+  timestamp: string
+  surface: "cli" | "orchestration" | "gateway"
+  kind: "runtime.opencode.route.selected" | "runtime.opencode.route.fallback"
+}): FluxEvent {
+  return {
+    id: `${params.surface}-${params.kind}-${params.timestamp}`,
+    timestamp: new Date(params.timestamp).getTime(),
+    traceID: `trace-${params.surface}-${params.kind}-${params.timestamp}`,
+    direction: "internal",
+    domain: "runtime",
+    kind: params.kind,
+    status: "ok",
+    metadata: {
+      surface: params.surface,
+      route: params.kind === "runtime.opencode.route.selected" ? "opencode_primary" : "legacy_fallback",
+      reason: params.kind === "runtime.opencode.route.selected" ? "default_primary" : "forced_legacy",
+    },
+  }
+}
+
+function makeSecurityReport(ok: boolean): SecurityAuditReport {
+  return {
+    ok,
+    errors: ok ? 0 : 1,
+    warnings: 0,
+    checked: ["gateway.controlUi.auth.required"],
+    findings: ok
+      ? []
+      : [{ severity: "error", code: "broken", message: "broken", remediation: "fix" }],
+    alerts: [],
+    metrics: {
+      checkedCount: 1,
+      findingCount: ok ? 0 : 1,
+      alertCount: 0,
+    },
+  }
+}
+
+function makeUsageSummary(): UsageSummary {
+  return {
+    period: "day",
+    startTime: 1_700_000_000_000,
+    endTime: 1_700_000_086_400,
+    totalRequests: 14,
+    totalInputTokens: 48_000,
+    totalOutputTokens: 22_000,
+    totalCost: 1.45,
+    byProvider: {},
+    byModel: {},
+    avgLatencyMs: 800,
+    errorCount: 0,
+    errorRate: 0,
+    cacheHitRate: 0.3,
+  }
+}
+
+function makeDocs(): V3ReleaseDocCheck[] {
+  return [
+    { id: "runtime-rollout", label: "OpenCode runtime rollout", path: "docs/architecture/opencode-runtime-rollout.md", exists: true },
+    { id: "v3-release-readiness", label: "V3 release readiness", path: "docs/architecture/v3-release-readiness.md", exists: true },
+    { id: "investing-eval-gates", label: "Investing eval gates", path: "docs/architecture/investing-eval-gates.md", exists: true },
+    { id: "v3-rollout-plan", label: "V3 rollout plan", path: "docs/architecture/v3-rollout-plan.md", exists: true },
+  ]
+}
+
+function makeReleaseReport(ready: boolean) {
+  const runtimeRollout = buildOpenCodeRuntimeRolloutReport(new Date("2026-03-15T12:00:00.000Z"), {
+    routeEvents: ready
+      ? [
+          makeRouteEvent({
+            timestamp: "2026-03-15T11:00:00.000Z",
+            surface: "cli",
+            kind: "runtime.opencode.route.selected",
+          }),
+          makeRouteEvent({
+            timestamp: "2026-03-15T11:01:00.000Z",
+            surface: "orchestration",
+            kind: "runtime.opencode.route.selected",
+          }),
+          makeRouteEvent({
+            timestamp: "2026-03-15T11:02:00.000Z",
+            surface: "gateway",
+            kind: "runtime.opencode.route.selected",
+          }),
+        ]
+      : [
+          makeRouteEvent({
+            timestamp: "2026-03-15T11:05:00.000Z",
+            surface: "gateway",
+            kind: "runtime.opencode.route.fallback",
+          }),
+        ],
+  })
+
+  return buildV3ReleaseReport({
+    generatedAt: new Date("2026-03-15T12:30:00.000Z"),
+    memoryStats: {},
+    mesh: {
+      totalAgents: 9,
+      maxAgents: 15,
+      crossDomainLinks: 4,
+      withinCapacity: true,
+    },
+    samplePlanSteps: 3,
+    runtimeRollout,
+    runtimeGate: buildOpenCodeRuntimeReleaseGate(runtimeRollout),
+    security: makeSecurityReport(ready),
+    nodePolicy: { enabled: false, securityMode: "deny" },
+    nodeStats: { active: 0, revoked: 0, total: 0 },
+    usageSummary: makeUsageSummary(),
+    docs: makeDocs(),
+  })
+}
+
+async function withRolloutEnv<T>(fn: (root: string) => Promise<T>): Promise<T> {
+  await using dir = await tmpdir()
+  const originalState = process.env.ZEE_V3_ROLLOUT_STATE_FILE
+  const originalEnv = process.env.ZEE_V3_ROLLOUT_ENV_FILE
+  process.env.ZEE_V3_ROLLOUT_STATE_FILE = path.join(dir.path, "v3-rollout.json")
+  process.env.ZEE_V3_ROLLOUT_ENV_FILE = path.join(dir.path, "daemon.env")
+
+  try {
+    return await fn(dir.path)
+  } finally {
+    if (originalState === undefined) delete process.env.ZEE_V3_ROLLOUT_STATE_FILE
+    else process.env.ZEE_V3_ROLLOUT_STATE_FILE = originalState
+
+    if (originalEnv === undefined) delete process.env.ZEE_V3_ROLLOUT_ENV_FILE
+    else process.env.ZEE_V3_ROLLOUT_ENV_FILE = originalEnv
+  }
+}
+
+describe("v3 rollout plan", () => {
+  test("applyV3RolloutStage writes managed daemon flags for canary", async () => {
+    await withRolloutEnv(async () => {
+      const report = await applyV3RolloutStage({
+        stage: "canary",
+        actor: "release-manager",
+        reason: "Start CLI canary.",
+        releaseReport: makeReleaseReport(true),
+      })
+
+      const envBody = readFileSync(process.env.ZEE_V3_ROLLOUT_ENV_FILE!, "utf-8")
+      expect(report.state.currentStage).toBe("canary")
+      expect(report.nextRecommendedStage).toBe("internal")
+      expect(report.managedEnv.ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES).toBe("orchestration,gateway")
+      expect(envBody).toContain("export ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES=orchestration,gateway")
+      expect(report.state.history[0]).toMatchObject({
+        action: "apply",
+        actor: "release-manager",
+      })
+    })
+  })
+
+  test("applyV3RolloutStage blocks promotion when the release report is not ready", async () => {
+    await withRolloutEnv(async () => {
+      await expect(
+        applyV3RolloutStage({
+          stage: "canary",
+          actor: "release-manager",
+          reason: "Should be blocked.",
+          releaseReport: makeReleaseReport(false),
+        }),
+      ).rejects.toThrow("blocked")
+    })
+  })
+
+  test("rollbackV3Rollout pins all surfaces to legacy", async () => {
+    await withRolloutEnv(async () => {
+      await applyV3RolloutStage({
+        stage: "canary",
+        actor: "release-manager",
+        reason: "Start CLI canary.",
+        releaseReport: makeReleaseReport(true),
+      })
+
+      const report = await rollbackV3Rollout({
+        actor: "sre-owner",
+        reason: "Parity breach on gateway.",
+        releaseReport: makeReleaseReport(false),
+      })
+
+      const envBody = readFileSync(process.env.ZEE_V3_ROLLOUT_ENV_FILE!, "utf-8")
+      expect(report.state.currentStage).toBe("paused")
+      expect(report.managedEnv.ZEE_RUNTIME_OPENCODE_FORCE_LEGACY_SURFACES).toBe("cli,orchestration,gateway")
+      expect(envBody).toContain("export ZEE_RUNTIME_OPENCODE_ALLOW_LEGACY_FALLBACK=true")
+      expect(report.state.history[0]).toMatchObject({
+        action: "rollback",
+        actor: "sre-owner",
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a persisted v3 rollout state machine with one-step promotions and rollback to paused
- write managed OpenCode rollout flags into daemon.env and expose them through zee v3 rollout commands
- document the rollout plan and add focused runtime rollout tests

## Testing
- bash scripts/bun-audit-ci.sh
- bash scripts/verify-skills.sh
- bun run --cwd packages/zee typecheck
- bun test --cwd packages/zee test/runtime/v3-release.test.ts test/runtime/v3-rollout.test.ts test/runtime/opencode-rollout.test.ts
- CLI smoke: cd packages/zee && ZEE_V3_ROLLOUT_STATE_FILE=/tmp/v3-rollout.json ZEE_V3_ROLLOUT_ENV_FILE=/tmp/daemon.env ZEE_FLUX_LOG_MIRROR=false bun src/index.ts v3 rollout apply canary --actor release-manager --reason "Start CLI canary" --json
- CI=true bun test --cwd packages/zee --reporter=dots --coverage-reporter=lcov
- cd packages/zee && bun run build
- cd packages/zee && ./script/verify-binary.sh

Closes #519